### PR TITLE
Add FPS combat HTN scenarios

### DIFF
--- a/tests/scenarios/fps/fpsCombatDomain.test.ts
+++ b/tests/scenarios/fps/fpsCombatDomain.test.ts
@@ -7,18 +7,51 @@ function planNames(plan: Array<{ Name: string }>): string[] {
   return plan.map((task) => task.Name);
 }
 
-test("Prefers retreat when health critical", () => {
+test("Retreat uses carried medkit", () => {
   const domain = createFpsCombatDomain();
   const context = createFpsContext({
     Health: 10,
     EnemyDistance: 15,
+    MedkitInInventory: 1,
+    MedkitAvailable: 0,
   });
 
   const { status, plan } = domain.findPlan(context);
 
   assert.is(status, DecompositionStatus.Succeeded);
   assert.ok(plan);
-  assert.equal(planNames(plan), ["RetreatToCover", "ApplyMedkit"]);
+  assert.equal(planNames(plan), ["RetreatToCover", "UseCarriedMedkit"]);
+});
+
+test("Retrieves medkit before healing", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    Health: 8,
+    EnemyDistance: 18,
+    MedkitInInventory: 0,
+    MedkitAvailable: 1,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), ["RetreatToCover", "MoveToMedkitCache", "CollectMedkit", "ApplyMedkit"]);
+});
+
+test("Holds defensive position when no medkit available", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    Health: 12,
+    MedkitInInventory: 0,
+    MedkitAvailable: 0,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), ["RetreatToCover", "HoldDefensivePosition"]);
 });
 
 test("Advances to range before shooting", () => {
@@ -29,6 +62,10 @@ test("Advances to range before shooting", () => {
     KnownWeaponAvailable: 0,
     EnemyDistance: 55,
     CurrentWeaponRange: 30,
+    PrimaryWeaponAmmo: 3,
+    GrenadeCount: 0,
+    GrenadeAvailable: 0,
+    GrenadeCacheAvailable: 0,
   });
 
   const { status, plan } = domain.findPlan(context);
@@ -40,6 +77,336 @@ test("Advances to range before shooting", () => {
     "ConfirmPrimaryWeapon",
     "AdvanceIntoRange",
     "FirePrimaryWeapon",
+  ]);
+});
+
+test("Reloads rifle before firing", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    EnemyDistance: 50,
+    CurrentWeaponRange: 30,
+    PrimaryWeaponAmmo: 0,
+    SpareAmmoClips: 1,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmLineOfSight",
+    "ReloadPrimaryWeapon",
+    "AdvanceIntoRange",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Resupplies from ammo cache when empty", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    EnemyDistance: 60,
+    CurrentWeaponRange: 30,
+    PrimaryWeaponAmmo: 0,
+    SpareAmmoClips: 0,
+    AmmoCacheAvailable: 1,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmLineOfSight",
+    "MoveToAmmoCache",
+    "CollectAmmoClips",
+    "ReloadPrimaryWeaponFromCache",
+    "AdvanceIntoRange",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Uses sidearm when rifle dry", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    EnemyDistance: 8,
+    PrimaryWeaponAmmo: 0,
+    SpareAmmoClips: 0,
+    AmmoCacheAvailable: 0,
+    HasSidearm: 1,
+    SidearmAmmo: 2,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+    GrenadeAvailable: 0,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmLineOfSight",
+    "ConfirmSidearmReady",
+    "FireSidearmBurst",
+  ]);
+});
+
+test("Reloads sidearm before use", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    EnemyDistance: 8,
+    PrimaryWeaponAmmo: 0,
+    SpareAmmoClips: 0,
+    AmmoCacheAvailable: 0,
+    HasSidearm: 1,
+    SidearmAmmo: 0,
+    SidearmClips: 1,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+    GrenadeAvailable: 0,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmLineOfSight",
+    "ReloadSidearm",
+    "FireSidearmBurst",
+  ]);
+});
+
+test("Destroys cover with grenade in hand", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    GrenadeCount: 1,
+    GrenadeAvailable: 0,
+    GrenadeCacheAvailable: 0,
+    RocketLauncherAvailable: 0,
+    RocketCacheAmmo: 0,
+    HasRocketLauncher: 0,
+    VehicleAvailable: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 2,
+    CurrentWeaponRange: 30,
+    EnemyDistance: 20,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmGrenadeReadyForCover",
+    "ThrowGrenadeAtCover",
+    "ConfirmPrimaryWeapon",
+    "HoldPositionForShot",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Fetches grenades to clear cover", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    GrenadeCount: 0,
+    GrenadeAvailable: 0,
+    GrenadeCacheAvailable: 1,
+    GrenadeCacheStock: 2,
+    RocketLauncherAvailable: 0,
+    RocketCacheAmmo: 0,
+    HasRocketLauncher: 0,
+    VehicleAvailable: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 2,
+    CurrentWeaponRange: 30,
+    EnemyDistance: 20,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "MoveToGrenadeCache",
+    "CollectGrenades",
+    "ThrowGrenadeAtCover",
+    "ConfirmPrimaryWeapon",
+    "HoldPositionForShot",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Resupplies rocket ammo before breaching", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    HasRocketLauncher: 1,
+    RocketAmmo: 0,
+    RocketCacheAmmo: 2,
+    RocketLauncherAvailable: 0,
+    VehicleAvailable: 0,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 3,
+    CurrentWeaponRange: 35,
+    EnemyDistance: 35,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ReturnToRocketCache",
+    "ResupplyRocketAmmo",
+    "FireRocketAtCover",
+    "ConfirmPrimaryWeapon",
+    "HoldPositionForShot",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Flanks when no destruction options remain", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    RocketLauncherAvailable: 0,
+    RocketCacheAmmo: 0,
+    HasRocketLauncher: 0,
+    GrenadeCount: 0,
+    GrenadeAvailable: 0,
+    GrenadeCacheAvailable: 0,
+    VehicleAvailable: 0,
+    AlternateVantageAvailable: 1,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 3,
+    CurrentWeaponRange: 30,
+    EnemyDistance: 50,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "MoveToFlankingPosition",
+    "ConfirmPrimaryWeapon",
+    "HoldPositionForShot",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Prefers grenade assault on exposed enemy", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 0,
+    GrenadeCount: 1,
+    GrenadeAvailable: 0,
+    GrenadeCacheAvailable: 0,
+    EnemyDistance: 12,
+    GrenadeEffectiveRange: 20,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 3,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "ConfirmLineOfSight",
+    "ConfirmGrenadeReady",
+    "ThrowGrenadeAtEnemy",
+  ]);
+});
+
+test("Destroys cover with rocket then fires rifle", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    RocketLauncherAvailable: 1,
+    HasRocketLauncher: 0,
+    RocketCacheAmmo: 1,
+    VehicleAvailable: 0,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    PrimaryWeaponAmmo: 2,
+    CurrentWeaponRange: 35,
+    EnemyDistance: 35,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "MoveToRocketCache",
+    "EquipRocketLauncher",
+    "FireRocketAtCover",
+    "ConfirmPrimaryWeapon",
+    "HoldPositionForShot",
+    "FirePrimaryWeapon",
+  ]);
+});
+
+test("Uses vehicle breach and finishes with melee", () => {
+  const domain = createFpsCombatDomain();
+  const context = createFpsContext({
+    EnemyObstructed: 1,
+    CoverDestructible: 1,
+    RocketLauncherAvailable: 0,
+    RocketCacheAmmo: 0,
+    HasRocketLauncher: 0,
+    VehicleAvailable: 1,
+    HasRangedWeapon: 1,
+    KnownWeaponAvailable: 0,
+    CurrentWeaponRange: 20,
+    PrimaryWeaponAmmo: 2,
+    EnemyDistance: 50,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
+  });
+
+  const { status, plan } = domain.findPlan(context);
+
+  assert.is(status, DecompositionStatus.Succeeded);
+  assert.ok(plan);
+  assert.equal(planNames(plan), [
+    "MoveToVehicle",
+    "EnterVehicle",
+    "DriveThroughCover",
+    "ExitVehicleAfterBreach",
+    "CloseDistanceForMelee",
+    "MeleeStrike",
   ]);
 });
 
