### PR TITLE
Add GOAP heuristic and weighted A* support

### DIFF
--- a/src/Tasks/compoundTask.ts
+++ b/src/Tasks/compoundTask.ts
@@ -55,6 +55,10 @@ class CompoundTask<TContext extends Context = Context> {
 
   private goapCost?: (context: TContext) => number;
 
+  private goapHeuristic?: (context: TContext, goal: Record<string, number>) => number;
+
+  private goapHeuristicWeight = 1;
+
   public Goal?: Record<string, number>;
 
   constructor({ name, tasks, type, conditions, goal }: CompoundTaskConfig<TContext>) {
@@ -188,6 +192,30 @@ class CompoundTask<TContext extends Context = Context> {
     }
 
     return 0;
+  }
+
+  setGoapHeuristic(heuristic?: (context: TContext, goal: Record<string, number>) => number): this {
+    this.goapHeuristic = heuristic;
+
+    return this;
+  }
+
+  getGoapHeuristic(): ((context: TContext, goal: Record<string, number>) => number) | undefined {
+    return this.goapHeuristic;
+  }
+
+  setGoapHeuristicWeight(weight: number): this {
+    if (typeof weight !== "number" || !Number.isFinite(weight) || weight < 1) {
+      this.goapHeuristicWeight = 1;
+    } else {
+      this.goapHeuristicWeight = weight;
+    }
+
+    return this;
+  }
+
+  getGoapHeuristicWeight(): number {
+    return this.goapHeuristicWeight;
   }
 }
 

--- a/src/domainBuilder.ts
+++ b/src/domainBuilder.ts
@@ -113,6 +113,30 @@ class DomainBuilder<TContext extends Context<WorldStateBase> = Context> {
     return this;
   }
 
+  goapHeuristic(heuristic: (context: TContext, goal: Record<string, number>) => number): this {
+    const pointer = this.ensureCompoundPointer();
+
+    if (pointer.Type !== "goap_sequence") {
+      throw new Error("goapHeuristic can only be used inside a GOAP sequence task");
+    }
+
+    pointer.setGoapHeuristic(heuristic);
+
+    return this;
+  }
+
+  goapHeuristicWeight(weight: number): this {
+    const pointer = this.ensureCompoundPointer();
+
+    if (pointer.Type !== "goap_sequence") {
+      throw new Error("goapHeuristicWeight can only be used inside a GOAP sequence task");
+    }
+
+    pointer.setGoapHeuristicWeight(weight);
+
+    return this;
+  }
+
   cost(costFn: (context: TContext) => number): this {
     const pointer = this.pointer;
 


### PR DESCRIPTION
## Summary
- add per-sequence heuristic and weight configuration for GOAP tasks via the domain builder
- update GOAP sequence decomposition to use A*/weighted A* scoring with heuristic sanitization while preserving UCS fallback
- expand GOAP tests and documentation to cover heuristics, weighted search, and safety cases

## Testing
- npm run build
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_690724d6cb80832f859cc1ee25b8aa50