### PR TITLE
feat: allow custom GOAP goal satisfaction evaluation

### DIFF
--- a/src/Tasks/goapSequenceTask.ts
+++ b/src/Tasks/goapSequenceTask.ts
@@ -134,7 +134,7 @@ const createVirtualContext = (baseContext: Context, world: WorldState): Context 
   return virtual;
 };
 
-const isGoalSatisfied = (goal: Record<string, number>, world: WorldState): boolean => {
+const defaultGoalEvaluator = (goal: Record<string, number>, world: WorldState): boolean => {
   for (const [key, value] of Object.entries(goal)) {
     if (world[key] !== value) {
       return false;
@@ -177,6 +177,9 @@ const decompose = (context: Context, _startIndex: number, task: CompoundTask): P
 
   const visited = new Map<string, number>();
 
+  const goal = task.Goal;
+  const goalEvaluator = task.GoalEvaluator ?? defaultGoalEvaluator;
+
   while (open.length > 0) {
     let lowestIndex = 0;
 
@@ -196,7 +199,7 @@ const decompose = (context: Context, _startIndex: number, task: CompoundTask): P
 
     visited.set(worldKey, current.cost);
 
-    if (isGoalSatisfied(task.Goal, current.world)) {
+    if (goalEvaluator(goal, current.world, context)) {
       if (context.MethodTraversalRecord.length === 0) {
         context.MethodTraversalRecord.push(0);
       }

--- a/src/domainBuilder.ts
+++ b/src/domainBuilder.ts
@@ -2,7 +2,7 @@ import Domain from "./domain";
 import type Context from "./context";
 import type { WorldStateBase } from "./context";
 import { type EffectTypeValue } from "./effectType";
-import CompoundTask, { type CompoundTaskChild } from "./Tasks/compoundTask";
+import CompoundTask, { type CompoundTaskChild, type GoalEvaluator } from "./Tasks/compoundTask";
 import PrimitiveTask, { type PrimitiveTaskOperator, type TaskCondition } from "./Tasks/primitiveTask";
 import PausePlanTask from "./Tasks/pausePlanTask";
 import Slot from "./Tasks/slot";
@@ -60,12 +60,24 @@ class DomainBuilder<TContext extends Context<WorldStateBase> = Context> {
     return this.addCompoundTask(new CompoundTask<TContext>({ name, type: "utility_select" }));
   }
 
-  goapSequence(name: string, goal: Record<string, number>): this {
-    return this.addCompoundTask(new CompoundTask<TContext>({ name, type: "goap_sequence", goal }));
+  goapSequence(name: string, goal: Record<string, number>, goalEvaluator?: GoalEvaluator<TContext>): this {
+    return this.addCompoundTask(new CompoundTask<TContext>({ name, type: "goap_sequence", goal, goalEvaluator }));
   }
 
   compoundTask(task: CompoundTask<TContext>): this {
     return this.addCompoundTask(task);
+  }
+
+  goalEvaluator(goalEvaluator?: GoalEvaluator<TContext>): this {
+    const pointer = this.ensureCompoundPointer();
+
+    if (pointer.Type !== "goap_sequence") {
+      throw new Error("Goal evaluators can only be assigned to GOAP sequence tasks");
+    }
+
+    pointer.setGoalEvaluator(goalEvaluator);
+
+    return this;
   }
 
   primitiveTask(task: PrimitiveTask<TContext>): this {


### PR DESCRIPTION
## Summary
- allow GOAP sequence tasks to provide optional custom goal evaluators
- expose DomainBuilder helpers for configuring evaluators when building domains
- cover the new behavior with a GOAP sequence unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690725bafd74832faee46cf6ed2b1a21