@@ -72,6 +439,8 @@ test("Falls back to melee when unarmed", () => {
     KnownWeaponAvailable: 0,
     EnemyObstructed: 0,
     EnemyDistance: 40,
+    GrenadeCount: 0,
+    GrenadeCacheAvailable: 0,
   });
 
   const { status, plan } = domain.findPlan(context);
@@ -80,58 +449,6 @@ test("Falls back to melee when unarmed", () => {
   assert.ok(plan);
   assert.equal(planNames(plan), [
     "ConfirmLineOfSight",
-    "CloseDistanceForMelee",
-    "MeleeStrike",
-  ]);
-});
-
-test("Destroys cover with rocket then fires rifle", () => {
-  const domain = createFpsCombatDomain();
-  const context = createFpsContext({
-    EnemyObstructed: 1,
-    CoverDestructible: 1,
-    RocketLauncherAvailable: 1,
-    HasRangedWeapon: 1,
-    KnownWeaponAvailable: 0,
-    CurrentWeaponRange: 35,
-    EnemyDistance: 35,
-  });
-
-  const { status, plan } = domain.findPlan(context);
-
-  assert.is(status, DecompositionStatus.Succeeded);
-  assert.ok(plan);
-  assert.equal(planNames(plan), [
-    "MoveToRocketCache",
-    "EquipRocketLauncher",
-    "FireRocketAtCover",
-    "ConfirmPrimaryWeapon",
-    "HoldPositionForShot",
-    "FirePrimaryWeapon",
-  ]);
-});
-
-test("Uses vehicle breach and finishes with melee", () => {
-  const domain = createFpsCombatDomain();
-  const context = createFpsContext({
-    EnemyObstructed: 1,
-    RocketLauncherAvailable: 0,
-    VehicleAvailable: 1,
-    HasRangedWeapon: 1,
-    KnownWeaponAvailable: 0,
-    CurrentWeaponRange: 20,
-    EnemyDistance: 50,
-  });
-
-  const { status, plan } = domain.findPlan(context);
-
-  assert.is(status, DecompositionStatus.Succeeded);
-  assert.ok(plan);
-  assert.equal(planNames(plan), [
-    "MoveToVehicle",
-    "EnterVehicle",
-    "DriveThroughCover",
-    "ExitVehicleAfterBreach",
     "CloseDistanceForMelee",
     "MeleeStrike",
   ]);

--- a/tests/scenarios/fps/fpsCombatDomain.ts
+++ b/tests/scenarios/fps/fpsCombatDomain.ts
@@ -11,7 +11,10 @@ export type LocationId =
   | "rocket_cache"
   | "garage"
   | "enemy_post"
-  | "flank_route";
+  | "flank_route"
+  | "medbay"
+  | "ammo_cache"
+  | "grenade_locker";
 
 export type FpsWorldState = {
   Health: number;
@@ -36,6 +39,17 @@ export type FpsWorldState = {
   KnownWeaponRange: number;
   HasRangedWeapon: number;
   CurrentWeaponRange: number;
+  PrimaryWeaponAmmo: number;
+  PrimaryWeaponClipSize: number;
+  SpareAmmoClips: number;
+  AmmoCacheAvailable: number;
+  AmmoCacheLocation: LocationId;
+  AmmoClipRestockAmount: number;
+  HasSidearm: number;
+  SidearmRange: number;
+  SidearmAmmo: number;
+  SidearmClipSize: number;
+  SidearmClips: number;
   RocketLauncherAvailable: number;
   HasRocketLauncher: number;
   RocketAmmo: number;
@@ -46,6 +60,15 @@ export type FpsWorldState = {
   HasVehicle: number;
   IsInVehicle: number;
   AlternateVantageAvailable: number;
+  MedkitAvailable: number;
+  MedkitInInventory: number;
+  MedkitLocation: LocationId;
+  GrenadeCount: number;
+  GrenadeAvailable: number;
+  GrenadeEffectiveRange: number;
+  GrenadeCacheAvailable: number;
+  GrenadeCacheLocation: LocationId;
+  GrenadeCacheStock: number;
 };
 
 export type FpsContext = Context<FpsWorldState>;
@@ -73,6 +96,17 @@ const DEFAULT_STATE: FpsWorldState = {
   KnownWeaponRange: 40,
   HasRangedWeapon: 1,
   CurrentWeaponRange: 30,
+  PrimaryWeaponAmmo: 5,
+  PrimaryWeaponClipSize: 5,
+  SpareAmmoClips: 1,
+  AmmoCacheAvailable: 0,
+  AmmoCacheLocation: "ammo_cache",
+  AmmoClipRestockAmount: 2,
+  HasSidearm: 1,
+  SidearmRange: 12,
+  SidearmAmmo: 3,
+  SidearmClipSize: 3,
+  SidearmClips: 1,
   RocketLauncherAvailable: 0,
   HasRocketLauncher: 0,
   RocketAmmo: 0,
@@ -83,6 +117,15 @@ const DEFAULT_STATE: FpsWorldState = {
   HasVehicle: 0,
   IsInVehicle: 0,
   AlternateVantageAvailable: 1,
+  MedkitAvailable: 1,
+  MedkitInInventory: 0,
+  MedkitLocation: "medbay",
+  GrenadeCount: 0,
+  GrenadeAvailable: 0,
+  GrenadeEffectiveRange: 20,
+  GrenadeCacheAvailable: 0,
+  GrenadeCacheLocation: "grenade_locker",
+  GrenadeCacheStock: 2,
 };
 
 function planEffect<K extends keyof FpsWorldState>(
@@ -118,17 +161,58 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
           .do(() => TaskStatus.Success)
           .effect("Move to cover", EffectType.PlanOnly, (context, effectType) => {
             planEffect(context, "AgentPosition", context.getState("CoverPosition"), effectType);
-            // Retreat increases distance from the threat.
             const distance = (context.getState("EnemyDistance") as number) + 10;
             planEffect(context, "EnemyDistance", distance, effectType);
             planEffect(context, "CloseQuartersAdvantage", 0, effectType);
           })
         .end()
-        .action("ApplyMedkit")
-          .do(() => TaskStatus.Success)
-          .effect("Restore health", EffectType.PlanOnly, (context, effectType) => {
-            planEffect(context, "Health", context.getState("MaxHealth"), effectType);
-          })
+        .select("SecureHealing")
+          .sequence("UseCarriedMedkitDirectly")
+            .condition("Medkit carried", (context) => context.hasState("MedkitInInventory", 1))
+            .action("UseCarriedMedkit")
+              .do(() => TaskStatus.Success)
+              .effect("Restore health with carried medkit", EffectType.PlanOnly, (context, effectType) => {
+                planEffect(context, "Health", context.getState("MaxHealth"), effectType);
+                planEffect(context, "MedkitInInventory", 0, effectType);
+              })
+            .end()
+          .end()
+          .sequence("RetrieveAndApplyMedkit")
+            .condition("Medkit cache accessible", (context) => context.hasState("MedkitAvailable", 1))
+            .action("MoveToMedkitCache")
+              .do(() => TaskStatus.Success)
+              .effect("Navigate to medbay", EffectType.PlanOnly, (context, effectType) => {
+                planEffect(context, "AgentPosition", context.getState("MedkitLocation"), effectType);
+                const distance = (context.getState("EnemyDistance") as number) + 5;
+                planEffect(context, "EnemyDistance", distance, effectType);
+              })
+            .end()
+            .action("CollectMedkit")
+              .do(() => TaskStatus.Success)
+              .effect("Secure medkit", EffectType.PlanOnly, (context, effectType) => {
+                planEffect(context, "MedkitInInventory", 1, effectType);
+                planEffect(context, "MedkitAvailable", 0, effectType);
+              })
+            .end()
+            .action("ApplyMedkit")
+              .do(() => TaskStatus.Success)
+              .effect("Restore health from medbay cache", EffectType.PlanOnly, (context, effectType) => {
+                planEffect(context, "Health", context.getState("MaxHealth"), effectType);
+                planEffect(context, "MedkitInInventory", 0, effectType);
+              })
+            .end()
+          .end()
+          .sequence("HoldDefensivePositionWithoutMedkit")
+            .action("HoldDefensivePosition")
+              .do(() => TaskStatus.Success)
+              .effect("Regain composure", EffectType.PlanOnly, (context, effectType) => {
+                const threshold = context.getState("CriticalHealthThreshold") as number;
+                const max = context.getState("MaxHealth") as number;
+                const recovered = Math.min(max, threshold + 10);
+                planEffect(context, "Health", recovered, effectType);
+              })
+            .end()
+          .end()
         .end()
       .end()
       .sequence("EngageKnownEnemy")
@@ -146,7 +230,7 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
             .condition("Cover is destructible", (context) => context.hasState("CoverDestructible", 1))
             .condition("Rocket option available", (context) => {
               const hasRocket = context.hasState("HasRocketLauncher", 1) && (context.getState("RocketAmmo") as number) > 0;
-              return hasRocket || context.hasState("RocketLauncherAvailable", 1);
+              return hasRocket || context.hasState("RocketLauncherAvailable", 1) || (context.getState("RocketCacheAmmo") as number) > 0;
             })
             .select("EnsureRocketLauncher")
               .sequence("AlreadyCarryingRocket")
@@ -154,6 +238,27 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
                 .condition("Rocket ammo loaded", (context) => (context.getState("RocketAmmo") as number) > 0)
                 .action("ReadyRocketLauncher")
                   .do(() => TaskStatus.Success)
+                .end()
+              .end()
+              .sequence("RestockRocketAmmo")
+                .condition("Rocket owned but empty", (context) =>
+                  context.hasState("HasRocketLauncher", 1) && (context.getState("RocketAmmo") as number) === 0,
+                )
+                .condition("Rocket ammo cache stocked", (context) => (context.getState("RocketCacheAmmo") as number) > 0)
+                .action("ReturnToRocketCache")
+                  .do(() => TaskStatus.Success)
+                  .effect("Backtrack to rocket cache", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "AgentPosition", context.getState("KnownRocketLocation"), effectType);
+                  })
+                .end()
+                .action("ResupplyRocketAmmo")
+                  .do(() => TaskStatus.Success)
+                  .effect("Reload rocket ammo", EffectType.PlanOnly, (context, effectType) => {
+                    const ammoFromCache = context.getState("RocketCacheAmmo") as number;
+                    planEffect(context, "RocketAmmo", Math.max(1, ammoFromCache), effectType);
+                    planEffect(context, "RocketCacheAmmo", 0, effectType);
+                    planEffect(context, "HasRocketLauncher", 1, effectType);
+                  })
                 .end()
               .end()
               .sequence("CollectRocketLauncher")
@@ -167,9 +272,11 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
                 .action("EquipRocketLauncher")
                   .do(() => TaskStatus.Success)
                   .effect("Gain rocket launcher", EffectType.PlanOnly, (context, effectType) => {
+                    const ammoFromCache = context.getState("RocketCacheAmmo") as number;
                     planEffect(context, "HasRocketLauncher", 1, effectType);
-                    planEffect(context, "RocketAmmo", context.getState("RocketCacheAmmo") as number, effectType);
+                    planEffect(context, "RocketAmmo", Math.max(1, ammoFromCache), effectType);
                     planEffect(context, "RocketLauncherAvailable", 0, effectType);
+                    planEffect(context, "RocketCacheAmmo", 0, effectType);
                   })
                 .end()
               .end()
@@ -180,6 +287,61 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
               .effect("Destroy obstruction", EffectType.PlanOnly, (context, effectType) => {
                 const remaining = Math.max(0, (context.getState("RocketAmmo") as number) - 1);
                 planEffect(context, "RocketAmmo", remaining, effectType);
+                planEffect(context, "EnemyObstructed", 0, effectType);
+                planEffect(context, "EnemyCoverIntegrity", 0, effectType);
+                planEffect(context, "CloseQuartersAdvantage", 0, effectType);
+              })
+            .end()
+          .end()
+          .sequence("DestroyCoverWithGrenade")
+            .condition("Obstruction present", (context) => context.hasState("EnemyObstructed", 1))
+            .condition("Cover is destructible", (context) => context.hasState("CoverDestructible", 1))
+            .condition("Grenade tactic available", (context) => {
+              const grenades = context.getState("GrenadeCount") as number;
+              return grenades > 0 || context.hasState("GrenadeAvailable", 1) || context.hasState("GrenadeCacheAvailable", 1);
+            })
+            .select("EnsureGrenadeForBreach")
+              .sequence("GrenadeOnHandForBreach")
+                .condition("Grenade carried", (context) => (context.getState("GrenadeCount") as number) > 0)
+                .action("ConfirmGrenadeReadyForCover")
+                  .do(() => TaskStatus.Success)
+                .end()
+              .end()
+              .sequence("GrabNearbyGrenadeForBreach")
+                .condition("Loose grenade spotted", (context) => context.hasState("GrenadeAvailable", 1))
+                .action("PickUpLooseGrenade")
+                  .do(() => TaskStatus.Success)
+                  .effect("Grab loose grenade", EffectType.PlanOnly, (context, effectType) => {
+                    const grenades = (context.getState("GrenadeCount") as number) + 1;
+                    planEffect(context, "GrenadeCount", grenades, effectType);
+                    planEffect(context, "GrenadeAvailable", 0, effectType);
+                  })
+                .end()
+              .end()
+              .sequence("FetchGrenadeCacheForBreach")
+                .condition("Grenade cache stocked", (context) => context.hasState("GrenadeCacheAvailable", 1))
+                .action("MoveToGrenadeCache")
+                  .do(() => TaskStatus.Success)
+                  .effect("Approach grenade locker", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "AgentPosition", context.getState("GrenadeCacheLocation"), effectType);
+                    const distance = (context.getState("EnemyDistance") as number) + 5;
+                    planEffect(context, "EnemyDistance", distance, effectType);
+                  })
+                .end()
+                .action("CollectGrenades")
+                  .do(() => TaskStatus.Success)
+                  .effect("Stock grenades", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "GrenadeCount", context.getState("GrenadeCacheStock") as number, effectType);
+                    planEffect(context, "GrenadeCacheAvailable", 0, effectType);
+                  })
+                .end()
+              .end()
+            .end()
+            .action("ThrowGrenadeAtCover")
+              .do(() => TaskStatus.Success)
+              .effect("Shatter enemy cover", EffectType.PlanOnly, (context, effectType) => {
+                const grenades = Math.max(0, (context.getState("GrenadeCount") as number) - 1);
+                planEffect(context, "GrenadeCount", grenades, effectType);
                 planEffect(context, "EnemyObstructed", 0, effectType);
                 planEffect(context, "EnemyCoverIntegrity", 0, effectType);
                 planEffect(context, "CloseQuartersAdvantage", 0, effectType);
@@ -249,16 +411,128 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
           .end()
         .end()
         .utilitySelect("ChooseAttackMode")
+          .sequence("GrenadeAssault")
+            .utility((context) => {
+              const grenades = context.getState("GrenadeCount") as number;
+              return grenades > 0 ? 110 : 70;
+            })
+            .condition("Grenade assault possible", (context) => {
+              const grenades = context.getState("GrenadeCount") as number;
+              const distance = context.getState("EnemyDistance") as number;
+              const range = context.getState("GrenadeEffectiveRange") as number;
+              return distance <= range && (grenades > 0 || context.hasState("GrenadeAvailable", 1) || context.hasState("GrenadeCacheAvailable", 1));
+            })
+            .select("EnsureGrenadesForAttack")
+              .sequence("GrenadeReadyForAttack")
+                .condition("Grenade on hand", (context) => (context.getState("GrenadeCount") as number) > 0)
+                .action("ConfirmGrenadeReady")
+                  .do(() => TaskStatus.Success)
+                .end()
+              .end()
+              .sequence("GrabNearbyGrenadeForAttack")
+                .condition("Loose grenade available", (context) => context.hasState("GrenadeAvailable", 1))
+                .action("PickUpLooseGrenade")
+                  .do(() => TaskStatus.Success)
+                  .effect("Grab loose grenade", EffectType.PlanOnly, (context, effectType) => {
+                    const grenades = (context.getState("GrenadeCount") as number) + 1;
+                    planEffect(context, "GrenadeCount", grenades, effectType);
+                    planEffect(context, "GrenadeAvailable", 0, effectType);
+                  })
+                .end()
+              .end()
+              .sequence("AcquireGrenadesForAttack")
+                .condition("Grenade cache stocked", (context) => context.hasState("GrenadeCacheAvailable", 1))
+                .action("MoveToGrenadeCache")
+                  .do(() => TaskStatus.Success)
+                  .effect("Approach grenade locker", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "AgentPosition", context.getState("GrenadeCacheLocation"), effectType);
+                    const distance = (context.getState("EnemyDistance") as number) + 5;
+                    planEffect(context, "EnemyDistance", distance, effectType);
+                  })
+                .end()
+                .action("CollectGrenades")
+                  .do(() => TaskStatus.Success)
+                  .effect("Stock grenades", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "GrenadeCount", context.getState("GrenadeCacheStock") as number, effectType);
+                    planEffect(context, "GrenadeCacheAvailable", 0, effectType);
+                  })
+                .end()
+              .end()
+            .end()
+            .action("ThrowGrenadeAtEnemy")
+              .do(() => TaskStatus.Success)
+              .effect("Eliminate enemy with grenade", EffectType.PlanOnly, (context, effectType) => {
+                const grenades = Math.max(0, (context.getState("GrenadeCount") as number) - 1);
+                planEffect(context, "GrenadeCount", grenades, effectType);
+                planEffect(context, "EnemyNeutralized", 1, effectType);
+              })
+            .end()
+          .end()
           .sequence("RangedEngagementPlan")
             .utility((context) => (context.hasState("CloseQuartersAdvantage", 1) ? 25 : 100))
