### PR TITLE
Enhance puzzle scenario tests with functional state transitions

### DIFF
--- a/tests/scenarios/puzzles/blocksWorld.test.ts
+++ b/tests/scenarios/puzzles/blocksWorld.test.ts
@@ -1,0 +1,231 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface BlocksWorldState extends WorldStateBase {
+  stacks: Record<string, string[]>;
+  table: string[];
+  tableCapacity: number;
+  goalTower: string[];
+  goalStackId: string;
+}
+
+type BlocksWorldContext = Context<BlocksWorldState>;
+
+function cloneStacks(state: BlocksWorldState): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.entries(state.stacks).map(([key, stack]) => [key, [...stack]]),
+  );
+}
+
+function findBlock(state: BlocksWorldState, block: string): { stackId: string | null; index: number } {
+  for (const [stackId, stack] of Object.entries(state.stacks)) {
+    const index = stack.indexOf(block);
+    if (index !== -1) {
+      return { stackId, index };
+    }
+  }
+
+  const tableIndex = state.table.indexOf(block);
+  if (tableIndex !== -1) {
+    return { stackId: null, index: tableIndex };
+  }
+
+  throw new Error(`Block ${block} not found in world state`);
+}
+
+function blocksAbove(state: BlocksWorldState, block: string): number {
+  const location = findBlock(state, block);
+  if (!location.stackId) {
+    return 0;
+  }
+
+  const stack = state.stacks[location.stackId];
+  return stack.length - location.index - 1;
+}
+
+function ensureTableCapacity(state: BlocksWorldState, requiredSpace: number): void {
+  if (state.table.length + requiredSpace > state.tableCapacity) {
+    throw new Error("Insufficient table capacity to clear blocks");
+  }
+}
+
+function exposeBaseBlock(context: BlocksWorldContext): void {
+  const world = context.WorldState;
+  const base = world.goalTower[0];
+  const location = findBlock(world, base);
+  if (!location.stackId) {
+    return;
+  }
+
+  const stack = world.stacks[location.stackId];
+  ensureTableCapacity(world, stack.length - location.index - 1);
+
+  while (stack[stack.length - 1] !== base) {
+    const removed = stack.pop();
+    if (!removed) {
+      break;
+    }
+    world.table.push(removed);
+  }
+
+  context.setState("stacks", cloneStacks(world), false);
+  context.setState("table", [...world.table], false);
+}
+
+function moveBaseToGoalStack(context: BlocksWorldContext): void {
+  const world = context.WorldState;
+  const base = world.goalTower[0];
+  const { stackId, index } = findBlock(world, base);
+
+  if (stackId === world.goalStackId) {
+    return;
+  }
+
+  if (stackId === null) {
+    // Pull from table
+    world.table.splice(index, 1);
+  } else {
+    const stack = world.stacks[stackId];
+    if (stack.length !== 1) {
+      throw new Error(`Base block ${base} still has blocks above it`);
+    }
+    delete world.stacks[stackId];
+  }
+
+  world.stacks[world.goalStackId] = [base];
+
+  context.setState("stacks", cloneStacks(world), false);
+  context.setState("table", [...world.table], false);
+}
+
+function stackRemainingBlocks(context: BlocksWorldContext): void {
+  const world = context.WorldState;
+  const stack = world.stacks[world.goalStackId];
+  if (!stack || stack.length === 0) {
+    throw new Error("Goal stack not prepared");
+  }
+
+  for (let i = 1; i < world.goalTower.length; i++) {
+    const block = world.goalTower[i];
+    const location = findBlock(world, block);
+
+    if (location.stackId !== null) {
+      const sourceStack = world.stacks[location.stackId];
+      if (sourceStack.length - 1 !== location.index) {
+        throw new Error(`Block ${block} is not clear to move`);
+      }
+      sourceStack.pop();
+      if (sourceStack.length === 0) {
+        delete world.stacks[location.stackId];
+      }
+    } else {
+      world.table.splice(location.index, 1);
+    }
+
+    stack.push(block);
+  }
+
+  context.setState("stacks", cloneStacks(world), false);
+  context.setState("table", [...world.table], false);
+}
+
+function createBlocksWorldDomain(): DomainBuilder<BlocksWorldContext> {
+  const builder = new DomainBuilder<BlocksWorldContext>("Blocks world");
+
+  builder
+    .sequence("Assemble goal tower")
+      .action("Expose goal base")
+        .condition("Have capacity to clear base", (ctx) => {
+          const world = ctx.WorldState;
+          const required = blocksAbove(world, world.goalTower[0]);
+          return world.table.length + required <= world.tableCapacity;
+        })
+        .do((ctx) => {
+          exposeBaseBlock(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Move base to goal stack")
+        .do((ctx) => {
+          moveBaseToGoalStack(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Stack remaining blocks")
+        .do((ctx) => {
+          stackRemainingBlocks(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createBlocksWorldContext(overrides: Partial<BlocksWorldState> = {}): BlocksWorldContext {
+  return createPuzzleContext<BlocksWorldState>({
+    stacks: {
+      start: ["C", "A"],
+      spare: ["B"],
+    },
+    table: [],
+    tableCapacity: 2,
+    goalTower: ["C", "B", "A"],
+    goalStackId: "goal",
+    ...overrides,
+  });
+}
+
+test("Blocks world clears stacked blockers before assembling tower", () => {
+  const domain = buildDomain(createBlocksWorldDomain());
+  const context = createBlocksWorldContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Expose goal base",
+    "Move base to goal stack",
+    "Stack remaining blocks",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("stacks").goal, ["C", "B", "A"]);
+  assert.equal(context.getState("table"), []);
+  assert.ok(!context.getState("stacks").start);
+});
+
+test("Blocks world handles pre-cleared base without extra moves", () => {
+  const domain = buildDomain(createBlocksWorldDomain());
+  const context = createBlocksWorldContext({
+    stacks: { start: ["C"], spare: [] },
+    table: ["B", "A"],
+  });
+
+  const plan = ensurePlan(domain, context);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("stacks").goal, ["C", "B", "A"]);
+  assert.equal(context.getState("table"), []);
+});
+
+test("Blocks world planning fails when insufficient table capacity", () => {
+  const domain = buildDomain(createBlocksWorldDomain());
+  const context = createBlocksWorldContext({ tableCapacity: 0 });
+
+  ensureNoPlan(domain, context);
+});
+
+test.run();

--- a/tests/scenarios/puzzles/bridgeAndTorch.test.ts
+++ b/tests/scenarios/puzzles/bridgeAndTorch.test.ts
@@ -1,0 +1,184 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface Person {
+  name: string;
+  time: number;
+}
+
+type TorchSide = "left" | "right";
+type Strategy = "courier" | "pairSlowest";
+
+interface BridgeWorldState extends WorldStateBase {
+  left: Person[];
+  right: Person[];
+  torchSide: TorchSide;
+  elapsed: number;
+  strategy: Strategy;
+}
+
+type BridgeContext = Context<BridgeWorldState>;
+
+function clonePeople(people: Person[]): Person[] {
+  return people.map((person) => ({ ...person }));
+}
+
+function sortByTime(people: Person[]): Person[] {
+  return [...people].sort((a, b) => a.time - b.time);
+}
+
+function movePeople(
+  context: BridgeContext,
+  names: string[],
+  from: "left" | "right",
+  to: "left" | "right",
+): number {
+  const world = context.WorldState;
+  const source = from === "left" ? world.left : world.right;
+  const destination = to === "left" ? world.left : world.right;
+
+  const travelers: Person[] = [];
+  for (const name of names) {
+    const index = source.findIndex((person) => person.name === name);
+    if (index === -1) {
+      throw new Error(`Unable to find ${name} on ${from} bank`);
+    }
+    const [person] = source.splice(index, 1);
+    travelers.push(person);
+  }
+
+  const duration = Math.max(...travelers.map((person) => person.time));
+  destination.push(...travelers);
+
+  context.setState(from, clonePeople(source), false);
+  context.setState(to, clonePeople(destination), false);
+  context.setState("torchSide", to as TorchSide, false);
+  context.setState("elapsed", context.getState("elapsed") + duration, false);
+
+  return duration;
+}
+
+function createBridgeAndTorchDomain(): DomainBuilder<BridgeContext> {
+  const builder = new DomainBuilder<BridgeContext>("Bridge and torch");
+
+  builder
+    .sequence("Cross bridge")
+      .condition("Torch is on starting bank", (ctx) => ctx.getState("torchSide") === "left")
+      .select("Pick crossing heuristic")
+        .sequence("Courier strategy")
+          .condition("Using courier strategy", (ctx) => ctx.getState("strategy") === "courier")
+          .action("Escort slowest with fastest")
+            .condition("At least two travelers", (ctx) => ctx.getState("left").length >= 2)
+            .do((ctx) => {
+              const sorted = sortByTime(ctx.getState("left"));
+              const fastest = sorted[0];
+              const slowest = sorted[sorted.length - 1];
+              movePeople(ctx, [fastest.name, slowest.name], "left", "right");
+              return TaskStatus.Success;
+            })
+          .end()
+          .action("Return fastest with torch")
+            .do((ctx) => {
+              if (ctx.getState("right").length === 0) {
+                throw new Error("No one available to return with torch");
+              }
+              const fastest = sortByTime(ctx.getState("right"))[0];
+              movePeople(ctx, [fastest.name], "right", "left");
+              return TaskStatus.Success;
+            })
+          .end()
+        .end()
+        .sequence("Pair slowest together")
+          .condition("Using slowest pairing", (ctx) => ctx.getState("strategy") === "pairSlowest")
+          .action("Send two slowest across")
+            .condition("Enough travelers remaining", (ctx) => ctx.getState("left").length >= 2)
+            .do((ctx) => {
+              const sorted = sortByTime(ctx.getState("left"));
+              const slowest = sorted.slice(-2);
+              movePeople(ctx, slowest.map((person) => person.name), "left", "right");
+              return TaskStatus.Success;
+            })
+          .end()
+          .action("Return guide")
+            .do((ctx) => {
+              if (ctx.getState("right").length === 0) {
+                throw new Error("No traveler can return");
+              }
+              const fastest = sortByTime(ctx.getState("right"))[0];
+              movePeople(ctx, [fastest.name], "right", "left");
+              return TaskStatus.Success;
+            })
+          .end()
+        .end()
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createBridgeContext(overrides: Partial<BridgeWorldState> = {}): BridgeContext {
+  return createPuzzleContext<BridgeWorldState>({
+    left: [
+      { name: "Alice", time: 1 },
+      { name: "Ben", time: 2 },
+      { name: "Cara", time: 5 },
+      { name: "Doug", time: 10 },
+    ],
+    right: [],
+    torchSide: "left",
+    elapsed: 0,
+    strategy: "courier",
+    ...overrides,
+  });
+}
+
+test("Bridge and torch follows courier plan and tracks time", () => {
+  const domain = buildDomain(createBridgeAndTorchDomain());
+  const context = createBridgeContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Escort slowest with fastest", "Return fastest with torch"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("left").map((person) => person.name).sort(), ["Alice", "Ben", "Cara"]);
+  assert.equal(context.getState("right").map((person) => person.name), ["Doug"]);
+  assert.is(context.getState("elapsed"), 11);
+  assert.is(context.getState("torchSide"), "left");
+});
+
+test("Bridge and torch pairs slowest travelers when configured", () => {
+  const domain = buildDomain(createBridgeAndTorchDomain());
+  const context = createBridgeContext({ strategy: "pairSlowest" });
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Send two slowest across", "Return guide"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("right").map((person) => person.name), ["Doug"]);
+  assert.equal(context.getState("left").map((person) => person.name).sort(), ["Alice", "Ben", "Cara"]);
+  assert.is(context.getState("elapsed"), 15);
+  assert.is(context.getState("torchSide"), "left");
+});
+
+test("Bridge and torch planning fails without torch on starting bank", () => {
+  const domain = buildDomain(createBridgeAndTorchDomain());
+  const context = createBridgeContext({ torchSide: "right" });
+
+  ensureNoPlan(domain, context);
+});
+
+test.run();

--- a/tests/scenarios/puzzles/bridgeMath.test.ts
+++ b/tests/scenarios/puzzles/bridgeMath.test.ts
@@ -1,0 +1,140 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface BridgeMathState extends WorldStateBase {
+  knowns: Record<string, number>;
+  variables: Record<string, number | null>;
+  steps: string[];
+  sanityCheck: number | null;
+}
+
+type BridgeMathContext = Context<BridgeMathState>;
+
+function appendStep(context: BridgeMathContext, message: string): void {
+  context.setState("steps", [...context.getState("steps"), message], false);
+}
+
+function createBridgeMathDomain(): DomainBuilder<BridgeMathContext> {
+  const builder = new DomainBuilder<BridgeMathContext>("Bridge word problem");
+
+  builder
+    .sequence("Solve bridge span length")
+      .action("Extract givens")
+        .condition("Total length provided", (ctx) => typeof ctx.getState("knowns").totalLength === "number")
+        .condition("Ramp length provided", (ctx) => typeof ctx.getState("knowns").rampLength === "number")
+        .condition("Span count provided", (ctx) => ctx.getState("knowns").spanCount > 0)
+        .do((ctx) => {
+          appendStep(ctx, "Captured givens from problem statement");
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Set up bridge relation")
+        .do((ctx) => {
+          const { totalLength, rampLength, spanCount } = ctx.getState("knowns");
+          const spanTotal = totalLength - rampLength;
+          if (spanTotal <= 0) {
+            throw new Error("Ramp length exceeds total bridge length");
+          }
+          ctx.setState("variables", { ...ctx.getState("variables"), spanTotal }, false);
+          appendStep(ctx, `Isolated span total: ${spanTotal}`);
+          ctx.setState("sanityCheck", spanTotal + rampLength, false);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Solve for individual span")
+        .do((ctx) => {
+          const { spanCount } = ctx.getState("knowns");
+          const { spanTotal } = ctx.getState("variables");
+          if (typeof spanTotal !== "number" || spanCount <= 0) {
+            throw new Error("Invalid span configuration");
+          }
+          const spanLength = spanTotal / spanCount;
+          ctx.setState("variables", { ...ctx.getState("variables"), spanLength }, false);
+          appendStep(ctx, `Computed span length: ${spanLength}`);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Validate solution")
+        .do((ctx) => {
+          const { totalLength } = ctx.getState("knowns");
+          const { spanLength, spanTotal } = ctx.getState("variables");
+          if (typeof spanLength !== "number" || typeof spanTotal !== "number") {
+            throw new Error("Missing calculated values");
+          }
+          const recomputed = spanLength * ctx.getState("knowns").spanCount + ctx.getState("knowns").rampLength;
+          if (Math.abs(recomputed - totalLength) > 1e-6) {
+            throw new Error("Solution does not satisfy original equation");
+          }
+          appendStep(ctx, "Validated result against original equation");
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createBridgeMathContext(overrides: Partial<BridgeMathState> = {}): BridgeMathContext {
+  return createPuzzleContext<BridgeMathState>({
+    knowns: {
+      totalLength: 96,
+      rampLength: 12,
+      spanCount: 3,
+    },
+    variables: {
+      spanTotal: null,
+      spanLength: null,
+    },
+    steps: [],
+    sanityCheck: null,
+    ...overrides,
+  });
+}
+
+test("Bridge word problem derives span length with back substitution", () => {
+  const domain = buildDomain(createBridgeMathDomain());
+  const context = createBridgeMathContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Extract givens",
+    "Set up bridge relation",
+    "Solve for individual span",
+    "Validate solution",
+  ]);
+
+  executePlan(plan, context);
+
+  const variables = context.getState("variables");
+  assert.is(variables.spanTotal, 84);
+  assert.is(variables.spanLength, 28);
+  assert.is(context.getState("sanityCheck"), 84 + 12);
+  assert.ok(context.getState("steps").length >= 3);
+});
+
+test("Bridge word problem planning fails when givens incomplete", () => {
+  const domain = buildDomain(createBridgeMathDomain());
+  const context = createBridgeMathContext({
+    knowns: {
+      totalLength: 96,
+      rampLength: 12,
+      spanCount: 0,
+    },
+  });
+
+  ensureNoPlan(domain, context);
+});
+
+test.run();

--- a/tests/scenarios/puzzles/crosswordFill.test.ts
+++ b/tests/scenarios/puzzles/crosswordFill.test.ts
@@ -1,0 +1,180 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface Slot {
+  id: string;
+  positions: Array<[number, number]>;
+  filled: string | null;
+}
+
+interface CrosswordState extends WorldStateBase {
+  grid: string[][];
+  slots: Slot[];
+  words: string[];
+  placed: Record<string, string>;
+}
+
+type CrosswordContext = Context<CrosswordState>;
+
+function cloneGrid(grid: string[][]): string[][] {
+  return grid.map((row) => [...row]);
+}
+
+function slotPattern(context: CrosswordContext, slot: Slot): string {
+  const letters = slot.positions.map(([row, col]) => context.getState("grid")[row][col]);
+  return letters.join("");
+}
+
+function compatible(word: string, pattern: string): boolean {
+  if (word.length !== pattern.length) {
+    return false;
+  }
+  for (let i = 0; i < word.length; i++) {
+    if (pattern[i] !== "_" && pattern[i] !== word[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function placeWord(context: CrosswordContext, slot: Slot, word: string): void {
+  const grid = cloneGrid(context.getState("grid"));
+  slot.positions.forEach(([row, col], index) => {
+    grid[row][col] = word[index];
+  });
+
+  const slots = context.getState("slots").map((existing) => (
+    existing.id === slot.id ? { ...existing, filled: word } : existing
+  ));
+
+  const remainingWords = context
+    .getState("words")
+    .filter((candidate) => candidate !== word);
+
+  context.setState("grid", grid, false);
+  context.setState("slots", slots, false);
+  context.setState("words", remainingWords, false);
+  context.setState("placed", { ...context.getState("placed"), [slot.id]: word }, false);
+}
+
+function fillLongestSlot(context: CrosswordContext): void {
+  const slots = context.getState("slots");
+  const unfilled = slots.filter((slot) => !slot.filled);
+  if (unfilled.length === 0) {
+    return;
+  }
+
+  const longest = [...unfilled].sort((a, b) => b.positions.length - a.positions.length)[0];
+  const pattern = slotPattern(context, longest);
+  const word = context.getState("words").find((candidate) => compatible(candidate, pattern));
+  if (!word) {
+    throw new Error(`No word fits slot ${longest.id}`);
+  }
+
+  placeWord(context, longest, word);
+}
+
+function fillRemainingSlots(context: CrosswordContext): void {
+  let placed = 0;
+  while (context.getState("slots").some((slot) => !slot.filled)) {
+    const nextSlot = context.getState("slots").find((slot) => !slot.filled);
+    if (!nextSlot) {
+      break;
+    }
+    const pattern = slotPattern(context, nextSlot);
+    const word = context.getState("words").find((candidate) => compatible(candidate, pattern));
+    if (!word) {
+      throw new Error(`Unable to place remaining slot ${nextSlot.id}`);
+    }
+    placeWord(context, nextSlot, word);
+    placed += 1;
+    if (placed > 10) {
+      throw new Error("Exceeded reasonable placement attempts");
+    }
+  }
+}
+
+function createCrosswordDomain(): DomainBuilder<CrosswordContext> {
+  const builder = new DomainBuilder<CrosswordContext>("Crossword fill");
+
+  builder
+    .sequence("Fill crossword grid")
+      .action("Fill longest slot first")
+        .condition("Slots remaining", (ctx) => ctx.getState("slots").some((slot) => !slot.filled))
+        .condition("Words available", (ctx) => ctx.getState("words").length > 0)
+        .do((ctx) => {
+          fillLongestSlot(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Propagate remaining slots")
+        .do((ctx) => {
+          fillRemainingSlots(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createCrosswordContext(overrides: Partial<CrosswordState> = {}): CrosswordContext {
+  return createPuzzleContext<CrosswordState>({
+    grid: [
+      ["_", "_", "_"],
+      ["#", "_", "#"],
+      ["_", "_", "_"],
+    ],
+    slots: [
+      { id: "Across1", positions: [[0, 0], [0, 1], [0, 2]], filled: null },
+      { id: "Down2", positions: [[0, 1], [1, 1], [2, 1]], filled: null },
+      { id: "Across3", positions: [[2, 0], [2, 1], [2, 2]], filled: null },
+    ],
+    words: ["CAR", "ADO", "ROW"],
+    placed: {},
+    ...overrides,
+  });
+}
+
+test("Crossword fill places consistent words respecting crossings", () => {
+  const domain = buildDomain(createCrosswordDomain());
+  const context = createCrosswordContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Fill longest slot first", "Propagate remaining slots"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("grid"), [
+    ["C", "A", "R"],
+    ["#", "D", "#"],
+    ["R", "O", "W"],
+  ]);
+  assert.equal(context.getState("placed"), {
+    Across1: "CAR",
+    Down2: "ADO",
+    Across3: "ROW",
+  });
+});
+
+test("Crossword fill detects incompatible word list", () => {
+  const domain = buildDomain(createCrosswordDomain());
+  const context = createCrosswordContext({ words: ["DOG", "EEL"] });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/helpers.ts
+++ b/tests/scenarios/puzzles/helpers.ts
@@ -1,0 +1,66 @@
+import Context, { type WorldStateBase } from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import DecompositionStatus from "../../../src/decompositionStatus";
+import type Domain from "../../../src/domain";
+import PrimitiveTask from "../../../src/Tasks/primitiveTask";
+import TaskStatus, { type TaskStatusValue } from "../../../src/taskStatus";
+import { ContextState } from "../../../src/contextState";
+
+export type PuzzleWorldState = WorldStateBase;
+
+export function createPuzzleContext<TState extends PuzzleWorldState>(state: TState): Context<TState> {
+  const ctx = new Context(state);
+  ctx.init();
+  return ctx;
+}
+
+export function buildDomain<TContext extends Context<PuzzleWorldState>>(builder: DomainBuilder<TContext>): Domain<TContext> {
+  return builder.build();
+}
+
+export function ensurePlan<TContext extends Context<PuzzleWorldState>>(
+  domain: Domain<TContext>,
+  context: TContext,
+): PrimitiveTask<TContext>[] {
+  const { status, plan } = domain.findPlan(context);
+  if (status !== DecompositionStatus.Succeeded || !plan) {
+    throw new Error(`Expected plan but got status ${status}`);
+  }
+  return plan;
+}
+
+export function ensureNoPlan<TContext extends Context<PuzzleWorldState>>(
+  domain: Domain<TContext>,
+  context: TContext,
+): void {
+  const { status } = domain.findPlan(context);
+  if (status === DecompositionStatus.Succeeded) {
+    throw new Error("Expected planning failure but got success");
+  }
+}
+
+export function planNames<TContext extends Context<PuzzleWorldState>>(plan: PrimitiveTask<TContext>[]): string[] {
+  return plan.map((task) => task.Name);
+}
+
+export function executePlan<TContext extends Context<PuzzleWorldState>>(
+  plan: PrimitiveTask<TContext>[],
+  context: TContext,
+): TaskStatusValue[] {
+  return plan.map((task) => {
+    if (typeof task.operator !== "function") {
+      throw new Error(`Task '${task.Name}' is missing an operator`);
+    }
+
+    const status = task.operator(context);
+    if (status !== TaskStatus.Success) {
+      throw new Error(`Task '${task.Name}' execution failed with status ${status}`);
+    }
+
+    task.applyEffects(context);
+    context.IsDirty = false;
+    context.ContextState = ContextState.Executing;
+
+    return status;
+  });
+}

--- a/tests/scenarios/puzzles/logicGrid.test.ts
+++ b/tests/scenarios/puzzles/logicGrid.test.ts
@@ -1,0 +1,180 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+type PossibilityMap = Record<string, string[]>;
+
+interface LogicGridState extends WorldStateBase {
+  people: string[];
+  pets: string[];
+  possibilities: PossibilityMap;
+  assignments: Record<string, string | null>;
+  appliedClues: string[];
+}
+
+type LogicGridContext = Context<LogicGridState>;
+
+function removeOption(possibilities: PossibilityMap, person: string, pet: string): PossibilityMap {
+  return {
+    ...possibilities,
+    [person]: possibilities[person].filter((option) => option !== pet),
+  };
+}
+
+function ensureSingletons(context: LogicGridContext): void {
+  const world = context.WorldState;
+  const assignments = { ...world.assignments };
+  const possibilities = { ...world.possibilities };
+
+  let progress = true;
+  while (progress) {
+    progress = false;
+    for (const person of world.people) {
+      const options = possibilities[person];
+      if (options.length === 1 && assignments[person] !== options[0]) {
+        assignments[person] = options[0];
+        for (const other of world.people) {
+          if (other !== person && possibilities[other].includes(options[0]!)) {
+            possibilities[other] = possibilities[other].filter((candidate) => candidate !== options[0]);
+            progress = true;
+          }
+        }
+        context.setState(
+          "appliedClues",
+          [...context.getState("appliedClues"), `${person} assigned to ${options[0]}`],
+          false,
+        );
+      }
+    }
+  }
+
+  context.setState("assignments", assignments, false);
+  context.setState("possibilities", possibilities, false);
+}
+
+function applyDirectClues(context: LogicGridContext): void {
+  const world = context.WorldState;
+  const updated = removeOption(world.possibilities, "Ada", "Dog");
+  context.setState("possibilities", updated, false);
+  context.setState("appliedClues", [...world.appliedClues, "Ada does not own the dog"], false);
+}
+
+function resolveExclusiveClue(context: LogicGridContext): void {
+  const world = context.WorldState;
+  const possibilities = { ...world.possibilities };
+
+  const catOwners = world.people.filter((person) => possibilities[person].includes("Cat"));
+  if (catOwners.length === 1) {
+    const owner = catOwners[0]!;
+    possibilities[owner] = ["Cat"];
+    for (const person of world.people) {
+      if (person !== owner) {
+        possibilities[person] = possibilities[person].filter((pet) => pet !== "Cat");
+      }
+    }
+    context.setState("appliedClues", [...world.appliedClues, `Cat assigned to ${owner}`], false);
+  } else if (catOwners.length === 0) {
+    throw new Error("Clue contradiction: cat must have an owner");
+  }
+
+  context.setState("possibilities", possibilities, false);
+  ensureSingletons(context);
+}
+
+function finalizeAssignments(context: LogicGridContext): void {
+  const world = context.WorldState;
+  ensureSingletons(context);
+  const solved = Object.values(context.getState("assignments")).every((value) => value !== null);
+  if (!solved) {
+    throw new Error("Failed to deduce complete assignment");
+  }
+}
+
+function createLogicGridDomain(): DomainBuilder<LogicGridContext> {
+  const builder = new DomainBuilder<LogicGridContext>("Logic grid");
+
+  builder
+    .sequence("Solve pet ownership puzzle")
+      .action("Apply direct clues")
+        .do((ctx) => {
+          applyDirectClues(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Resolve exclusive clue")
+        .do((ctx) => {
+          resolveExclusiveClue(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Finalize assignments")
+        .do((ctx) => {
+          finalizeAssignments(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createLogicGridContext(overrides: Partial<LogicGridState> = {}): LogicGridContext {
+  const people = ["Ada", "Ben"];
+  const pets = ["Cat", "Dog"];
+  return createPuzzleContext<LogicGridState>({
+    people,
+    pets,
+    possibilities: {
+      Ada: [...pets],
+      Ben: [...pets],
+    },
+    assignments: {
+      Ada: null,
+      Ben: null,
+    },
+    appliedClues: [],
+    ...overrides,
+  });
+}
+
+test("Logic grid applies elimination to deduce assignments", () => {
+  const domain = buildDomain(createLogicGridDomain());
+  const context = createLogicGridContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Apply direct clues",
+    "Resolve exclusive clue",
+    "Finalize assignments",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("assignments"), { Ada: "Cat", Ben: "Dog" });
+  assert.ok(context.getState("appliedClues").length >= 1);
+});
+
+test("Logic grid detects contradictory clues", () => {
+  const domain = buildDomain(createLogicGridDomain());
+  const context = createLogicGridContext({
+    possibilities: {
+      Ada: ["Dog"],
+      Ben: ["Dog"],
+    },
+  });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/recipeAssembly.test.ts
+++ b/tests/scenarios/puzzles/recipeAssembly.test.ts
@@ -1,0 +1,123 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface RecipeState extends WorldStateBase {
+  pantry: Record<string, boolean>;
+  prep: Record<string, boolean>;
+  assembled: boolean;
+  plated: boolean;
+  notes: string[];
+}
+
+type RecipeContext = Context<RecipeState>;
+
+function appendNote(context: RecipeContext, message: string): void {
+  context.setState("notes", [...context.getState("notes"), message], false);
+}
+
+function createRecipeDomain(): DomainBuilder<RecipeContext> {
+  const builder = new DomainBuilder<RecipeContext>("Recipe assembly");
+
+  builder
+    .sequence("Prepare sandwich")
+      .action("Prep ingredients")
+        .condition("Bread available", (ctx) => ctx.getState("pantry").bread)
+        .condition("Protein available", (ctx) => ctx.getState("pantry").tempeh)
+        .condition("Veggies washed", (ctx) => ctx.getState("pantry").greens)
+        .do((ctx) => {
+          const prep = { ...ctx.getState("prep"), breadToasted: true, tempehSeared: true, sauceMixed: true };
+          ctx.setState("prep", prep, false);
+          appendNote(ctx, "Toasted bread and seared tempeh");
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Assemble sandwich")
+        .do((ctx) => {
+          const prep = ctx.getState("prep");
+          if (!prep.breadToasted || !prep.tempehSeared || !prep.sauceMixed) {
+            throw new Error("Attempted to assemble without prep");
+          }
+          ctx.setState("assembled", true, false);
+          appendNote(ctx, "Layered components with sauce");
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Plate and finish")
+        .do((ctx) => {
+          if (!ctx.getState("assembled")) {
+            throw new Error("Cannot plate before assembly");
+          }
+          ctx.setState("plated", true, false);
+          appendNote(ctx, "Garnished with greens");
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createRecipeContext(overrides: Partial<RecipeState> = {}): RecipeContext {
+  return createPuzzleContext<RecipeState>({
+    pantry: {
+      bread: true,
+      tempeh: true,
+      greens: true,
+    },
+    prep: {
+      breadToasted: false,
+      tempehSeared: false,
+      sauceMixed: false,
+    },
+    assembled: false,
+    plated: false,
+    notes: [],
+    ...overrides,
+  });
+}
+
+test("Recipe assembly prepares, assembles, and plates sandwich", () => {
+  const domain = buildDomain(createRecipeDomain());
+  const context = createRecipeContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Prep ingredients", "Assemble sandwich", "Plate and finish"]);
+
+  executePlan(plan, context);
+
+  assert.ok(context.getState("prep").breadToasted);
+  assert.ok(context.getState("assembled"));
+  assert.ok(context.getState("plated"));
+  assert.is(context.getState("notes").length, 3);
+});
+
+test("Recipe assembly planning fails without protein", () => {
+  const domain = buildDomain(createRecipeDomain());
+  const context = createRecipeContext({ pantry: { bread: true, tempeh: false, greens: true } });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Recipe assembly refuses to plate unfinished sandwich", () => {
+  const domain = buildDomain(createRecipeDomain());
+  const context = createRecipeContext();
+
+  const plan = ensurePlan(domain, context);
+  const [, assemble] = plan;
+  context.setState("prep", { breadToasted: false, tempehSeared: false, sauceMixed: false }, false);
+  assert.throws(() => assemble.operator?.(context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/riverCrossing.test.ts
+++ b/tests/scenarios/puzzles/riverCrossing.test.ts
@@ -1,0 +1,195 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+type Bank = "left" | "right";
+
+interface RiverState extends WorldStateBase {
+  left: string[];
+  right: string[];
+  boatSide: Bank;
+  history: string[];
+}
+
+type RiverContext = Context<RiverState>;
+
+const FARMER = "Farmer";
+const WOLF = "Wolf";
+const GOAT = "Goat";
+const CABBAGE = "Cabbage";
+
+function isSafe(bank: string[]): boolean {
+  const hasFarmer = bank.includes(FARMER);
+  if (hasFarmer) {
+    return true;
+  }
+  const goatWithWolf = bank.includes(GOAT) && bank.includes(WOLF);
+  const goatWithCabbage = bank.includes(GOAT) && bank.includes(CABBAGE);
+  return !goatWithWolf && !goatWithCabbage;
+}
+
+function validateSafety(state: RiverState): void {
+  if (!isSafe(state.left) || !isSafe(state.right)) {
+    throw new Error("Unsafe pairing detected");
+  }
+}
+
+function movePassengers(context: RiverContext, passengers: string[]): void {
+  const fromBank = context.getState("boatSide");
+  const toBank: Bank = fromBank === "left" ? "right" : "left";
+  const fromList = fromBank === "left" ? context.getState("left") : context.getState("right");
+  const toList = toBank === "left" ? context.getState("left") : context.getState("right");
+
+  if (!passengers.includes(FARMER)) {
+    throw new Error("Boat must include the farmer");
+  }
+
+  const missingPassenger = passengers.find((occupant) => !fromList.includes(occupant));
+  if (missingPassenger) {
+    throw new Error(`${missingPassenger} is not on the ${fromBank} bank`);
+  }
+
+  const updatedFrom = fromList.filter((occupant) => !passengers.includes(occupant));
+  const updatedTo = [...toList, ...passengers];
+
+  const nextState: RiverState = {
+    ...context.WorldState,
+    left: fromBank === "left" ? updatedFrom : updatedTo,
+    right: fromBank === "right" ? updatedFrom : updatedTo,
+    boatSide: toBank,
+  };
+
+  validateSafety(nextState);
+
+  context.setState("left", nextState.left, false);
+  context.setState("right", nextState.right, false);
+  context.setState("boatSide", nextState.boatSide, false);
+  context.setState("history", [...context.getState("history"), `${passengers.join(" & ")} -> ${toBank}`], false);
+}
+
+function createRiverDomain(): DomainBuilder<RiverContext> {
+  const builder = new DomainBuilder<RiverContext>("River crossing");
+
+  builder
+    .sequence("Solve crossing")
+      .action("Take goat across")
+        .condition("Boat on left", (ctx) => ctx.getState("boatSide") === "left")
+        .condition("Goat present", (ctx) => ctx.getState("left").includes(GOAT))
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER, GOAT]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Return farmer alone")
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Take wolf across")
+        .condition("Wolf present", (ctx) => ctx.getState("left").includes(WOLF))
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER, WOLF]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Return goat")
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER, GOAT]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Take cabbage across")
+        .condition("Cabbage present", (ctx) => ctx.getState("left").includes(CABBAGE))
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER, CABBAGE]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Return farmer again")
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER]);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Take goat final time")
+        .condition("Goat waiting", (ctx) => ctx.getState("left").includes(GOAT))
+        .do((ctx) => {
+          movePassengers(ctx, [FARMER, GOAT]);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createRiverContext(overrides: Partial<RiverState> = {}): RiverContext {
+  return createPuzzleContext<RiverState>({
+    left: [FARMER, WOLF, GOAT, CABBAGE],
+    right: [],
+    boatSide: "left",
+    history: [],
+    ...overrides,
+  });
+}
+
+function everyoneOnRight(state: RiverState): boolean {
+  return [FARMER, WOLF, GOAT, CABBAGE].every((actor) => state.right.includes(actor));
+}
+
+test("River crossing executes canonical solution safely", () => {
+  const domain = buildDomain(createRiverDomain());
+  const context = createRiverContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Take goat across",
+    "Return farmer alone",
+    "Take wolf across",
+    "Return goat",
+    "Take cabbage across",
+    "Return farmer again",
+    "Take goat final time",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.ok(everyoneOnRight(context.WorldState));
+  assert.is(context.getState("history").length, 7);
+});
+
+test("River crossing planning fails if goat missing", () => {
+  const domain = buildDomain(createRiverDomain());
+  const context = createRiverContext({ left: [FARMER, WOLF, CABBAGE] });
+
+  ensureNoPlan(domain, context);
+});
+
+test("River crossing aborts when unsafe pairing would occur", () => {
+  const domain = buildDomain(createRiverDomain());
+  const context = createRiverContext();
+
+  const plan = ensurePlan(domain, context);
+  const [takeGoat] = plan;
+  if (!takeGoat.operator) {
+    throw new Error("Expected primitive operator");
+  }
+  context.setState("left", [FARMER, WOLF, CABBAGE], false);
+  context.setState("right", [GOAT], false);
+  const operator = takeGoat.operator;
+  assert.throws(() => operator(context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/rubiksCube.test.ts
+++ b/tests/scenarios/puzzles/rubiksCube.test.ts
@@ -1,0 +1,132 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface RubikState extends WorldStateBase {
+  stages: Record<string, boolean>;
+  turnLog: string[];
+  parity: "even" | "odd";
+}
+
+type RubikContext = Context<RubikState>;
+
+function appendTurn(context: RubikContext, algorithm: string): void {
+  context.setState("turnLog", [...context.getState("turnLog"), algorithm], false);
+}
+
+function createRubikDomain(): DomainBuilder<RubikContext> {
+  const builder = new DomainBuilder<RubikContext>("Rubik CFOP");
+
+  builder
+    .sequence("Solve cube with CFOP")
+      .action("Build cross")
+        .condition("Cross unsolved", (ctx) => !ctx.getState("stages").cross)
+        .do((ctx) => {
+          ctx.setState("stages", { ...ctx.getState("stages"), cross: true }, false);
+          appendTurn(ctx, "F R U R' U' F'");
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Complete F2L")
+        .do((ctx) => {
+          if (!ctx.getState("stages").cross) {
+            throw new Error("Cannot solve F2L before cross");
+          }
+          if (!ctx.getState("stages").f2l) {
+            ctx.setState("stages", { ...ctx.getState("stages"), f2l: true }, false);
+            appendTurn(ctx, "(U R U' R') (U' F' U F)");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Orient last layer")
+        .do((ctx) => {
+          if (!ctx.getState("stages").f2l) {
+            throw new Error("Cannot run OLL before finishing F2L");
+          }
+          if (ctx.getState("parity") === "odd") {
+            throw new Error("Cannot orient odd-parity cube without setup");
+          }
+          if (!ctx.getState("stages").oll) {
+            ctx.setState("stages", { ...ctx.getState("stages"), oll: true }, false);
+            appendTurn(ctx, "R U2 R' U' R U' R'");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Permute last layer")
+        .do((ctx) => {
+          if (!ctx.getState("stages").oll) {
+            throw new Error("Cannot run PLL before OLL");
+          }
+          if (!ctx.getState("stages").pll) {
+            ctx.setState("stages", { ...ctx.getState("stages"), pll: true }, false);
+            appendTurn(ctx, "(R' U R' U') R' U R D' R' U' R D");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createRubikContext(overrides: Partial<RubikState> = {}): RubikContext {
+  return createPuzzleContext<RubikState>({
+    stages: {
+      cross: false,
+      f2l: false,
+      oll: false,
+      pll: false,
+    },
+    turnLog: [],
+    parity: "even",
+    ...overrides,
+  });
+}
+
+test("Rubik CFOP plan solves each stage in order", () => {
+  const domain = buildDomain(createRubikDomain());
+  const context = createRubikContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Build cross",
+    "Complete F2L",
+    "Orient last layer",
+    "Permute last layer",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("stages"), { cross: true, f2l: true, oll: true, pll: true });
+  assert.is(context.getState("turnLog").length, 4);
+});
+
+test("Rubik CFOP refuses to run OLL on odd parity state", () => {
+  const domain = buildDomain(createRubikDomain());
+  const context = createRubikContext({ parity: "odd" });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test("Rubik CFOP planning fails if cross already solved without log", () => {
+  const domain = buildDomain(createRubikDomain());
+  const context = createRubikContext({ stages: { cross: true, f2l: false, oll: false, pll: false } });
+
+  ensureNoPlan(domain, context);
+});
+
+test.run();

--- a/tests/scenarios/puzzles/scheduling.test.ts
+++ b/tests/scenarios/puzzles/scheduling.test.ts
@@ -1,0 +1,189 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface TaskSlot {
+  name: string;
+  duration: number;
+  prerequisites: string[];
+}
+
+interface ScheduleState extends WorldStateBase {
+  tasks: TaskSlot[];
+  assignments: Record<string, number | null>;
+  dayLength: number;
+  reservedSlots: number[];
+}
+
+type ScheduleContext = Context<ScheduleState>;
+
+function findAvailableSlot(state: ScheduleState, duration: number, startAt = 0): number | null {
+  for (let slot = startAt; slot <= state.dayLength - duration; slot++) {
+    const occupied = state.reservedSlots.some((time) => time >= slot && time < slot + duration);
+    if (!occupied) {
+      return slot;
+    }
+  }
+  return null;
+}
+
+function reserveSlots(context: ScheduleContext, start: number, duration: number): void {
+  const reservations = [...context.getState("reservedSlots")];
+  for (let offset = 0; offset < duration; offset++) {
+    reservations.push(start + offset);
+  }
+  context.setState("reservedSlots", reservations, false);
+}
+
+function scheduleIndependentTasks(context: ScheduleContext): void {
+  const world = context.WorldState;
+  const assignments = { ...world.assignments };
+  for (const task of world.tasks.filter((entry) => entry.prerequisites.length === 0)) {
+    if (assignments[task.name] !== null) {
+      continue;
+    }
+    const slot = findAvailableSlot(world, task.duration, 0);
+    if (slot === null) {
+      throw new Error(`Unable to schedule ${task.name}`);
+    }
+    assignments[task.name] = slot;
+    reserveSlots(context, slot, task.duration);
+  }
+  context.setState("assignments", assignments, false);
+}
+
+function scheduleDependentTasks(context: ScheduleContext): void {
+  const world = context.WorldState;
+  const assignments = { ...world.assignments };
+
+  for (const task of world.tasks.filter((entry) => entry.prerequisites.length > 0)) {
+    const prerequisiteTimes = task.prerequisites.map((name) => assignments[name]);
+    if (prerequisiteTimes.some((time) => time === null)) {
+      throw new Error(`Prerequisites for ${task.name} incomplete`);
+    }
+    const earliestStart = Math.max(...(prerequisiteTimes as number[])) + 1;
+    const slot = findAvailableSlot(context.WorldState, task.duration, earliestStart);
+    if (slot === null) {
+      throw new Error(`Unable to schedule dependent task ${task.name}`);
+    }
+    assignments[task.name] = slot;
+    reserveSlots(context, slot, task.duration);
+  }
+
+  context.setState("assignments", assignments, false);
+}
+
+function validateSchedule(context: ScheduleContext): void {
+  const world = context.WorldState;
+  for (const task of world.tasks) {
+    const start = world.assignments[task.name];
+    if (start === null) {
+      throw new Error(`Task ${task.name} was not scheduled`);
+    }
+    for (const prereq of task.prerequisites) {
+      const prereqStart = world.assignments[prereq];
+      if (prereqStart === null || prereqStart + 1 > start) {
+        throw new Error(`Task ${task.name} violates prerequisite ${prereq}`);
+      }
+    }
+  }
+}
+
+function createScheduleDomain(): DomainBuilder<ScheduleContext> {
+  const builder = new DomainBuilder<ScheduleContext>("Mini schedule");
+
+  builder
+    .sequence("Build exam schedule")
+      .action("Schedule independent tasks")
+        .do((ctx) => {
+          scheduleIndependentTasks(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Schedule dependent tasks")
+        .do((ctx) => {
+          scheduleDependentTasks(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Validate ordering")
+        .do((ctx) => {
+          validateSchedule(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createScheduleContext(overrides: Partial<ScheduleState> = {}): ScheduleContext {
+  const tasks: TaskSlot[] = [
+    { name: "Study", duration: 1, prerequisites: [] },
+    { name: "GroupReview", duration: 1, prerequisites: ["Study"] },
+    { name: "Exam", duration: 1, prerequisites: ["GroupReview"] },
+  ];
+
+  return createPuzzleContext<ScheduleState>({
+    tasks,
+    assignments: {
+      Study: null,
+      GroupReview: null,
+      Exam: null,
+    },
+    dayLength: 5,
+    reservedSlots: [],
+    ...overrides,
+  });
+}
+
+test("Scheduling pipeline assigns tasks respecting prerequisites", () => {
+  const domain = buildDomain(createScheduleDomain());
+  const context = createScheduleContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Schedule independent tasks",
+    "Schedule dependent tasks",
+    "Validate ordering",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.ok(context.getState("assignments").Study !== null);
+  assert.ok(context.getState("assignments").GroupReview! > context.getState("assignments").Study!);
+  assert.ok(context.getState("assignments").Exam! > context.getState("assignments").GroupReview!);
+});
+
+test("Scheduling planning fails when day too short", () => {
+  const domain = buildDomain(createScheduleDomain());
+  const context = createScheduleContext({ dayLength: 2 });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test("Scheduling execution detects prerequisite violation", () => {
+  const domain = buildDomain(createScheduleDomain());
+  const context = createScheduleContext();
+
+  const plan = ensurePlan(domain, context);
+  const [scheduleIndependents, scheduleDependents, validate] = plan;
+  scheduleIndependents.operator?.(context);
+  scheduleDependents.operator?.(context);
+  context.setState("assignments", { ...context.getState("assignments"), Exam: 1 }, false);
+  assert.throws(() => validate.operator?.(context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/sokoban.test.ts
+++ b/tests/scenarios/puzzles/sokoban.test.ts
@@ -1,0 +1,128 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface SokobanState extends WorldStateBase {
+  player: Point;
+  box: Point;
+  target: Point;
+  walls: Point[];
+  history: string[];
+}
+
+type SokobanContext = Context<SokobanState>;
+
+function equalPoint(a: Point, b: Point): boolean {
+  return a.x === b.x && a.y === b.y;
+}
+
+function movePlayer(context: SokobanContext, destination: Point): void {
+  context.setState("player", destination, false);
+  context.setState("history", [...context.getState("history"), `Move to (${destination.x}, ${destination.y})`], false);
+}
+
+function pushBox(context: SokobanContext, delta: Point): void {
+  const box = context.getState("box");
+  const player = context.getState("player");
+  const required = { x: box.x - delta.x, y: box.y - delta.y };
+  if (!equalPoint(player, required)) {
+    throw new Error("Player not positioned to push the box");
+  }
+  const target = { x: box.x + delta.x, y: box.y + delta.y };
+  if (context.getState("walls").some((wall) => equalPoint(wall, target))) {
+    throw new Error("Attempted to push box into a wall");
+  }
+  context.setState("box", target, false);
+  context.setState("player", { x: box.x, y: box.y }, false);
+  context.setState("history", [...context.getState("history"), `Push box to (${target.x}, ${target.y})`], false);
+}
+
+function createSokobanDomain(): DomainBuilder<SokobanContext> {
+  const builder = new DomainBuilder<SokobanContext>("Sokoban");
+
+  builder
+    .sequence("Solve single-box puzzle")
+      .action("Route behind box")
+        .condition("Player not yet positioned", (ctx) => !equalPoint(ctx.getState("player"), { x: 0, y: 1 }))
+        .do((ctx) => {
+          movePlayer(ctx, { x: 0, y: 1 });
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Push box to target")
+        .condition("Target not blocked", (ctx) => !ctx.getState("walls").some((wall) => equalPoint(wall, ctx.getState("target"))))
+        .do((ctx) => {
+          pushBox(ctx, { x: 1, y: 0 });
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Verify solved")
+        .do((ctx) => {
+          if (!equalPoint(ctx.getState("box"), ctx.getState("target"))) {
+            throw new Error("Box not on target");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createSokobanContext(overrides: Partial<SokobanState> = {}): SokobanContext {
+  return createPuzzleContext<SokobanState>({
+    player: { x: 0, y: 0 },
+    box: { x: 1, y: 1 },
+    target: { x: 2, y: 1 },
+    walls: [{ x: 3, y: 1 }],
+    history: [],
+    ...overrides,
+  });
+}
+
+test("Sokoban solver routes player and pushes box to target", () => {
+  const domain = buildDomain(createSokobanDomain());
+  const context = createSokobanContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Route behind box", "Push box to target", "Verify solved"]);
+
+  executePlan(plan, context);
+
+  assert.ok(equalPoint(context.getState("box"), context.getState("target")));
+  assert.is(context.getState("history").length, 2);
+});
+
+test("Sokoban planning fails when walls block target", () => {
+  const domain = buildDomain(createSokobanDomain());
+  const context = createSokobanContext({ walls: [{ x: 2, y: 1 }] });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Sokoban execution catches illegal pushes", () => {
+  const domain = buildDomain(createSokobanDomain());
+  const context = createSokobanContext();
+
+  const plan = ensurePlan(domain, context);
+  context.setState("walls", [...context.getState("walls"), context.getState("target")], false);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/sudoku.test.ts
+++ b/tests/scenarios/puzzles/sudoku.test.ts
@@ -1,0 +1,217 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+type Grid = number[][];
+
+interface SudokuState extends WorldStateBase {
+  grid: Grid;
+  size: number;
+  boxSize: number;
+}
+
+type SudokuContext = Context<SudokuState>;
+
+function cloneGrid(grid: Grid): Grid {
+  return grid.map((row) => [...row]);
+}
+
+function candidatesForCell(state: SudokuState, row: number, col: number): number[] {
+  if (state.grid[row][col] !== 0) {
+    return [];
+  }
+
+  const possible = new Set<number>(Array.from({ length: state.size }, (_, index) => index + 1));
+
+  for (let i = 0; i < state.size; i++) {
+    possible.delete(state.grid[row][i]);
+    possible.delete(state.grid[i][col]);
+  }
+
+  const boxRow = Math.floor(row / state.boxSize) * state.boxSize;
+  const boxCol = Math.floor(col / state.boxSize) * state.boxSize;
+  for (let r = 0; r < state.boxSize; r++) {
+    for (let c = 0; c < state.boxSize; c++) {
+      possible.delete(state.grid[boxRow + r][boxCol + c]);
+    }
+  }
+
+  return Array.from(possible);
+}
+
+function applySingletons(context: SudokuContext): boolean {
+  const state = context.WorldState;
+  const grid = cloneGrid(state.grid);
+  let progress = false;
+
+  for (let row = 0; row < state.size; row++) {
+    for (let col = 0; col < state.size; col++) {
+      if (grid[row][col] !== 0) {
+        continue;
+      }
+      const options = candidatesForCell(state, row, col);
+      if (options.length === 0) {
+        throw new Error(`Cell (${row},${col}) has no valid candidates`);
+      }
+      if (options.length === 1) {
+        grid[row][col] = options[0]!;
+        progress = true;
+      }
+    }
+  }
+
+  if (progress) {
+    context.setState("grid", grid, false);
+  }
+
+  return progress;
+}
+
+function applyHiddenSingles(context: SudokuContext): boolean {
+  const state = context.WorldState;
+  const grid = cloneGrid(state.grid);
+  let progress = false;
+
+  for (let row = 0; row < state.size; row++) {
+    const counts: Record<number, number> = {};
+    const positions: Record<number, [number, number]> = {};
+    for (let col = 0; col < state.size; col++) {
+      if (grid[row][col] !== 0) {
+        continue;
+      }
+      for (const candidate of candidatesForCell(state, row, col)) {
+        counts[candidate] = (counts[candidate] ?? 0) + 1;
+        positions[candidate] = [row, col];
+      }
+    }
+    for (const [value, count] of Object.entries(counts)) {
+      if (count === 1) {
+        const [r, c] = positions[Number(value)]!;
+        grid[r][c] = Number(value);
+        progress = true;
+      }
+    }
+  }
+
+  if (progress) {
+    context.setState("grid", grid, false);
+  }
+
+  return progress;
+}
+
+function isSolved(grid: Grid): boolean {
+  return grid.every((row) => row.every((value) => value !== 0));
+}
+
+function createSudokuDomain(): DomainBuilder<SudokuContext> {
+  const builder = new DomainBuilder<SudokuContext>("Sudoku tactics");
+
+  builder
+    .sequence("Solve 4x4 sudoku")
+      .condition("Puzzle incomplete", (ctx) => !isSolved(ctx.getState("grid")))
+      .action("Apply naked singles")
+        .do((ctx) => {
+          while (applySingletons(ctx)) {
+            // keep applying until no progress
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Apply hidden singles")
+        .do((ctx) => {
+          let progress = true;
+          while (progress) {
+            progress = applyHiddenSingles(ctx);
+            if (applySingletons(ctx)) {
+              progress = true;
+            }
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Validate completed grid")
+        .do((ctx) => {
+          if (!isSolved(ctx.getState("grid"))) {
+            throw new Error("Puzzle not solved after tactics");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createSudokuContext(overrides: Partial<SudokuState> = {}): SudokuContext {
+  return createPuzzleContext<SudokuState>({
+    grid: [
+      [0, 0, 2, 0],
+      [0, 3, 0, 1],
+      [1, 0, 0, 0],
+      [0, 4, 0, 2],
+    ],
+    size: 4,
+    boxSize: 2,
+    ...overrides,
+  });
+}
+
+test("Sudoku tactics solve a simple 4x4 puzzle", () => {
+  const domain = buildDomain(createSudokuDomain());
+  const context = createSudokuContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Apply naked singles", "Apply hidden singles", "Validate completed grid"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("grid"), [
+    [4, 1, 2, 3],
+    [2, 3, 4, 1],
+    [1, 2, 3, 4],
+    [3, 4, 1, 2],
+  ]);
+});
+
+test("Sudoku planning fails when puzzle already solved", () => {
+  const domain = buildDomain(createSudokuDomain());
+  const context = createSudokuContext({
+    grid: [
+      [4, 1, 2, 3],
+      [2, 3, 4, 1],
+      [1, 2, 3, 4],
+      [3, 4, 1, 2],
+    ],
+  });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Sudoku execution catches inconsistent puzzle", () => {
+  const domain = buildDomain(createSudokuDomain());
+  const context = createSudokuContext({
+    grid: [
+      [1, 2, 0, 3],
+      [3, 4, 1, 2],
+      [2, 1, 4, 0],
+      [4, 3, 2, 1],
+    ],
+  });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/towerOfHanoi.test.ts
+++ b/tests/scenarios/puzzles/towerOfHanoi.test.ts
@@ -1,0 +1,175 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+type Peg = "A" | "B" | "C";
+
+interface TowerWorldState extends WorldStateBase {
+  pegs: Record<Peg, number[]>;
+  moveLog: Array<{ from: Peg; to: Peg; disk: number }>;
+}
+
+type TowerContext = Context<TowerWorldState>;
+
+function clonePegState(state: TowerWorldState): TowerWorldState["pegs"] {
+  return {
+    A: [...state.pegs.A],
+    B: [...state.pegs.B],
+    C: [...state.pegs.C],
+  };
+}
+
+function moveDisk(
+  context: TowerContext,
+  from: Peg,
+  to: Peg,
+): void {
+  const { pegs, moveLog } = context.WorldState;
+  const source = pegs[from];
+  if (source.length === 0) {
+    throw new Error(`No disk available on peg ${from}`);
+  }
+
+  const disk = source[source.length - 1];
+  const destination = pegs[to];
+  const destinationTop = destination[destination.length - 1] ?? Infinity;
+
+  if (disk > destinationTop) {
+    throw new Error(`Illegal move: cannot place disk ${disk} on top of ${destinationTop}`);
+  }
+
+  source.pop();
+  destination.push(disk);
+
+  context.setState("pegs", clonePegState(context.WorldState), false);
+  context.setState("moveLog", [...moveLog, { from, to, disk }], false);
+}
+
+function moveStack(
+  context: TowerContext,
+  n: number,
+  from: Peg,
+  to: Peg,
+  via: Peg,
+): void {
+  if (n <= 0) {
+    return;
+  }
+
+  if (n === 1) {
+    moveDisk(context, from, to);
+    return;
+  }
+
+  moveStack(context, n - 1, from, via, to);
+  moveDisk(context, from, to);
+  moveStack(context, n - 1, via, to, from);
+}
+
+function createTowerOfHanoiDomain(): Domain<TowerContext> {
+  const builder = new DomainBuilder<TowerContext>("Tower of Hanoi");
+
+  builder
+    .sequence("Solve tower")
+      .select("Choose approach")
+        .sequence("Single disk move")
+          .condition("Exactly one disk", (ctx) => ctx.getState("pegs").A.length === 1)
+          .action("Move single disk")
+            .do((ctx) => {
+              moveDisk(ctx, "A", "C");
+              return TaskStatus.Success;
+            })
+          .end()
+        .end()
+        .sequence("Recursive solution")
+          .condition("Multiple disks", (ctx) => ctx.getState("pegs").A.length > 1)
+          .condition("Auxiliary clear", (ctx) => ctx.getState("pegs").B.length === 0)
+          .action("Move top stack to auxiliary")
+            .do((ctx) => {
+              const count = ctx.getState("pegs").A.length - 1;
+              moveStack(ctx, count, "A", "B", "C");
+              return TaskStatus.Success;
+            })
+          .end()
+          .action("Move base disk to target")
+            .do((ctx) => {
+              moveDisk(ctx, "A", "C");
+              return TaskStatus.Success;
+            })
+          .end()
+          .action("Move stack from auxiliary")
+            .do((ctx) => {
+              const count = ctx.getState("pegs").B.length;
+              moveStack(ctx, count, "B", "C", "A");
+              return TaskStatus.Success;
+            })
+          .end()
+        .end()
+      .end()
+    .end();
+
+  return buildDomain(builder);
+}
+
+function createTowerContext(pegs: Record<Peg, number[]>): TowerContext {
+  return createPuzzleContext<TowerWorldState>({
+    pegs,
+    moveLog: [],
+  });
+}
+
+function goalStack(count: number): number[] {
+  return Array.from({ length: count }, (_, index) => count - index);
+}
+
+test("Tower of Hanoi moves a single disk to the target peg", () => {
+  const domain = createTowerOfHanoiDomain();
+  const context = createTowerContext({ A: [1], B: [], C: [] });
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Move single disk"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("pegs"), { A: [], B: [], C: [1] });
+  assert.equal(context.getState("moveLog"), [{ from: "A", to: "C", disk: 1 }]);
+});
+
+test("Tower of Hanoi performs recursive transfer for a three-disk stack", () => {
+  const domain = createTowerOfHanoiDomain();
+  const context = createTowerContext({ A: [3, 2, 1], B: [], C: [] });
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), [
+    "Move top stack to auxiliary",
+    "Move base disk to target",
+    "Move stack from auxiliary",
+  ]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("pegs"), { A: [], B: [], C: goalStack(3) });
+  assert.is(context.getState("moveLog").length, 7);
+  assert.equal(context.getState("moveLog")[0], { from: "A", to: "C", disk: 1 });
+  assert.equal(context.getState("moveLog")[6], { from: "A", to: "C", disk: 1 });
+});
+
+test("Tower of Hanoi rejects plan when auxiliary peg occupied", () => {
+  const domain = createTowerOfHanoiDomain();
+  const context = createTowerContext({ A: [3, 2, 1], B: [4], C: [] });
+
+  ensureNoPlan(domain, context);
+});
+
+test.run();

--- a/tests/scenarios/puzzles/treasureHunt.test.ts
+++ b/tests/scenarios/puzzles/treasureHunt.test.ts
@@ -1,0 +1,116 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface TreasureState extends WorldStateBase {
+  location: string;
+  keys: string[];
+  unlocked: string[];
+  treasureCollected: boolean;
+  route: string[];
+}
+
+type TreasureContext = Context<TreasureState>;
+
+const FOREST_KEY = "ForestKey";
+const GATE = "AncientGate";
+const VAULT = "TreasureVault";
+
+function moveTo(context: TreasureContext, location: string): void {
+  context.setState("location", location, false);
+  context.setState("route", [...context.getState("route"), location], false);
+}
+
+function createTreasureDomain(): DomainBuilder<TreasureContext> {
+  const builder = new DomainBuilder<TreasureContext>("Treasure hunt");
+
+  builder
+    .sequence("Recover vault treasure")
+      .action("Retrieve forest key")
+        .condition("Starting in village", (ctx) => ctx.getState("location") === "Village")
+        .do((ctx) => {
+          moveTo(ctx, "Forest");
+          ctx.setState("keys", [...ctx.getState("keys"), FOREST_KEY], false);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Unlock gate")
+        .do((ctx) => {
+          if (!ctx.getState("keys").includes(FOREST_KEY)) {
+            throw new Error("Missing required key");
+          }
+          moveTo(ctx, GATE);
+          ctx.setState("unlocked", [...ctx.getState("unlocked"), GATE], false);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Collect treasure")
+        .do((ctx) => {
+          if (!ctx.getState("unlocked").includes(GATE)) {
+            throw new Error("Gate remains locked");
+          }
+          moveTo(ctx, VAULT);
+          ctx.setState("treasureCollected", true, false);
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createTreasureContext(overrides: Partial<TreasureState> = {}): TreasureContext {
+  return createPuzzleContext<TreasureState>({
+    location: "Village",
+    keys: [],
+    unlocked: [],
+    treasureCollected: false,
+    route: ["Village"],
+    ...overrides,
+  });
+}
+
+test("Treasure hunt navigates key-door sequence", () => {
+  const domain = buildDomain(createTreasureDomain());
+  const context = createTreasureContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Retrieve forest key", "Unlock gate", "Collect treasure"]);
+
+  executePlan(plan, context);
+
+  assert.ok(context.getState("treasureCollected"));
+  assert.equal(context.getState("route"), ["Village", "Forest", GATE, VAULT]);
+});
+
+test("Treasure hunt planning fails when starting away from key", () => {
+  const domain = buildDomain(createTreasureDomain());
+  const context = createTreasureContext({ location: "Cave", route: ["Cave"] });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Treasure hunt execution detects locked vault", () => {
+  const domain = buildDomain(createTreasureDomain());
+  const context = createTreasureContext();
+
+  const plan = ensurePlan(domain, context);
+  const [retrieveKey, unlockGate, collectTreasure] = plan;
+  retrieveKey.operator?.(context);
+  unlockGate.operator?.(context);
+  context.setState("unlocked", [], false);
+  assert.throws(() => collectTreasure.operator?.(context));
+});
+
+test.run();

--- a/tests/scenarios/puzzles/waterJug.test.ts
+++ b/tests/scenarios/puzzles/waterJug.test.ts
@@ -1,0 +1,150 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface Jug {
+  capacity: number;
+  amount: number;
+}
+
+interface JugState extends WorldStateBase {
+  jugs: Record<string, Jug>;
+  target: number;
+  history: string[];
+}
+
+type JugContext = Context<JugState>;
+
+function fillJug(jug: Jug): Jug {
+  return { ...jug, amount: jug.capacity };
+}
+
+function emptyJug(jug: Jug): Jug {
+  return { ...jug, amount: 0 };
+}
+
+function pour(source: Jug, dest: Jug): { source: Jug; dest: Jug } {
+  const availableSpace = dest.capacity - dest.amount;
+  const transfer = Math.min(source.amount, availableSpace);
+  return {
+    source: { ...source, amount: source.amount - transfer },
+    dest: { ...dest, amount: dest.amount + transfer },
+  };
+}
+
+function runJugAlgorithm(context: JugContext): void {
+  let { A, B } = context.getState("jugs");
+  const history = [...context.getState("history")];
+  const target = context.getState("target");
+
+  let iterations = 0;
+  while (A.amount !== target && B.amount !== target) {
+    if (A.amount === 0) {
+      A = fillJug(A);
+      history.push("Fill jug A");
+    } else if (B.amount === B.capacity) {
+      B = emptyJug(B);
+      history.push("Empty jug B");
+    } else {
+      const poured = pour(A, B);
+      A = poured.source;
+      B = poured.dest;
+      history.push(`Pour A->B (A=${A.amount}, B=${B.amount})`);
+    }
+
+    iterations += 1;
+    if (iterations > 30) {
+      throw new Error("Exceeded pour iterations");
+    }
+  }
+
+  context.setState("jugs", { A, B }, false);
+  context.setState("history", history, false);
+}
+
+function createWaterJugDomain(): DomainBuilder<JugContext> {
+  const builder = new DomainBuilder<JugContext>("Water jug");
+
+  builder
+    .sequence("Reach target volume")
+      .action("Execute pour sequence")
+        .condition("Target unmet", (ctx) => {
+          const { A, B } = ctx.getState("jugs");
+          return A.amount !== ctx.getState("target") && B.amount !== ctx.getState("target");
+        })
+        .do((ctx) => {
+          runJugAlgorithm(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Confirm measurement")
+        .do((ctx) => {
+          const { A, B } = ctx.getState("jugs");
+          if (A.amount !== ctx.getState("target") && B.amount !== ctx.getState("target")) {
+            throw new Error("Target volume not reached");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createWaterJugContext(overrides: Partial<JugState> = {}): JugContext {
+  return createPuzzleContext<JugState>({
+    jugs: {
+      A: { capacity: 3, amount: 0 },
+      B: { capacity: 5, amount: 0 },
+    },
+    target: 4,
+    history: [],
+    ...overrides,
+  });
+}
+
+test("Water jug sequence measures the target volume", () => {
+  const domain = buildDomain(createWaterJugDomain());
+  const context = createWaterJugContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Execute pour sequence", "Confirm measurement"]);
+
+  executePlan(plan, context);
+
+  const { A, B } = context.getState("jugs");
+  assert.ok(A.amount === 4 || B.amount === 4);
+  assert.ok(context.getState("history").length > 0);
+});
+
+test("Water jug planning fails when target already present", () => {
+  const domain = buildDomain(createWaterJugDomain());
+  const context = createWaterJugContext({ jugs: { A: { capacity: 3, amount: 0 }, B: { capacity: 5, amount: 4 } } });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Water jug execution detects impossible target", () => {
+  const domain = buildDomain(createWaterJugDomain());
+  const context = createWaterJugContext({
+    jugs: { A: { capacity: 2, amount: 0 }, B: { capacity: 4, amount: 0 } },
+    target: 3,
+  });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();
+

--- a/tests/scenarios/puzzles/wordLadder.test.ts
+++ b/tests/scenarios/puzzles/wordLadder.test.ts
@@ -1,0 +1,135 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import type Context from "../../../src/context";
+import DomainBuilder from "../../../src/domainBuilder";
+import TaskStatus from "../../../src/taskStatus";
+import type { WorldStateBase } from "../../../src/context";
+import {
+  buildDomain,
+  createPuzzleContext,
+  ensureNoPlan,
+  ensurePlan,
+  executePlan,
+  planNames,
+} from "./helpers";
+
+interface LadderState extends WorldStateBase {
+  start: string;
+  target: string;
+  dictionary: string[];
+  path: string[];
+}
+
+type LadderContext = Context<LadderState>;
+
+function neighbors(word: string, dictionary: Set<string>): string[] {
+  const results: string[] = [];
+  const letters = "abcdefghijklmnopqrstuvwxyz";
+  for (let i = 0; i < word.length; i++) {
+    for (const char of letters) {
+      if (char === word[i]) {
+        continue;
+      }
+      const candidate = `${word.slice(0, i)}${char}${word.slice(i + 1)}`;
+      if (dictionary.has(candidate)) {
+        results.push(candidate);
+      }
+    }
+  }
+  return results;
+}
+
+function buildLadder(context: LadderContext): void {
+  const { start, target, dictionary } = context.WorldState;
+  const dict = new Set(dictionary);
+  if (!dict.has(target)) {
+    dict.add(target);
+  }
+
+  const queue: Array<{ word: string; path: string[] }> = [{ word: start, path: [start] }];
+  const visited = new Set<string>([start]);
+
+  while (queue.length > 0) {
+    const { word, path } = queue.shift()!;
+    if (word === target) {
+      context.setState("path", path, false);
+      return;
+    }
+
+    for (const next of neighbors(word, dict)) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push({ word: next, path: [...path, next] });
+      }
+    }
+  }
+
+  throw new Error("No ladder found");
+}
+
+function createWordLadderDomain(): DomainBuilder<LadderContext> {
+  const builder = new DomainBuilder<LadderContext>("Word ladder");
+
+  builder
+    .sequence("Transform start into target")
+      .action("Generate ladder path")
+        .condition("Start differs from target", (ctx) => ctx.getState("start") !== ctx.getState("target"))
+        .do((ctx) => {
+          buildLadder(ctx);
+          return TaskStatus.Success;
+        })
+      .end()
+      .action("Validate ladder")
+        .do((ctx) => {
+          const path = ctx.getState("path");
+          if (path.length === 0 || path[path.length - 1] !== ctx.getState("target")) {
+            throw new Error("Ladder does not reach target");
+          }
+          return TaskStatus.Success;
+        })
+      .end()
+    .end();
+
+  return builder;
+}
+
+function createWordLadderContext(overrides: Partial<LadderState> = {}): LadderContext {
+  return createPuzzleContext<LadderState>({
+    start: "cold",
+    target: "warm",
+    dictionary: ["cord", "card", "ward", "warm", "wold", "word"],
+    path: [],
+    ...overrides,
+  });
+}
+
+test("Word ladder computes a transformation path", () => {
+  const domain = buildDomain(createWordLadderDomain());
+  const context = createWordLadderContext();
+
+  const plan = ensurePlan(domain, context);
+  assert.equal(planNames(plan), ["Generate ladder path", "Validate ladder"]);
+
+  executePlan(plan, context);
+
+  assert.equal(context.getState("path")[0], "cold");
+  assert.equal(context.getState("path")[context.getState("path").length - 1], "warm");
+  assert.ok(context.getState("path").length > 2);
+});
+
+test("Word ladder planning fails when already solved", () => {
+  const domain = buildDomain(createWordLadderDomain());
+  const context = createWordLadderContext({ start: "same", target: "same" });
+
+  ensureNoPlan(domain, context);
+});
+
+test("Word ladder execution detects missing path", () => {
+  const domain = buildDomain(createWordLadderDomain());
+  const context = createWordLadderContext({ dictionary: ["cold", "bold"] });
+
+  const plan = ensurePlan(domain, context);
+  assert.throws(() => executePlan(plan, context));
+});
+
+test.run();


### PR DESCRIPTION
## Summary
- rework each puzzle scenario test suite to mutate world state through real operators instead of placeholder assertions
- expand helper utilities for planning assertions and plan execution so tests can validate runtime effects and failures
- tighten river crossing safety checks by ensuring passengers exist on the departing bank before moving

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69089a53bfb0832fbf9ac4969638d978)