### PR TITLE
Fix world state change stack typing

### DIFF
--- a/tests/context.ts
+++ b/tests/context.ts
@@ -16,7 +16,7 @@ test("Init Initializes Collections", () => {
 
   ctx.init();
 
-  assert.is(true, ctx.WorldStateChangeStack !== null);
+  assert.ok(ctx.WorldStateChangeStack);
 
   // TODO: Evaluate how to handle the MyWorldState concept since we're in JS land
   // assert.is(Enum.GetValues(typeof (MyWorldState)).Length, ctx.WorldStateChangeStack.Length);
@@ -45,10 +45,16 @@ test("setState Planning Context expected behavior", () => {
   ctx.setState("HasB", 1, true, EffectType.Permanent);
 
   assert.equal(true, ctx.hasState("HasB"));
-  assert.equal(ctx.WorldStateChangeStack.HasA.length, 0);
-  assert.equal(ctx.WorldStateChangeStack.HasB.length, 1);
-  assert.equal(ctx.WorldStateChangeStack.HasB[0].effectType, EffectType.Permanent);
-  assert.equal(ctx.WorldStateChangeStack.HasB[0].value, 1);
+  const hasAChanges = TestUtil.getWorldStateChangeStack(ctx, "HasA");
+  assert.equal(hasAChanges.length, 0);
+  const hasBChanges = TestUtil.getWorldStateChangeStack(ctx, "HasB");
+  assert.equal(hasBChanges.length, 1);
+  const firstHasBChange = hasBChanges[0];
+  if (!firstHasBChange) {
+    throw new Error("Expected HasB stack to contain an entry");
+  }
+  assert.equal(firstHasBChange.effectType, EffectType.Permanent);
+  assert.equal(firstHasBChange.value, 1);
   assert.equal(ctx.WorldState.HasB, 0);
 });
 
@@ -60,7 +66,8 @@ test("setState executing Context expected behavior", () => {
   ctx.setState("HasB", 1, true, EffectType.Permanent);
 
   assert.ok(ctx.hasState("HasB"));
-  assert.equal(ctx.WorldStateChangeStack.HasB.length, 0);
+  const hasBChanges = TestUtil.getWorldStateChangeStack(ctx, "HasB");
+  assert.equal(hasBChanges.length, 0);
   assert.equal(ctx.WorldState.HasB, 1);
 });
 
@@ -100,11 +107,11 @@ test("GetWorldStateChangeDepth expected behavior", () => {
   ctx.setState("HasB", 1, true, EffectType.Permanent);
   const changeDepthPlanning = ctx.getWorldStateChangeDepth();
 
-  assert.equal(Object.keys(ctx.WorldStateChangeStack!).length, Object.keys(changeDepthExecuting).length);
+  assert.equal(Object.keys(ctx.WorldStateChangeStack).length, Object.keys(changeDepthExecuting).length);
   assert.equal(changeDepthExecuting.HasA, 0);
   assert.equal(changeDepthExecuting.HasB, 0);
 
-  assert.equal(Object.keys(ctx.WorldStateChangeStack!).length, Object.keys(changeDepthPlanning).length);
+  assert.equal(Object.keys(ctx.WorldStateChangeStack).length, Object.keys(changeDepthPlanning).length);
   assert.equal(changeDepthPlanning.HasA, 0);
   assert.equal(changeDepthPlanning.HasB, 1);
 });
@@ -119,9 +126,12 @@ test("Trim for execution expected behavior", () => {
   ctx.setState("HasC", 1, true, EffectType.PlanOnly);
   ctx.trimForExecution();
 
-  assert.equal(ctx.WorldStateChangeStack.HasA.length, 0);
-  assert.equal(ctx.WorldStateChangeStack.HasB.length, 1);
-  assert.equal(ctx.WorldStateChangeStack.HasC.length, 0);
+  const hasAChanges = TestUtil.getWorldStateChangeStack(ctx, "HasA");
+  const hasBChanges = TestUtil.getWorldStateChangeStack(ctx, "HasB");
+  const hasCChanges = TestUtil.getWorldStateChangeStack(ctx, "HasC");
+  assert.equal(hasAChanges.length, 0);
+  assert.equal(hasBChanges.length, 1);
+  assert.equal(hasCChanges.length, 0);
 });
 
 test("Trim for execution throws exception on wrong context state", () => {
@@ -149,9 +159,12 @@ test("Trim to stack depth expected behavior", () => {
   ctx.setState("HasC", 1, false, EffectType.PlanOnly);
   ctx.trimToStackDepth(stackDepth);
 
-  assert.equal(ctx.WorldStateChangeStack.HasA.length, 1);
-  assert.equal(ctx.WorldStateChangeStack.HasB.length, 1);
-  assert.equal(ctx.WorldStateChangeStack.HasC.length, 1);
+  const hasAChanges = TestUtil.getWorldStateChangeStack(ctx, "HasA");
+  const hasBChanges = TestUtil.getWorldStateChangeStack(ctx, "HasB");
+  const hasCChanges = TestUtil.getWorldStateChangeStack(ctx, "HasC");
+  assert.equal(hasAChanges.length, 1);
+  assert.equal(hasBChanges.length, 1);
+  assert.equal(hasCChanges.length, 1);
 });
 
 test("Trim to stack depth throws exception on wrong context state", () => {

--- a/tests/planner.ts
+++ b/tests/planner.ts
@@ -3,6 +3,7 @@ import * as assert from "uvu/assert";
 import ContextState from "../src/contextState";
 import Effect from "../src/effect";
 import EffectType from "../src/effectType";
+import Domain from "../src/domain";
 import DomainBuilder from "../src/domainBuilder";
 import Planner from "../src/planner";
 import PrimitiveTask from "../src/Tasks/primitiveTask";
@@ -15,7 +16,7 @@ test("Get Plan returns instance at start ", () => {
   const planner = new Planner();
   const plan = planner.getPlan();
 
-  assert.ok(plan, null);
+  assert.ok(plan);
   assert.equal(plan.length, 0);
 });
 
@@ -30,7 +31,7 @@ test("Tick with null parameters throws error ", () => {
   const planner = new Planner();
 
   assert.throws(() => {
-    planner.tick(null, null);
+    planner.tick(null as unknown as Domain<TestContext>, null as unknown as TestContext);
   });
 });
 
@@ -42,7 +43,7 @@ test("Tick with null domain throws exception ", () => {
   const planner = new Planner();
 
   assert.throws(() => {
-    planner.tick(null, ctx);
+    planner.tick(null as unknown as Domain<TestContext>, ctx);
   });
 });
 
@@ -456,7 +457,7 @@ test("On Apply Effec expected behavior ", () => {
   task3.addEffect(new Effect({
     name: "TestEffect",
     type: EffectType.PlanAndExecute,
-    action: (context, type) => context.setState("HasA", 1, true, type),
+    action: (context, type) => context.setState("HasA", 1, true, type ?? undefined),
   }));
   task4.setOperator((_context) => TaskStatus.Continue);
 

--- a/tests/primitiveTask.ts
+++ b/tests/primitiveTask.ts
@@ -5,6 +5,7 @@ import * as assert from "uvu/assert";
 import PrimitiveTask from "../src/Tasks/primitiveTask";
 import Context from "../src/context";
 import Effect from "../src/effect";
+import EffectType from "../src/effectType";
 import TaskStatus from "../src/taskStatus";
 import FuncCondition from "../src/conditions/funcCondition";
 import FuncOperator from "../src/operators/funcOperator";
@@ -82,7 +83,7 @@ test("AddEffect wraps definition and returns task", () => {
   const task = new PrimitiveTask({ name: "Test" });
   const result = task.addEffect({
     name: "Apply",
-    type: null,
+    type: EffectType.PlanOnly,
     action: (context) => {
       context.setState("Done", true, false);
     },
@@ -232,7 +233,7 @@ test("Stop throws for invalid context", () => {
   const task = new PrimitiveTask({ name: "Handlers" });
 
   assert.throws(() => {
-    task.stop(null);
+    task.stop(null as unknown as Context);
   });
 });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import Context, { type WorldStateBase } from "../src/context";
+import Context, { type WorldStateBase, type WorldStateChange } from "../src/context";
 import Domain from "../src/domain";
 import CompoundTask from "../src/Tasks/compoundTask";
 import PrimitiveTask from "../src/Tasks/primitiveTask";
@@ -75,9 +75,32 @@ function getSimpleEffect(name, type, state) {
     name,
     type,
     action: (context, innerType) => {
-      context.setState(state, 1, true, innerType);
+      context.setState(state, 1, true, innerType ?? undefined);
     },
   });
+}
+
+function getWorldStateChangeStack<TWorldState extends WorldStateBase, TKey extends keyof TWorldState & string>(
+  context: Context<TWorldState>,
+  key: TKey,
+): WorldStateChange<TWorldState[TKey]>[] {
+  const stack = context.WorldStateChangeStack[key];
+
+  if (!stack) {
+    throw new Error(`Missing world state change stack for ${String(key)}`);
+  }
+
+  return stack as WorldStateChange<TWorldState[TKey]>[];
+}
+
+function shiftOrFail<T>(items: T[]): T {
+  const value = items.shift();
+
+  if (value === undefined) {
+    throw new Error("Expected a value when shifting from array");
+  }
+
+  return value;
 }
 
 export {
@@ -89,6 +112,8 @@ export {
   getSimplePrimitiveTaskWithDoneCondition,
   getEmptySequenceTask,
   getSimpleEffect,
+  getWorldStateChangeStack,
+  shiftOrFail,
 };
 
 export type {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "dist/types",
     "rootDir": "src",
     "strict": false,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "allowJs": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- restrict world state change stack keys to string-based world state entries
- update context helpers to enforce string world state keys and share stack initialization logic

## Testing
- npm run build
- npm run typecheck
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69067f9a3650832fab08d1a4cb177045