-            .condition("Ranged option possible", (context) =>
-              context.hasState("HasRangedWeapon", 1) || context.hasState("KnownWeaponAvailable", 1),
-            )
+            .condition("Ranged option possible", (context) => {
+              const hasWeapon = context.hasState("HasRangedWeapon", 1);
+              const ammoLoaded = (context.getState("PrimaryWeaponAmmo") as number) > 0;
+              const spareClips = (context.getState("SpareAmmoClips") as number) > 0;
+              const canResupply = context.hasState("AmmoCacheAvailable", 1);
+              const canRetrieveWeapon = context.hasState("KnownWeaponAvailable", 1);
+              return (hasWeapon && (ammoLoaded || spareClips || canResupply)) || canRetrieveWeapon;
+            })
             .select("EnsurePrimaryWeapon")
               .sequence("WeaponReady")
                 .condition("Already armed", (context) => context.hasState("HasRangedWeapon", 1))
+                .condition("Primary ammo loaded", (context) => (context.getState("PrimaryWeaponAmmo") as number) > 0)
                 .action("ConfirmPrimaryWeapon")
                   .do(() => TaskStatus.Success)
+                .end()
+              .end()
+              .sequence("ReloadPrimaryWeapon")
+                .condition("Weapon on hand but empty", (context) =>
+                  context.hasState("HasRangedWeapon", 1) && (context.getState("PrimaryWeaponAmmo") as number) === 0,
+                )
+                .condition("Spare rifle clip available", (context) => (context.getState("SpareAmmoClips") as number) > 0)
+                .action("ReloadPrimaryWeapon")
+                  .do(() => TaskStatus.Success)
+                  .effect("Reload primary weapon", EffectType.PlanOnly, (context, effectType) => {
+                    const clipSize = context.getState("PrimaryWeaponClipSize") as number;
+                    const spare = Math.max(0, (context.getState("SpareAmmoClips") as number) - 1);
+                    planEffect(context, "PrimaryWeaponAmmo", clipSize, effectType);
+                    planEffect(context, "SpareAmmoClips", spare, effectType);
+                    planEffect(context, "HasRangedWeapon", 1, effectType);
+                  })
+                .end()
+              .end()
+              .sequence("ResupplyPrimaryAmmo")
+                .condition("Weapon dry without spare clips", (context) =>
+                  context.hasState("HasRangedWeapon", 1) &&
+                  (context.getState("PrimaryWeaponAmmo") as number) === 0 &&
+                  (context.getState("SpareAmmoClips") as number) === 0,
+                )
+                .condition("Ammo cache accessible", (context) => context.hasState("AmmoCacheAvailable", 1))
+                .action("MoveToAmmoCache")
+                  .do(() => TaskStatus.Success)
+                  .effect("Travel to ammo cache", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "AgentPosition", context.getState("AmmoCacheLocation"), effectType);
+                    const distance = (context.getState("EnemyDistance") as number) + 5;
+                    planEffect(context, "EnemyDistance", distance, effectType);
+                  })
+                .end()
+                .action("CollectAmmoClips")
+                  .do(() => TaskStatus.Success)
+                  .effect("Restock rifle ammo", EffectType.PlanOnly, (context, effectType) => {
+                    planEffect(context, "SpareAmmoClips", context.getState("AmmoClipRestockAmount") as number, effectType);
+                    planEffect(context, "AmmoCacheAvailable", 0, effectType);
+                  })
+                .end()
+                .action("ReloadPrimaryWeaponFromCache")
+                  .do(() => TaskStatus.Success)
+                  .effect("Reload from cache", EffectType.PlanOnly, (context, effectType) => {
+                    const clipSize = context.getState("PrimaryWeaponClipSize") as number;
+                    const spare = Math.max(0, (context.getState("SpareAmmoClips") as number) - 1);
+                    planEffect(context, "PrimaryWeaponAmmo", clipSize, effectType);
+                    planEffect(context, "SpareAmmoClips", spare, effectType);
+                    planEffect(context, "HasRangedWeapon", 1, effectType);
+                  })
                 .end()
               .end()
               .sequence("RetrieveNearbyWeapon")
@@ -276,6 +550,8 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
                     planEffect(context, "HasRangedWeapon", 1, effectType);
                     planEffect(context, "CurrentWeaponRange", context.getState("KnownWeaponRange") as number, effectType);
                     planEffect(context, "KnownWeaponAvailable", 0, effectType);
+                    planEffect(context, "PrimaryWeaponAmmo", context.getState("PrimaryWeaponClipSize") as number, effectType);
+                    planEffect(context, "SpareAmmoClips", 1, effectType);
                   })
                 .end()
               .end()
@@ -297,7 +573,12 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
                     const maxRange = context.getState("CurrentWeaponRange") as number;
                     const newDistance = Math.min(preferred, maxRange);
                     planEffect(context, "EnemyDistance", newDistance, effectType);
-                    planEffect(context, "CloseQuartersAdvantage", newDistance <= (context.getState("MeleeRange") as number) ? 1 : 0, effectType);
+                    planEffect(
+                      context,
+                      "CloseQuartersAdvantage",
+                      newDistance <= (context.getState("MeleeRange") as number) ? 1 : 0,
+                      effectType,
+                    );
                   })
                 .end()
               .end()
@@ -307,6 +588,46 @@ export function createFpsCombatDomain(): Domain<FpsContext> {
               .do(() => TaskStatus.Success)
               .effect("Neutralize enemy at range", EffectType.PlanOnly, (context, effectType) => {
                 planEffect(context, "EnemyNeutralized", 1, effectType);
+                const ammo = Math.max(0, (context.getState("PrimaryWeaponAmmo") as number) - 1);
+                planEffect(context, "PrimaryWeaponAmmo", ammo, effectType);
+              })
+            .end()
+          .end()
+          .sequence("SidearmBurst")
+            .utility(() => 80)
+            .condition("Sidearm available", (context) => context.hasState("HasSidearm", 1))
+            .condition("Enemy within sidearm range", (context) =>
+              (context.getState("EnemyDistance") as number) <= (context.getState("SidearmRange") as number),
+            )
+            .select("EnsureSidearmReady")
+              .sequence("SidearmLoaded")
+                .condition("Sidearm ammo remaining", (context) => (context.getState("SidearmAmmo") as number) > 0)
+                .action("ConfirmSidearmReady")
+                  .do(() => TaskStatus.Success)
+                .end()
+              .end()
+              .sequence("ReloadSidearm")
+                .condition("Sidearm empty", (context) => (context.getState("SidearmAmmo") as number) === 0)
+                .condition("Sidearm clips available", (context) => (context.getState("SidearmClips") as number) > 0)
+                .action("ReloadSidearm")
+                  .do(() => TaskStatus.Success)
+                  .effect("Reload sidearm", EffectType.PlanOnly, (context, effectType) => {
+                    const clipSize = context.getState("SidearmClipSize") as number;
+                    const remainingClips = Math.max(0, (context.getState("SidearmClips") as number) - 1);
+                    planEffect(context, "SidearmAmmo", clipSize, effectType);
+                    planEffect(context, "SidearmClips", remainingClips, effectType);
+                    planEffect(context, "HasSidearm", 1, effectType);
+                  })
+                .end()
+              .end()
+            .end()
+            .action("FireSidearmBurst")
+              .do(() => TaskStatus.Success)
+              .effect("Neutralize enemy with sidearm", EffectType.PlanOnly, (context, effectType) => {
+                const ammo = Math.max(0, (context.getState("SidearmAmmo") as number) - 1);
+                planEffect(context, "SidearmAmmo", ammo, effectType);
+                planEffect(context, "EnemyNeutralized", 1, effectType);
+                planEffect(context, "CloseQuartersAdvantage", 0, effectType);
               })
             .end()
           .end()


### PR DESCRIPTION
## Summary
- add a headless FPS combat domain that models survival, ranged combat, cover removal, and close-quarters tactics
- create scenario tests that exercise weapon acquisition, rocket-based breaching, vehicle ramming, and melee fallback behaviors

## Testing
- npm run build
- npm run typecheck
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6906dee01bac832f8e5609f02d852031