### PR TITLE
Add plan: web app preview + 3D block-stacking battle-test

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
 .git*
 coverage/*
 tests/*
+scenarios/*
+examples/*
 .eslint*
+PLAN-*.md

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -231,9 +231,29 @@ fluents: [
   { name: "pos", params: [{ name: "a", type: "agent" }], kind: "vec2" },
 
   // a relation: a 2-arg boolean table (graph edges, adjacency, …)
-  { name: "road", params: [{ name: "a", type: "node" }, { name: "b", type: "node" }], kind: "boolean" },
+  // `static: true` ⇒ immutable after init (see below) — a big planning speedup
+  { name: "road", params: [{ name: "a", type: "node" }, { name: "b", type: "node" }], kind: "boolean", static: true },
 ]
 ```
+
+### Static fluents (immutable relations) — declare them, it's a major speedup
+
+Maps, adjacency, alignment, type tables, recipe tables — relations that are set
+once at init and never change — should be declared `static: true`. The compiler
+then treats precondition lits over them as **compile-time constants** and **drops
+every ground operator whose static precondition can never hold** (e.g. `move(a,b)`
+where `road(a,b)` is false), so they never enter search *or* the heuristic. On a
+grid this turns the operator set from O(cells²) into O(edges):
+
+```ts
+{ name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", static: true }
+//   nav 10×10: 10 000 ground move ops → 360;  Scavenger HUGE: 6.1 s → 0.08 s
+```
+
+It is a **promise**: a `static` fluent must never be written — not by an operator
+(validated: declaring it and writing it is a compile error) *and not by the host*
+at runtime (e.g. don't `state.set` it between plans). Use it only for genuinely
+fixed structure; leave host-controlled inputs (like `has_vehicle`) non-static.
 
 ### The seven kinds and how they encode
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1263,9 +1263,33 @@ use it only for prototyping or for genuinely state-independent checks.
 F.opaque("preflightOk")   // predicate registered under `predicates.preflightOk`
 ```
 
+### Relaxation hints (`relax`) — let a black box guide the heuristic
+
+Externals and opaque predicates are invisible to the delete-relaxation heuristic
+(treated optimistically as always-satisfiable), so `h` can't account for whatever
+they gate — search degrades toward brute force on the paths they sit on. Attach a
+**sound over-approximation**: a T1 formula the predicate's truth *implies* (a
+necessary condition). The relaxation folds its conjunctive lits in as extra
+preconditions, so `h` becomes informative again — often by orders of magnitude.
+
+```ts
+// "you can only `finish(x)` once x is prepared" — invisible while opaque…
+F.opaque("ready", F.lit("prepared", ["?x"]))            // …now h knows it
+F.ext("canMoveTo", ["?d","?to"], ["peg","size"], F.lit("clear", ["?to"]))
+```
+
+It only feeds the heuristic — the real applicability check still runs unchanged,
+so a hint can never make search *incorrect*. It must be a genuine necessary
+condition (predicate ⟹ hint): if it is, the heuristic stays admissible (`hmax`
+remains optimal); if you over-claim, you only risk suboptimal/greedier search,
+exactly like an over-tight declared read set. Only the conjunctive lits of the
+hint are used (an `or`/`cmp` part is skipped, staying optimistic). In one
+opaque-gated benchmark this cut expansions 14376 → 23 at K=6.
+
 **Rule of thumb:** stay in T1 whenever you can (best heuristics, exact replan
 triggers, fully serializable). Reach for T2 when you need real computation but can
-still declare its fluent footprint. Reserve T3 for throwaway checks.
+still declare its fluent footprint. Reserve T3 for throwaway checks — and add a
+`relax` hint whenever a T2/T3 predicate gates a planning-relevant choice.
 
 ---
 

--- a/PERF-ROADMAP.md
+++ b/PERF-ROADMAP.md
@@ -1,0 +1,284 @@
+# Performance roadmap — what's next (for future PRs)
+
+> Companion to [`PERFORMANCE.md`](./PERFORMANCE.md) (what's already landed). This is
+> a **decision document**: the remaining optimization opportunities, each with an
+> honest **impact / risk / effort** estimate and trade-offs, grounded in this
+> repo's profiles + scaling sweeps and recent (2024–2026) research. Nothing here
+> is implemented yet. Read the profile first, then pick.
+
+## Where the time actually goes now (post-optimization)
+
+From `bench`/`bench:scale` + CPU profiles after the 10 landed optimizations:
+
+| Regime | Examples | Dominant cost | What would move it |
+|---|---|---|---|
+| Heuristic-bound GOAP | quarry, scavenger, HUGE grids | `relaxCore`+`materialize` ≈ **42%** | better/incremental heuristic (§1, §2) |
+| Inherent precondition eval | quarry geometry comparisons | `(anon)`/`fn`/`dyn` ≈ **21%** | mostly irreducible; helpful-actions (§3) |
+| A* machinery | all GOAP | `goalSearch` ≈ **17%** | node pooling / lazy children (§7) |
+| HTN decomposition | tour, htn, real hierarchies | **uninformed** (depth-first + MTR) | TDG/landmark HTN heuristics (§4) |
+| Relational (dynamic) | none in suite yet | successor gen O(candidates) | match-tree / lifted (§6) |
+
+Two facts shape everything below: (a) the **exact-optimal tests** (`hmax`+`w=1`)
+pin plan length/cost, so any change to the *default/admissible* heuristic is
+high-risk — most heuristic work should be **opt-in** for satisficing search; and
+(b) the **HTN half is currently heuristic-blind** — the biggest untapped area.
+
+## Quick-scan table
+
+| # | Item | Impact | Risk | Effort | When |
+|---|---|---|---|---|---|
+| 1 | h_FF + helpful actions (opt-in) | **High** | Low–Med | Med | **Next** |
+| 2 | Incremental delete-relaxation (parent→child Δ) | **High** | Med–High | High | Soon |
+| 3 | Preferred-operator / dual-queue search | Med–High | Low | Med | **Next** |
+| 4 | TDG + landmark heuristics for HTN | **High** | Med | High | Soon |
+| 5 | LLM-authored domain heuristics + harness | **High** (strategic) | Low | Med | Soon |
+| 6 | Match-tree / lifted successor generation | Med | Med | High | When a domain needs it |
+| 7 | Node pooling / lazy child materialization | Low–Med | Med | Med | Opportunistic |
+| 8 | BFWS / novelty-2 search mode (opt-in) | Med–High | Low–Med | Med | Soon |
+| 9 | Landmarks for GOAP (LM-cut / count) | Med | Med | High | Later |
+| 10 | Mutex / invariant synthesis | Med (enabler) | Med | High | Foundational |
+| 11 | Partial-order reduction + symmetry (optimal) | Med–High (optimal only) | **High** | High | Research |
+| 12 | Red-black / partial delete relaxation | Med | High | High | Research |
+| 13 | Regression-gated CI (`tinybench`) | Low (infra) | Low | Low | **Cheap win** |
+
+---
+
+## Tier 1 — high ROI, manageable risk (do these first)
+
+### 1. h_FF heuristic + helpful actions *(opt-in `heuristic: "ff"`)*
+
+**What.** The engine has `h_add`/`h_max`/`none`. Add **h_FF**: build the relaxed
+planning graph (already done in `relaxCore`), then extract a *relaxed plan* by
+back-chaining from the goal over best supporters; `h_FF` = its size. Standard in
+satisficing planning and typically **much more informative than h_add** → fewer
+expansions. The same back-chain yields **helpful (preferred) actions** — the
+first actions of the relaxed plan — for §3.
+
+**Impact.** High on hard satisficing problems (the greedy default). On easy ones
+(quarry is heuristic-saturated) it mainly helps via preferred operators.
+Reduces *expansions*, which compounds with the per-node speedups already landed.
+
+**Risk.** Low–Med. h_FF is **inadmissible** → it must be **opt-in**, never the
+`hmax` path the optimal tests use. Extraction is well-understood; the main care
+is reusing the existing interned-atom relaxation cleanly.
+
+**Effort.** Med (~1 PR). Reuses `relaxCore`'s graph; adds a back-chain pass + a
+`heuristic: "ff"` option + a test that it solves with fewer expansions than
+`hadd` on a hard instance.
+
+**Trade-offs.** Per-node cost rises slightly (extraction) but expansions drop —
+net win on hard problems, neutral on easy. *Research:* FF (Hoffmann & Nebel);
+the Datalog paper notes FF = back-chaining over supporting rules.
+
+### 3. Preferred-operator / dual-queue search
+
+**What.** Once §1 gives helpful actions, run a **dual open list**: one queue
+restricted to preferred operators, one for all, alternating pops (LAMA-style).
+Cheap, large practical speedups in satisficing planning.
+
+**Impact.** Med–High (compounds with §1). Directly attacks expansion count, which
+is the lever on the search-heavy scavenger grids.
+
+**Risk.** Low (opt-in; doesn't affect optimal search). **Effort.** Med (small
+once §1 lands). **Depends on §1.** *Research:* LAMA; [LAMA+BFWS 2024](https://arxiv.org/abs/2404.17648).
+
+### 5. LLM-authored domain heuristics + evaluation harness *(strategic for htn-ai)*
+
+**What.** Expose a sandboxed `(state, agenda) → number` heuristic slot (SPEC §11
+already specs it) plus a harness that scores candidate heuristics on benchmark
+instances (coverage / expansions / quality) and selects the best per domain.
+Because this is an **LLM-first** planner, the heuristics are authored by an LLM
+**offline** and run deterministically online.
+
+**Impact.** High and **differentiated**. NeurIPS 2025 (Corrêa et al.) showed
+**LLM-generated Python heuristics beat domain-independent heuristics** and rival
+learned ones, expanding *fewer* states in several domains; an HTN-specific
+result (Claude-Opus-written heuristics solved 131/139 IPC-2020 problems vs PANDA
+RC^FF's 134, less search on 83%). This turns "the LLM writes a heuristic once"
+into a real planning edge.
+
+**Risk.** Low for the core (it's a pluggable slot + harness; doesn't touch the
+default search). The risk is sandboxing/determinism of user/LLM code, which the
+T3 escape-hatch machinery already half-solves.
+
+**Effort.** Med. Mostly the harness + a clean heuristic-registration API + CSP-safe
+sandbox. **Trade-offs.** Domain-dependent (needs per-domain authoring) — but
+that's exactly the htn-ai workflow. *Research:*
+[Classical Planning with LLM-Generated Heuristics, NeurIPS 2025](https://arxiv.org/abs/2503.18809);
+[HTN Planning with LLM-Generated Heuristics](https://arxiv.org/html/2605.07707v1);
+[Successor-Generator Planning with LLM Heuristics](https://arxiv.org/pdf/2501.18784).
+
+### 13. Regression-gated CI (`tinybench`)
+
+**What.** Wire `npm run bench`/`bench:scale` into CI; fail on >10% per-node
+(µs/node) regressions. **Impact.** Low (infra) but **protects every win above**.
+**Risk/Effort.** Low/Low. SPEC §12 asks for it. Do it early.
+
+---
+
+## Tier 2 — high value, more effort
+
+### 2. Incremental delete-relaxation heuristic (parent→child Δ)
+
+**What.** `relaxCore` rebuilds the relaxed graph from scratch every state
+(~30–45% of GOAP CPU). A child differs from its parent by one operator's
+effects, so its relaxed costs can be **updated incrementally** instead of
+recomputed — the "semi-naive Δ evaluation" the 2026 Datalog paper formalizes
+(only re-fire rules whose body touched a changed fact).
+
+**Impact.** High — directly targets the single biggest remaining cost on the slow
+spatial domains. **Risk.** Med–High: must produce **identical h** (or it perturbs
+search and the optimal tests), and storing/reconstructing per-node relaxed state
+is memory-heavy. Note: an *intra*-evaluation worklist was already tried and
+reverted (dense small graphs); the *inter*-state Δ is a different, more promising
+target but trickier. **Effort.** High.
+
+**Trade-offs.** Big speedup *iff* the bookkeeping/memory stays below the recompute
+cost — true for large grounding (scavenger HUGE, big grids), marginal for tiny
+ones. Gate it on ground-op count. *Research:*
+[Parallel Lifted Planning via Semi-Naive Datalog Evaluation (2026)](https://arxiv.org/html/2605.07584v1).
+
+### 4. TDG + landmark heuristics for the HTN half
+
+**What.** Today HTN decomposition is **uninformed** — depth-first method order +
+MTR, no heuristic on task agenda items. Build the **Task Decomposition Graph**
+(reachable hierarchy) and derive a **TDG heuristic** (relaxed reachability over
+the hierarchy, admissible) and/or **HTN landmarks** to guide which method to try.
+
+**Impact.** High for real hierarchical domains (deep/branchy method trees), which
+the current toy `htn tour` doesn't stress but production HTNs will. It's the
+largest *untapped* area (the GOAP half is now well-optimized; the HTN half isn't).
+
+**Risk.** Med — new subsystem; integrating into the *unified* agenda search
+(tasks + goals interleaved) is non-trivial. Admissible TDG keeps optimality.
+**Effort.** High. *Research:* PANDA (dominated IPC-2023 HTN);
+[Heuristics based on TDGs, SoCS 2024];
+[Landmark Generation in HTN Planning Revisited (ICAPS)](https://ojs.aaai.org/index.php/ICAPS/article/download/36123/38277/40196).
+
+### 8. BFWS / novelty-2 search mode *(opt-in)*
+
+**What.** The engine has novelty-1 tie-breaking; **Best-First Width Search**
+makes novelty the *primary* driver, partitioned by heuristic (`#unachieved goals`,
+h), with novelty evaluated to width 2. SOTA exploration that **escapes heuristic
+plateaus** — the failure mode on hard scavenger-style instances.
+
+**Impact.** Med–High on hard/large satisficing problems; little on easy ones.
+**Risk.** Low–Med (separate opt-in search mode; novelty-2 needs a compact pair
+store). **Effort.** Med. *Research:*
+[BFWS, Lipovetzky & Geffner](https://ojs.aaai.org/index.php/AAAI/article/view/11027/10886);
+[LAMA+BFWS 2024](https://arxiv.org/abs/2404.17648).
+
+### 9. Landmarks for GOAP (admissible LM-cut and/or count)
+
+**What.** Extract fact/action landmarks; either **LM-cut** (admissible — could
+strengthen the optimal `hmax` path) or **landmark-count** (inadmissible, greedy).
+
+**Impact.** Med and **domain-dependent**. Prior analysis here: landmarks are
+*complementary* to the symbolic hints already landed (both make the heuristic see
+structure), but marginal for the current h_add-friendly suite; they shine on
+landmark-rich domains we'd need to add. **Risk.** Med (LM-cut admissibility is
+subtle; count must be opt-in). **Effort.** Med–High. Validate it beats h_add on a
+landmark-rich domain *before* landing. *Research:* LM-cut (Helmert & Domshlak).
+
+### 7. Node pooling / lazy child materialization
+
+**What.** `goalSearch` allocates a `StateView`+delta `Map` per candidate *before*
+the closed/heuristic prune may discard it (~10k discarded children/solve on
+quarry). Compute the child hash incrementally from the effect writes, run the
+`closed` check **before** committing the child, and pool discarded views.
+
+**Impact.** Low–Med (~5–10% of GOAP). **Risk.** Med (incremental hashing is
+correctness-sensitive). **Effort.** Med. Opportunistic — do it if touching
+`goalSearch` anyway.
+
+---
+
+## Tier 3 — research-grade (watch / prototype, don't commit blindly)
+
+### 6. Match-tree / lifted (join) successor generation
+
+**What.** A precompiled decision tree over operator preconditions (Fast Downward
+style), or full **lifted successor generation as a conjunctive-query/Datalog
+join** (Powerlifted style), so per-node cost depends on *applicable* count, not
+total ops, and **dynamic** relational preconditions are joined by the index.
+
+**Impact.** Med — but **static-fluent pruning already captured the static-relation
+case** (nav O(K⁴)→O(K²); the suite has no remaining dynamic-relational
+bottleneck). Real value only when a domain joins two *changing* relations per
+node, or when grounding itself explodes (lifted avoids grounding entirely).
+**Risk.** Med (match tree) → High (lifted rewrite). **Effort.** High. **Trigger:**
+build it when `bench:scale` shows a dynamic-relational domain regressing.
+*Research:* [Lifted Planning survey, IJCAI 2024](https://www.ijcai.org/proceedings/2024/0886.pdf);
+[Powerlifted](https://github.com/abcorrea/powerlifted);
+[Lifted Successor Generation by Maximum Clique Enumeration].
+
+### 10. Mutex / invariant synthesis
+
+**What.** Infer mutual-exclusion groups / state invariants (h²-style or
+monotonicity analysis), as SPEC §5.4 anticipates. **Impact.** Med as an
+**enabler** — sharpens heuristics, shrinks grounding (collapse boolean groups to
+enums), and underpins symmetry/POR (§11). **Risk/Effort.** Med/High. Foundational
+but indirect; sequence before §11.
+
+### 11. Partial-order reduction + symmetry elimination *(optimal search)*
+
+**What.** Strong stubborn sets + symmetry (orbit) pruning. Research shows **>98%
+of states pruned** in some optimal-planning domains. **Impact.** Med–High **but
+only for optimal (`hmax`) search**; a real-time *greedy* engine benefits far less.
+**Risk.** **High** — correctness-subtle (must provably preserve optimality &
+completeness). **Effort.** High. Mostly relevant if optimal planning becomes a
+first-class use case. *Research:* Wehrle & Helmert; "Faster Optimal Planning with
+Partial-Order Pruning"; dominance pruning.
+
+### 12. Red-black / partial delete relaxation
+
+**What.** Interpolate between delete-relaxed and real planning by painting a
+subset of variables "black" (real semantics). **Impact.** Med (more accurate h →
+fewer expansions). **Risk.** High (black-variable planning can be intractable;
+careful variable painting needed). **Effort.** High. *Research:*
+[Red-black planning (Domshlak, Hoffmann, Katz)](https://www.sciencedirect.com/science/article/pii/S0004370214001581).
+
+---
+
+## Recommended sequencing
+
+1. **One cheap-wins PR:** §13 regression CI + §7 if convenient.
+2. **The satisficing-search PR:** §1 h_FF + §3 preferred operators (together;
+   they share the relaxed-plan back-chain). Biggest expansion-count win,
+   opt-in, low risk.
+3. **The strategic PR:** §5 LLM-heuristic slot + harness — differentiated, low
+   core risk, leans into what htn-ai *is*.
+4. **The HTN PR:** §4 TDG/landmark heuristics — closes the biggest gap (the HTN
+   half is uninformed).
+5. **Then measure** and decide between §2 (incremental heuristic — hardest, but
+   the deepest per-node win) and §8 (BFWS) based on which regime is hurting.
+6. **Hold** §6/§10/§11/§12 until a benchmark demands them; keep `bench:scale` as
+   the trigger.
+
+### Cross-cutting guardrails
+
+- **Heuristic changes are opt-in unless proven admissible** — the exact-optimal
+  tests are the contract; never perturb the `hmax`+`w=1` path without an
+  admissibility proof.
+- **Every item ships with a benchmark** (a `bench:scale` row or a new domain) and
+  must keep all tests' **expansion counts** explainable.
+- **Prototype-before-land for uncertain wins** (§2, §9, §6) — measure it beats the
+  status quo on a representative domain first, as we did for the worklist (which
+  we reverted) and the relax hints (which we kept).
+
+---
+
+*Sources:*
+[Lifted Planning survey (IJCAI 2024)](https://www.ijcai.org/proceedings/2024/0886.pdf) ·
+[Powerlifted](https://github.com/abcorrea/powerlifted) ·
+[Semi-Naive Datalog lifted planning (2026)](https://arxiv.org/html/2605.07584v1) ·
+[Lifted Successor Generation in Numeric Planning (2025)](https://arxiv.org/pdf/2511.00673) ·
+[BFWS](https://ojs.aaai.org/index.php/AAAI/article/view/11027/10886) ·
+[LAMA + BFWS (2024)](https://arxiv.org/abs/2404.17648) ·
+[Classical Planning with LLM-Generated Heuristics (NeurIPS 2025)](https://arxiv.org/abs/2503.18809) ·
+[HTN Planning with LLM-Generated Heuristics](https://arxiv.org/html/2605.07707v1) ·
+[Successor-Generator Planning with LLM Heuristics](https://arxiv.org/pdf/2501.18784) ·
+[Landmark Generation in HTN Planning Revisited (ICAPS)](https://ojs.aaai.org/index.php/ICAPS/article/download/36123/38277/40196) ·
+[PANDA framework](https://link.springer.com/article/10.1007/s13218-020-00699-y) ·
+[Red-black planning](https://www.sciencedirect.com/science/article/pii/S0004370214001581) ·
+[Faster Optimal Planning with Partial-Order Pruning](https://aaai.org/papers/00100-13562-faster-optimal-planning-with-partial-order-pruning/)

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -6,23 +6,39 @@
 
 ## TL;DR
 
-The planner was **~10–20× slower than it needed to be**, dominated by the
-delete-relaxation heuristic and by re-doing per-node work the compiler could
-do once. A stack of semantics-preserving optimizations (all **80 tests pass
-unchanged**, expansion counts identical) brought:
+The planner was **~10–80× slower than it needed to be**, dominated by the
+delete-relaxation heuristic, by re-doing per-node work the compiler could do
+once, and by grounding/searching operators that can never apply. A stack of
+semantics-preserving optimizations (all tests pass unchanged, **expansion counts
+identical**) brought:
 
 | Workload | baseline | now | speedup |
 |---|--:|--:|--:|
-| quarry (hmax, w=1, optimal GOAP) | 176.3 ms | **14.1 ms** | **12.5×** |
-| quarry (hadd, w=2, greedy) | 178.9 ms | **13.2 ms** | 13.6× |
-| scavenger (hmax, w=1) | 14.1 ms | **1.55 ms** | 9.1× |
-| staircase (hmax, w=1) | 0.78 ms | **0.21 ms** | 3.7× |
-| blocks reverse-6 (w=1) | 4.14 ms | **0.20 ms** | **20.3×** |
-| blocks reverse-5 (w=1) | 1.87 ms | **0.18 ms** | 10.2× |
-| hanoi-5 (w=1) | 6.72 ms | **2.42 ms** | 2.8× |
+| quarry (hmax, w=1, optimal GOAP) | 176.3 ms | **~11 ms** | **~16×** |
+| scavenger (hmax, w=1) | 14.1 ms | **1.34 ms** | 10.5× |
+| blocks reverse-6 (w=1) | 4.14 ms | **0.24 ms** | **17×** |
+| hanoi-5 (w=1) | 6.72 ms | **2.4 ms** | 2.8× |
+| nav grid K=12 (relational) | 168.9 ms | **4.4 ms** | **38×** |
+| Scavenger XL (4×3, pushed) | 448 ms | **22 ms** | **20×** |
+| Scavenger HUGE (6×4, pushed) | 6150 ms | **78 ms** | **79×** |
 
-**Per-node cost on quarry: 116 µs → 9.2 µs (12.6×).** The uvu suite went
-707 ms → ~145 ms. (Node 22, single machine; ratios are stable, absolute ms vary.)
+**Per-node cost on quarry: 116 µs → ~8 µs.** The uvu suite went 707 ms → ~150 ms
+(now 84 tests incl. Scavenger XL). The biggest single wins: the allocation-free
+interned heuristic (≈4–9×), and **static-fluent pruning** (nav 38×, HUGE another
+4×). (Node 22, single machine; ratios stable, absolute ms vary ±10%.)
+
+### Optimizations landed (each preserves the search exactly)
+
+1. Allocation-free relaxation heuristic via compile-time interned atom ids
+2. Indexed successor generation (most-selective precondition atom)
+3. Adaptive copy-on-write state collapse (≈ slotCount/32)
+4. Flat-buffer heuristic reads (`materializeInto`)
+5. Grounding-time slot specialization (no per-eval lookups/allocs)
+6. Reusable `ExtQuery` for external/opaque predicate evaluation
+7. Arg-only external folding (empty read set ⇒ prune at grounding)
+8. Symbolic relaxation hints (`relax` over-approximations)
+9. **Static-fluent pruning** (`static: true` ⇒ drop dead groundings)
+10. Pure-atom precondition skip; heap/`freeBindings`/sort allocation cleanups
 
 ## How this was measured
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -160,6 +160,15 @@ Profiling sorts the scenarios into three regimes, each with a different next mov
 
 ## Remaining opportunities (ranked)
 
+### Landed since: symbolic relaxation hints
+
+External/opaque predicates were invisible to the heuristic. A predicate can now
+carry a `relax` over-approximation — a T1 necessary condition the relaxation
+folds in (feeds the heuristic only; search applicability is untouched, so a hint
+can't make search incorrect, and a *sound* hint keeps `hmax` admissible). On an
+opaque-gated benchmark this cut expansions **14376 → 23 at K=6** (and Hanoi-class
+predicate domains can hint `canMoveTo`). See `tests/hints.ts`, GUIDE §22.
+
 ### A. Help most scenarios more
 
 1. **Incremental / landmark heuristic** — the real ceiling for the *slowest*

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,212 +1,149 @@
-# Planner performance: analysis & proposal
+# Planner performance: analysis & optimization log
 
 > Scope: the planning **core** (`src/search.ts`, `src/compile.ts`, `src/state.ts`)
-> — the hot path that `Planner.tick` / `planOnce` run every frame. Methodology,
-> findings, the one optimization landed in this change, and a ranked proposal for
-> the rest. Reproduce everything with `npm run bench`.
+> — the hot path `Planner.tick` / `planOnce` run every frame. Methodology, the
+> findings, the optimizations landed, and what's left. Reproduce with `npm run bench`.
 
 ## TL;DR
 
-- The runtime was **dominated by the delete-relaxation heuristic** (`hAdd`):
-  **~77% of CPU** on the heaviest workload (the quarry GOAP search), because it
-  rebuilt the relaxed planning graph from scratch on every state using
-  **per-atom string keys** in a `Map<string,number>`. A *single* quarry solve
-  allocated **~1.04 million transient strings**.
-- **Landed here:** rewrote the heuristic to run over **compile-time interned
-  integer atom ids** into a **reusable numeric buffer** — zero strings, zero
-  maps, zero allocation on the hot path. Same algorithm, **identical search**
-  (every expansion count and the exact-optimal-plan tests are unchanged).
-  **Result: 4–9.5× faster**, e.g. quarry **176 ms → 44 ms**.
-- **Proposed next (evidence below):** an **applicable-action index** so each
-  node expansion stops scanning *all* ground operators (now the #1 remaining
-  cost at ~35%), plus **grounding-time slot specialization** and a few
-  allocation cleanups. Estimated another **2–4×** on top.
+The planner was **~10–20× slower than it needed to be**, dominated by the
+delete-relaxation heuristic and by re-doing per-node work the compiler could
+do once. A stack of semantics-preserving optimizations (all **80 tests pass
+unchanged**, expansion counts identical) brought:
+
+| Workload | baseline | now | speedup |
+|---|--:|--:|--:|
+| quarry (hmax, w=1, optimal GOAP) | 176.3 ms | **14.1 ms** | **12.5×** |
+| quarry (hadd, w=2, greedy) | 178.9 ms | **13.2 ms** | 13.6× |
+| scavenger (hmax, w=1) | 14.1 ms | **1.55 ms** | 9.1× |
+| staircase (hmax, w=1) | 0.78 ms | **0.21 ms** | 3.7× |
+| blocks reverse-6 (w=1) | 4.14 ms | **0.20 ms** | **20.3×** |
+| blocks reverse-5 (w=1) | 1.87 ms | **0.18 ms** | 10.2× |
+| hanoi-5 (w=1) | 6.72 ms | **3.43 ms** | 2.0× |
+
+**Per-node cost on quarry: 116 µs → 9.2 µs (12.6×).** The uvu suite went
+707 ms → ~145 ms. (Node 22, single machine; ratios are stable, absolute ms vary.)
 
 ## How this was measured
 
-- `npm run bench` — wall-clock per solve **plus the engine's own counters**
-  (`decompositions` / `expansions` / `heuristicEvals`). The decisive metric is
-  **ms ÷ expansions = per-node cost**: a "real-time, frame-budget" planner lives
-  or dies on it.
-- `bench/profile.ts` under V8's `--cpu-prof`, parsed for self-time per function.
-- Scalable instances (blocks-world reverse-a-tower at N=4/5/6, Hanoi at
-  3/4/5 disks) to see how cost grows with the ground-operator count.
+- `npm run bench` — wall-clock per solve **plus engine counters** (`decompositions`
+  / `expansions` / `heuristicEvals`). The decisive metric is **ms ÷ expansions =
+  per-node cost**: a "real-time, frame-budget" planner lives or dies on it.
+- `bench/profile.ts` under V8 `--cpu-prof`, parsed for self-time per function.
+- Scalable instances (blocks reverse-a-tower N=4/5/6, Hanoi 3/4/5) to watch cost
+  grow with the ground-operator count, and HTN-decomposition + multi-agent
+  `Scheduler` workloads so the non-GOAP paths are covered too.
 
-## Baseline findings
+## Baseline: where the time went
 
-Per-solve, `main` before this change:
+Baseline per-node cost was **~116 µs** on quarry — for a planner that advertises
+"plans in microseconds," a single moderate problem already blew a 16 ms frame.
 
-| Workload | ms/iter | expansions | **µs / expansion** |
-|---|--:|--:|--:|
-| quarry (hmax, w=1, optimal) | 176.3 | 1524 | **~116** |
-| scavenger (hmax, w=1) | 14.1 | 110 | ~128 |
-| hanoi 5 (w=1) | 6.72 | 185 | ~36 |
-| blocks reverse 6 (w=1) | 4.14 | 7 | — |
+CPU profile (quarry), and instrumenting one solve:
 
-**~116 µs per node** for a planner that advertises "plans in microseconds." A
-16 ms frame budget would be blown by a single moderate problem, and a
-`Scheduler` of agents far sooner.
+| Function | Self | | one quarry solve |
+|---|--:|---|--:|
+| `hAdd` | 49.3% | | 1482 `hAdd` calls, ~2.8 fixpoint rounds each |
+| `(anon)` (hAdd inner closures) | 19.0% | | 570k ground-op iterations in the heuristic |
+| `heuristic` (memo wrapper) | 8.7% | | **1,039,833 `${slot}:${value}` strings allocated** |
+| garbage collector | 3.8% | | |
 
-### The smoking gun
+**~77% of CPU was the heuristic**, which rebuilt the relaxed planning graph from
+scratch on every state using per-atom **string keys** in a `Map<string,number>`
+— over a million throwaway strings per solve. The fixpoint itself was cheap
+(~2.8 rounds); the **allocation and map churn** was the cost.
 
-CPU profile of the quarry search (80 iters, self-time):
+## What was landed (7 optimizations, 3 commits)
 
-| Function | Self |
+Every change preserves the search exactly (same plans, same expansion counts) —
+the exact-optimal-plan tests under `hmax`+`weight:1` are the regression net.
+
+1. **Allocation-free heuristic via interned atoms** *(the big one — targeted the
+   ~77%)*. Intern every distinct `(slot,value)` atom over the ground operators to
+   a dense integer id at compile time (`Model.buildRelaxTables`); emit typed-array
+   tables + per-ground-op `preIds`/`addIds`. `relaxCore` runs h_add/h_max over
+   those into a **reusable `Float64Array`** — no strings, no maps, no per-call
+   allocation. Goal atoms resolved to ids once per search; novelty switched to a
+   `Set<number>`. → **4–9.5×**.
+
+2. **Indexed successor generation**. Goal search was scanning **all** ground ops
+   per node and testing each precondition (1524 × 136 ≈ 207k evals, mostly
+   failing). Index each op by its **most-selective precondition atom**
+   (`buildSuccessorIndex`); a node only considers ops whose selector currently
+   holds. Candidates are processed in gid order, so the search is byte-identical
+   to the full scan. A cheap atom-level fast-reject precedes the full precondition
+   closure.
+
+3. **Adaptive copy-on-write collapse** (`state.ts`). `get()` walks the delta
+   chain via Map lookups (tens of ns); `materialize()` is a flat typed-array copy
+   (~0.5 ns/elem). The fixed depth-24 chain over-walked small states. Collapse at
+   **≈ slotCount/32** (clamped [2,32]) — near-O(1) reads for the common
+   small-state case, deeper chains only where copying would dominate. (Quarry:
+   30 ms → 19 ms.)
+
+4. **Flat-buffer heuristic reads** (`materializeInto`). The relaxation **seed**
+   read every atom through `StateView.get` (≈300k chain-walks/solve) — the real
+   cost inside `relaxCore`. Materialize the state into a **reused flat buffer**
+   once per eval; all seed/goal reads become O(1).
+
+5. **Slot specialization** (`slotFn`). The variable-arg slot closure did a
+   fluent-name lookup + per-type map lookup **and allocated two arrays** (a
+   `getArgs` result and the spread/rest) on every precondition/effect/cost eval.
+   Capture the fluent layout + per-param index maps at compile time; resolve the
+   slot inline with zero allocation.
+
+6. **Allocation cleanups**: cache `freeBindings` per compiled method (was
+   re-enumerated every task expansion — helps HTN); swap heap nodes with a temp
+   instead of array destructuring (no 2-elem array per sift); skip the
+   candidate sort when a domain's candidates can only come from one
+   gid-ordered bucket.
+
+7. **Benchmark harness** (`bench/`, `npm run bench`) covering GOAP, scalable
+   blocks/Hanoi, HTN decomposition, and the multi-agent Scheduler.
+
+### Profile, after
+
+`relaxCore` is back on top but ~7× cheaper than the old `hAdd`; the heuristic
+seed is O(1), precondition scanning is gone, and string/GC churn is eliminated:
+
+| Function | Self (after) |
 |---|--:|
-| `hAdd` (`search.ts`) | **49.3%** |
-| `(anon)` (`search.ts`) — `hAdd`'s inner closures / `atomKey` | **19.0%** |
-| `heuristic` (memo wrapper) | **8.7%** |
-| garbage collector | 3.8% |
-| `goalSearch` + compiled-formula closures (`compile.ts`) | ~13% |
+| `relaxCore` (heuristic fixpoint) | ~43% |
+| `goalSearch` (A* expansion machinery) | ~18% |
+| compiled precondition closures (`(anon)`/`fn`/`dyn`/`fluent`) | ~16% |
+| `materialize` / `slotOf` / GC | ~12% |
 
-So **~77% of all CPU was the heuristic.** Instrumenting one quarry solve:
+## What was tried and reverted
 
-```
-groundOps: 136
-hAdd calls: 1482        (one per distinct generated state; memoized by state hash)
-fixpoint rounds: 4194   => avg 2.8 rounds/call   (the 64-round cap is irrelevant)
-ground-op iterations inside hAdd: 570,384
-atomKey string allocations: 1,039,833   ← ~1.04M throwaway strings per solve
-```
+- **Worklist (Dijkstra-style) relaxation** — re-enqueue only the ops that read a
+  decreased atom. *Slower here* (29 → 31 ms): these relaxation graphs are small
+  and dense (one shared atom like `agentAt` gates almost every op), so a single
+  decrease re-enqueues nearly everything and the bookkeeping costs more than the
+  ~2.8-round dense sweep. Kept the round-based fixpoint; noted in code. (Expected
+  to win once domains get large and sparse — IPC-scale.)
 
-Root cause (was `src/search.ts`):
+## Remaining opportunities (ranked)
 
-- `hAdd` recomputed the full relaxed planning graph for **every** state.
-- Every atom touch built a string key `` `${slot}:${value}` `` and hit a
-  `Map<string,number>` — ~1M times per solve. That string churn (and its GC)
-  *was* the cost; the fixpoint itself is only ~2.8 rounds.
-
-### Why some domains barely moved
-
-Hanoi got the **smallest** win (1.9×). Its `move` precondition uses an **opaque**
-`canMoveTo` predicate, which the relaxation skips — so Hanoi's per-node cost is
-**precondition evaluation**, not the heuristic. That's the tell for the
-*next* bottleneck (below).
-
-## What landed in this change
-
-Rewrote the heuristic to be allocation-free while preserving the exact algorithm
-(`src/compile.ts` + `src/search.ts`):
-
-1. **Compile-time atom interning** (`Model.buildRelaxTables`, in
-   `groundOperators()`). Every distinct `(slot,value)` atom appearing in any
-   ground op's pre/add sets gets a dense integer id. Emitted once:
-   - `relaxAtomSlot` / `relaxAtomValue` / `relaxAtomFuzzy` (typed arrays), and
-   - per-ground-op `preIds` / `addIds` (`Int32Array`).
-2. **`relaxCore`** runs h_add / h_max over those typed arrays into a **reusable
-   `Float64Array` cost buffer** held by the `Engine` — no strings, no maps, no
-   per-call allocation. Goal atoms are resolved to ids **once per search**, not
-   per node. Novelty tie-breaking switched from a `Set<string>` to a
-   `Set<number>` of interned ids.
-3. The public `hAdd(model, s, goalAtoms, mode)` export keeps its signature
-   (builds descriptors + a scratch buffer per call).
-
-Semantics are intentionally identical — the fuzzy-atom optimism, the
-`missing===0` early-out, and h_add-vs-h_max combination all match the original,
-which is why **all 80 tests pass unchanged**, including the ones that assert
-*exact optimal* plan lengths/costs under `hmax` + `weight: 1`.
-
-### Result
-
-| Workload | before | after | speedup |
-|---|--:|--:|--:|
-| quarry (hmax, w=1, optimal) | 176.3 ms | **44.1 ms** | **4.0×** |
-| quarry (hadd, w=2, greedy) | 178.9 ms | **42.2 ms** | **4.2×** |
-| scavenger (hmax, w=1) | 14.1 ms | **2.62 ms** | **5.4×** |
-| staircase (hmax, w=1) | 0.78 ms | **0.35 ms** | 2.3× |
-| blocks reverse 5 (w=1) | 1.87 ms | **0.30 ms** | 6.3× |
-| blocks reverse 6 (w=1) | 4.14 ms | **0.44 ms** | **9.5×** |
-| hanoi 4 / 5 (w=1) | 1.73 / 6.72 ms | **0.91 / 3.62 ms** | 1.9× |
-
-Expansion counts are **identical** before/after (same search, faster nodes). The
-uvu suite went from ~707 ms to ~255 ms.
-
-## Proposal: the next wins (ranked)
-
-After the heuristic fix, the quarry profile re-balanced — proving where to go
-next:
-
-| Function | Self (after) | What it is |
-|---|--:|---|
-| `relaxCore` (`search.ts`) | 35.2% | the heuristic — still #1, but 4× cheaper |
-| **`(anon)` (`compile.ts`)** | **25.3%** | **compiled precondition closures** |
-| `dyn` (`compile.ts`) | 9.3% | dynamic lit compare in pre/eff |
-| `goalSearch` (`search.ts`) | 8.0% | A* loop / child creation |
-| `slotOf` (`compile.ts`) | 4.8% | slot computation from bindings |
-| `fn` / `fluent` (`compile.ts`) | 5.2% | more formula eval |
-
-### 1. Applicable-action indexing — biggest remaining win (~30–40% of CPU)
-
-**Problem.** `goalSearch` expands a node by looping over **every** ground
-operator and testing its precondition (`src/search.ts`, the `for (const g of
-model.groundOps)` loop). Quarry does `1524 expansions × 136 ground ops ≈ 207k`
-precondition evaluations, **the vast majority of which fail** — that is the
-`(anon) compile.ts` 25.3% + `dyn` 9.3%.
-
-**Fix.** A successor generator that only yields *plausibly applicable* ops:
-
-- Index ground ops by their precondition atoms: `consumersOf[atomId] → ops`.
-  Maintain, per state, a count of satisfied precondition atoms per op
-  (decrement/increment as atoms flip between parent and child) so only ops whose
-  symbolic preconditions hold are even considered — the classic
-  match-tree / counter-based successor generator the SPEC already calls for
-  (§5.4 "indexed successor generation", §12).
-- Cheaper intermediate step with most of the benefit: index by **one selective
-  precondition atom per op** (e.g. `agentAt(from)` / `on(x,from)`), and skip any
-  op whose selector doesn't currently hold. Ops with no indexable (all-external)
-  precondition fall back to "always consider," preserving correctness — this
-  also finally speeds up Hanoi.
-
-**Expected:** removes most of the ~35% precondition cost → roughly **1.5–2×**
-overall; compounding, quarry ≈ **25–30 ms**.
-
-### 2. Grounding-time slot specialization (`slotOf` 4.8% + part of the closures)
-
-For a **ground** op the operand slots are constant, yet the compiled
-`slot(b)` closures recompute them every evaluation via nested
-`indexInType.get(...).get(gid)` map lookups (`Model.slotOf`). Specialize each
-ground op's pre/eff evaluators against its fixed bindings at grounding time
-(precomputed slot constants), as SPEC §5.5 ("monomorphic evaluator
-specialization") anticipates. Removes `slotOf` from the hot path and shrinks the
-precondition-closure cost. **Expected:** ~1.1–1.2×, and it stacks with #1.
-
-### 3. Heuristic, round two (`relaxCore` still 35%)
-
-Two independent options, only if #1/#2 aren't enough:
-
-- **Inverted-index worklist** for the fixpoint (Dijkstra-style relaxation over
-  `consumersOf` from #1) instead of re-scanning all ops each round. With only
-  ~2.8 rounds the upside is modest here but grows with operator count.
-- **`h_max` reuse:** under `hmax`+`w=1` the heuristic is recomputed for states
-  that differ trivially; landmark/`h_max` caching keyed on the changed atoms
-  could amortize it. (Note: `hCache` is currently keyed by **state hash only**,
-  ignoring which goal is being searched — fine within one search, but a latent
-  correctness risk across multiple inline goals in one HTN agenda. Worth a
-  goal-id in the key when this area is next touched.)
-
-### 4. Allocation / micro cleanups (small here, real for HTN-heavy & multi-agent)
-
-These don't show up in the GOAP-dominated quarry profile but matter for
-decomposition-heavy and `Scheduler` workloads:
-
-- **`Engine.expandTask` recomputes `model.freeBindings(method)` every
-  expansion** — re-enumerates and allocates binding arrays each time. Cache per
-  compiled method at compile time (free-param types are fixed).
-- **`seek` builds plans with `[step, ...sub.steps]` at every recursion level** —
-  O(n²) in plan length. Collect into one array (or parent pointers) and reverse
-  once.
-- **`Heap` swaps via array destructuring** `[a[i],a[p]] = [a[p],a[i]]`, which
-  allocates a 2-element array per swap. Use a temp local.
-- **`agendaSignature` builds a string per task expansion** for cycle detection;
-  a structural/numeric key avoids the allocation.
-
-### 5. Worth having regardless: regression gating
-
-The SPEC asks for benchmark-gated CI (§12). `npm run bench` is the start; wiring
-a small `tinybench` job that fails on >10% per-node regressions would lock in
-these wins.
+1. **Heuristic relevance pruning / landmarks.** `relaxCore` (~43%) still sweeps
+   all ground ops each round. Restricting to goal-relevant ops would help, but
+   naive relevance pruning changes h values — needs a sound refinement (e.g.
+   landmarks, or `h_FF` with a justification cut) validated against the
+   exact-optimal tests. Highest upside, highest care.
+2. **Per-ground-op precondition specialization.** For ops whose precondition is
+   *pure positive atoms*, the fast-reject already proves applicability — skip the
+   full precondition closure entirely. (Limited for the spatial/blocks domains,
+   whose preconditions carry comparisons/externals; broad for plain STRIPS.)
+3. **Cut child allocation in `goalSearch`.** Each candidate allocates a
+   `StateView` + delta `Map` before the closed/heuristic prune may reject it.
+   Lazily allocate the delta map, or compute the child hash and run the closed
+   check before committing the child.
+4. **`seek` plan assembly is O(n²)** (`[step, ...sub.steps]` per level). Doesn't
+   show in the GOAP profile (one decomposition) but matters for deep HTN; collect
+   into one array (or parent pointers) and reverse once.
+5. **Regression-gated CI** (SPEC §12): wire `npm run bench` into a `tinybench`
+   job that fails on >10% per-node regressions to lock these wins in.
 
 ---
 
-*Reproduce:* `npm run bench` (numbers above: Node 22, single run; absolute ms
-vary by machine, ratios are stable).
+*Reproduce:* `npm run bench`. Per-node cost (`ms ÷ expansions`) is the number to
+watch.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -26,13 +26,31 @@ unchanged**, expansion counts identical) brought:
 
 ## How this was measured
 
-- `npm run bench` — wall-clock per solve **plus engine counters** (`decompositions`
-  / `expansions` / `heuristicEvals`). The decisive metric is **ms ÷ expansions =
-  per-node cost**: a "real-time, frame-budget" planner lives or dies on it.
+- `npm run bench` — robust stats: warm up, auto-calibrate the inner loop, run
+  several trials and report the **min** ms/iter (least contaminated by
+  GC/scheduler/CPU-freq noise), plus median and **spread%** so the noise is
+  visible, and **µs/node = min ÷ expansions** (size-normalized cost — what a
+  frame budget cares about). `--expose-gc` collects between trials for less
+  noise. *(Earlier single-batch means undersold the noise; medians ran ~40%
+  above the min on the heavier GOAP solves.)*
+- `npm run bench:scale` — sweeps each workload along one axis (hanoi disks,
+  blocks count, nav-grid size, HTN width, agent count, search weight) so
+  super-linear scaling is visible (`×prev` growth factor per step).
 - `bench/profile.ts` under V8 `--cpu-prof`, parsed for self-time per function.
-- Scalable instances (blocks reverse-a-tower N=4/5/6, Hanoi 3/4/5) to watch cost
-  grow with the ground-operator count, and HTN-decomposition + multi-agent
-  `Scheduler` workloads so the non-GOAP paths are covered too.
+
+### Scaling findings (`bench:scale`)
+
+| Axis | What scales | Observed |
+|---|---|---|
+| Hanoi disks 3→8 | exponential search | expansions ×~4/disk, **µs/node ~flat (7→15)** ✓ |
+| Blocks 4→12 | grounding O(n³) | search trivial, but **µs/node 10→239** — heuristic sweeps all ground ops |
+| **Nav grid K 4→12** | relational adjacency | **µs/node 18→7342 (~O(K⁴))** — successor generation can't index `adj(from,to)`; gathers all `K²` moves/node |
+| HTN tour 8→128 | decomposition width | ~linear ✓ |
+| Scheduler 1→32 | multi-agent | ~linear ✓ |
+
+Two clear next targets fall out: a **join/match-tree successor generator** for
+relational preconditions (nav is O(K⁴) today), and **relevance-pruning the
+heuristic** so it doesn't sweep every ground op when grounding is large (blocks).
 
 ## Baseline: where the time went
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -184,6 +184,30 @@ Profiling sorts the scenarios into three regimes, each with a different next mov
 
 ## Remaining opportunities (ranked)
 
+### Landed since: static-fluent pruning
+
+Fluents declared `static: true` (immutable after init — adjacency, maps,
+alignment) have their precondition lits treated as compile-time constants, so
+ground operators whose static precondition can never hold are **dropped at
+grounding** — out of both search and the relaxation. Sound (a static-false lit is
+unreachable in the relaxation too, so h is unchanged) and validated (writing a
+static fluent is a compile error). Static must be *declared*, not inferred: a
+fluent no operator writes can still be set by the host (e.g. `has_vehicle`), and
+grounding is shared across plans.
+
+| | before | after |
+|---|--:|--:|
+| nav grid 10×10 — ground move ops | 10 000 | **360** |
+| nav grid K=12 — solve | 168.9 ms | **4.4 ms** (38×) |
+| Scavenger HUGE — solve | 305 ms | **81 ms** (now **76× vs the original baseline**) |
+| quarry (adj+buildable static) | 14.0 ms | **10.9 ms** (~16× vs baseline) |
+
+This **captures most of the relational successor-generation win** for static
+relations (adjacency/maps/alignment) — the nav O(K⁴) wall is gone. A full
+join/match-tree successor generator remains relevant only for **dynamic**
+relational preconditions (two changing relations joined per node), which no
+current benchmark exercises; it's demoted to "build when a domain needs it."
+
 ### Landed since: symbolic relaxation hints
 
 External/opaque predicates were invisible to the heuristic. A predicate can now

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -52,6 +52,30 @@ Two clear next targets fall out: a **join/match-tree successor generator** for
 relational preconditions (nav is O(K⁴) today), and **relevance-pruning the
 heuristic** so it doesn't sweep every ground op when grounding is large (blocks).
 
+### Validation on the larger pushed examples (`bench/huge.ts`)
+
+Same-machine before/after on the bigger Scavenger instances (the baseline is the
+pre-optimization engine on its own branch; planning only, model built once;
+**identical expansion counts** ⇒ identical search, just faster nodes):
+
+| Instance | baseline | optimized | speedup | expansions |
+|---|--:|--:|--:|--:|
+| Scavenger XL (4×3, h3, hadd w=5) | 448 ms | **35 ms** | **12.8×** | 1608 |
+| Scavenger HUGE (6×4, h3, hadd w=6) | 6150 ms | **305 ms** | **20.2×** | 1716 |
+
+The speedup is *larger* on the bigger grid — exactly the prediction: more cells ⇒
+more ground ops ⇒ the per-node heuristic cost (what these optimizations cut
+hardest) dominates more. The `scavengerGrid(W,D)` sweep shows that per-node cost
+still grows with grounding even after the wins, motivating the static-pruning /
+relevance work:
+
+| W×D | cells | min ms | µs/node |
+|---|--:|--:|--:|
+| 4×3 | 12 | 65 | 43 |
+| 5×3 | 15 | 113 | 61 |
+| 6×3 | 18 | 181 | 105 |
+| 6×4 | 24 | 319 | 186 |
+
 ## Baseline: where the time went
 
 Baseline per-node cost was **~116 µs** on quarry — for a planner that advertises

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -200,6 +200,10 @@ Profiling sorts the scenarios into three regimes, each with a different next mov
 
 ## Remaining opportunities (ranked)
 
+> A fuller, research-grounded decision document with impact/risk/effort per item
+> lives in [`PERF-ROADMAP.md`](./PERF-ROADMAP.md). The summary below is kept for
+> quick reference.
+
 ### Landed since: static-fluent pruning
 
 Fluents declared `static: true` (immutable after init — adjacency, maps,

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -19,7 +19,7 @@ unchanged**, expansion counts identical) brought:
 | staircase (hmax, w=1) | 0.78 ms | **0.21 ms** | 3.7× |
 | blocks reverse-6 (w=1) | 4.14 ms | **0.20 ms** | **20.3×** |
 | blocks reverse-5 (w=1) | 1.87 ms | **0.18 ms** | 10.2× |
-| hanoi-5 (w=1) | 6.72 ms | **3.43 ms** | 2.0× |
+| hanoi-5 (w=1) | 6.72 ms | **2.42 ms** | 2.8× |
 
 **Per-node cost on quarry: 116 µs → 9.2 µs (12.6×).** The uvu suite went
 707 ms → ~145 ms. (Node 22, single machine; ratios are stable, absolute ms vary.)
@@ -98,7 +98,15 @@ the exact-optimal-plan tests under `hmax`+`weight:1` are the regression net.
    candidate sort when a domain's candidates can only come from one
    gid-ordered bucket.
 
-7. **Benchmark harness** (`bench/`, `npm run bench`) covering GOAP, scalable
+7. **Reusable `ExtQuery`** (`compile.ts`). External/opaque predicate & numeric
+   evaluation allocated a fresh 5-closure object per call, and its `get()` did a
+   `.map()` + spread/rest into `slotOf` — pure overhead around the user's
+   predicate, and the dominant cost for predicate-bound domains. A single
+   re-pointed `ExtQuery`/`ExtWriter` bound to mutable model state (external eval
+   is a synchronous leaf call) + an allocation-free `slotOfArgs`. → **Hanoi-5
+   3.43 → 2.42 ms (29%)**.
+
+8. **Benchmark harness** (`bench/`, `npm run bench`) covering GOAP, scalable
    blocks/Hanoi, HTN decomposition, and the multi-agent Scheduler.
 
 ### Profile, after
@@ -122,26 +130,69 @@ seed is O(1), precondition scanning is gone, and string/GC churn is eliminated:
   ~2.8-round dense sweep. Kept the round-based fixpoint; noted in code. (Expected
   to win once domains get large and sparse — IPC-scale.)
 
+## Where the time goes now, by scenario class
+
+Profiling sorts the scenarios into three regimes, each with a different next move:
+
+| Regime | Examples | Dominant cost (now) |
+|---|---|---|
+| Heuristic-bound GOAP | quarry, scavenger, staircase | `relaxCore` + `materialize` ≈ **57%** |
+| Predicate-bound GOAP | hanoi, csp | external/opaque eval (`fn`/`canMoveTo`/`slotOf`) |
+| Decomposition-bound HTN | tour, htn, scheduler | `seek`, `freeBindings`, agenda/cycle keys |
+
 ## Remaining opportunities (ranked)
 
-1. **Heuristic relevance pruning / landmarks.** `relaxCore` (~43%) still sweeps
-   all ground ops each round. Restricting to goal-relevant ops would help, but
-   naive relevance pruning changes h values — needs a sound refinement (e.g.
-   landmarks, or `h_FF` with a justification cut) validated against the
-   exact-optimal tests. Highest upside, highest care.
-2. **Per-ground-op precondition specialization.** For ops whose precondition is
-   *pure positive atoms*, the fast-reject already proves applicability — skip the
-   full precondition closure entirely. (Limited for the spatial/blocks domains,
-   whose preconditions carry comparisons/externals; broad for plain STRIPS.)
-3. **Cut child allocation in `goalSearch`.** Each candidate allocates a
-   `StateView` + delta `Map` before the closed/heuristic prune may reject it.
-   Lazily allocate the delta map, or compute the child hash and run the closed
-   check before committing the child.
-4. **`seek` plan assembly is O(n²)** (`[step, ...sub.steps]` per level). Doesn't
-   show in the GOAP profile (one decomposition) but matters for deep HTN; collect
-   into one array (or parent pointers) and reverse once.
-5. **Regression-gated CI** (SPEC §12): wire `npm run bench` into a `tinybench`
-   job that fails on >10% per-node regressions to lock these wins in.
+### A. Help most scenarios more
+
+1. **Incremental / landmark heuristic** — the real ceiling for the *slowest*
+   (spatial) domains, where `relaxCore` is ~50%. It is now allocation-free over a
+   flat buffer, so the only way down is algorithmic: reuse the parent's relaxed
+   graph across parent→child (incremental h_add), or a landmark-count heuristic.
+   Both **change h values**, so they must be validated against the exact-optimal
+   (`hmax`+`w=1`) tests — highest upside, highest care. *(A worklist variant was
+   tried and reverted — see above — because the graphs are small and dense.)*
+2. **Pure-atom precondition skip** — when an op's precondition is *exactly* a
+   conjunction of positive lits, the existing atom fast-reject already proves
+   applicability, so the full precondition closure can be skipped. Broad for
+   plain STRIPS (blocks/sokoban/HTN ops); nil for spatial domains whose
+   preconditions carry comparisons.
+3. **Cut child allocation in `goalSearch`** (~17%). Each candidate allocates a
+   `StateView`+delta `Map` and applies effects *before* the closed/heuristic
+   prune may discard it (~10k discarded children/solve on quarry). Compute the
+   child hash incrementally from the effect writes and run the `closed` check
+   *before* committing the child; pool the discarded `StateView`s.
+4. **`seek` plan assembly is O(n²)** (`[step, ...sub.steps]` per level) — matters
+   for deep HTN; collect once and reverse. **`freeBindings`** is cached but the
+   candidate `[...args, ...free]` arrays and `agendaSignature` cycle keys still
+   allocate per task expansion.
+
+### B. Opaque / external predicates specifically
+
+External (T2, *declared* reads) and opaque (T3, *no* declared reads) predicates
+share the `ExtQuery` machinery; the reusable query (landed) helps both. Further:
+
+1. **Fold & prune arg-only externals at grounding.** A T2 external with an
+   **empty read set** (e.g. `neq`) is a pure function of its arguments → constant
+   per ground op. Evaluate it once at grounding and **drop the ground ops where
+   it's false** (Hanoi: 27 → 18 `move` ops; blocks: all `x==to` ops) — they never
+   enter search or the successor index. Safe because the relaxation already
+   ignores externals, so dropping no-op/invalid groundings leaves h unchanged.
+2. **Memoize state-dependent T2 externals.** Because a T2 external's result is a
+   pure function of its *declared* read fluents + args, it can be cached keyed by
+   (predicate, args, read-fluent values) and invalidated by the existing dirty
+   tracking. Worth it for expensive predicates (`canMoveTo` scans all disks).
+   **Opaque (T3) cannot be memoized** — it declares nothing and may read the
+   outside world — but it still gets the reusable-query win, and should be
+   **ordered last** within a conjunction so cheaper symbolic lits reject first.
+3. **Precompiled fluent handles in `ExtQuery.get`.** User predicates call
+   `q.get("peg", d)`, re-resolving the fluent name every call. A
+   `q.handle("peg")` returning a closure that reads a fixed layout would remove
+   the per-call name lookup from hot predicates.
+
+### C. Lock it in
+
+**Regression-gated CI** (SPEC §12): wire `npm run bench` into a `tinybench` job
+that fails on >10% per-node regressions.
 
 ---
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,212 @@
+# Planner performance: analysis & proposal
+
+> Scope: the planning **core** (`src/search.ts`, `src/compile.ts`, `src/state.ts`)
+> — the hot path that `Planner.tick` / `planOnce` run every frame. Methodology,
+> findings, the one optimization landed in this change, and a ranked proposal for
+> the rest. Reproduce everything with `npm run bench`.
+
+## TL;DR
+
+- The runtime was **dominated by the delete-relaxation heuristic** (`hAdd`):
+  **~77% of CPU** on the heaviest workload (the quarry GOAP search), because it
+  rebuilt the relaxed planning graph from scratch on every state using
+  **per-atom string keys** in a `Map<string,number>`. A *single* quarry solve
+  allocated **~1.04 million transient strings**.
+- **Landed here:** rewrote the heuristic to run over **compile-time interned
+  integer atom ids** into a **reusable numeric buffer** — zero strings, zero
+  maps, zero allocation on the hot path. Same algorithm, **identical search**
+  (every expansion count and the exact-optimal-plan tests are unchanged).
+  **Result: 4–9.5× faster**, e.g. quarry **176 ms → 44 ms**.
+- **Proposed next (evidence below):** an **applicable-action index** so each
+  node expansion stops scanning *all* ground operators (now the #1 remaining
+  cost at ~35%), plus **grounding-time slot specialization** and a few
+  allocation cleanups. Estimated another **2–4×** on top.
+
+## How this was measured
+
+- `npm run bench` — wall-clock per solve **plus the engine's own counters**
+  (`decompositions` / `expansions` / `heuristicEvals`). The decisive metric is
+  **ms ÷ expansions = per-node cost**: a "real-time, frame-budget" planner lives
+  or dies on it.
+- `bench/profile.ts` under V8's `--cpu-prof`, parsed for self-time per function.
+- Scalable instances (blocks-world reverse-a-tower at N=4/5/6, Hanoi at
+  3/4/5 disks) to see how cost grows with the ground-operator count.
+
+## Baseline findings
+
+Per-solve, `main` before this change:
+
+| Workload | ms/iter | expansions | **µs / expansion** |
+|---|--:|--:|--:|
+| quarry (hmax, w=1, optimal) | 176.3 | 1524 | **~116** |
+| scavenger (hmax, w=1) | 14.1 | 110 | ~128 |
+| hanoi 5 (w=1) | 6.72 | 185 | ~36 |
+| blocks reverse 6 (w=1) | 4.14 | 7 | — |
+
+**~116 µs per node** for a planner that advertises "plans in microseconds." A
+16 ms frame budget would be blown by a single moderate problem, and a
+`Scheduler` of agents far sooner.
+
+### The smoking gun
+
+CPU profile of the quarry search (80 iters, self-time):
+
+| Function | Self |
+|---|--:|
+| `hAdd` (`search.ts`) | **49.3%** |
+| `(anon)` (`search.ts`) — `hAdd`'s inner closures / `atomKey` | **19.0%** |
+| `heuristic` (memo wrapper) | **8.7%** |
+| garbage collector | 3.8% |
+| `goalSearch` + compiled-formula closures (`compile.ts`) | ~13% |
+
+So **~77% of all CPU was the heuristic.** Instrumenting one quarry solve:
+
+```
+groundOps: 136
+hAdd calls: 1482        (one per distinct generated state; memoized by state hash)
+fixpoint rounds: 4194   => avg 2.8 rounds/call   (the 64-round cap is irrelevant)
+ground-op iterations inside hAdd: 570,384
+atomKey string allocations: 1,039,833   ← ~1.04M throwaway strings per solve
+```
+
+Root cause (was `src/search.ts`):
+
+- `hAdd` recomputed the full relaxed planning graph for **every** state.
+- Every atom touch built a string key `` `${slot}:${value}` `` and hit a
+  `Map<string,number>` — ~1M times per solve. That string churn (and its GC)
+  *was* the cost; the fixpoint itself is only ~2.8 rounds.
+
+### Why some domains barely moved
+
+Hanoi got the **smallest** win (1.9×). Its `move` precondition uses an **opaque**
+`canMoveTo` predicate, which the relaxation skips — so Hanoi's per-node cost is
+**precondition evaluation**, not the heuristic. That's the tell for the
+*next* bottleneck (below).
+
+## What landed in this change
+
+Rewrote the heuristic to be allocation-free while preserving the exact algorithm
+(`src/compile.ts` + `src/search.ts`):
+
+1. **Compile-time atom interning** (`Model.buildRelaxTables`, in
+   `groundOperators()`). Every distinct `(slot,value)` atom appearing in any
+   ground op's pre/add sets gets a dense integer id. Emitted once:
+   - `relaxAtomSlot` / `relaxAtomValue` / `relaxAtomFuzzy` (typed arrays), and
+   - per-ground-op `preIds` / `addIds` (`Int32Array`).
+2. **`relaxCore`** runs h_add / h_max over those typed arrays into a **reusable
+   `Float64Array` cost buffer** held by the `Engine` — no strings, no maps, no
+   per-call allocation. Goal atoms are resolved to ids **once per search**, not
+   per node. Novelty tie-breaking switched from a `Set<string>` to a
+   `Set<number>` of interned ids.
+3. The public `hAdd(model, s, goalAtoms, mode)` export keeps its signature
+   (builds descriptors + a scratch buffer per call).
+
+Semantics are intentionally identical — the fuzzy-atom optimism, the
+`missing===0` early-out, and h_add-vs-h_max combination all match the original,
+which is why **all 80 tests pass unchanged**, including the ones that assert
+*exact optimal* plan lengths/costs under `hmax` + `weight: 1`.
+
+### Result
+
+| Workload | before | after | speedup |
+|---|--:|--:|--:|
+| quarry (hmax, w=1, optimal) | 176.3 ms | **44.1 ms** | **4.0×** |
+| quarry (hadd, w=2, greedy) | 178.9 ms | **42.2 ms** | **4.2×** |
+| scavenger (hmax, w=1) | 14.1 ms | **2.62 ms** | **5.4×** |
+| staircase (hmax, w=1) | 0.78 ms | **0.35 ms** | 2.3× |
+| blocks reverse 5 (w=1) | 1.87 ms | **0.30 ms** | 6.3× |
+| blocks reverse 6 (w=1) | 4.14 ms | **0.44 ms** | **9.5×** |
+| hanoi 4 / 5 (w=1) | 1.73 / 6.72 ms | **0.91 / 3.62 ms** | 1.9× |
+
+Expansion counts are **identical** before/after (same search, faster nodes). The
+uvu suite went from ~707 ms to ~255 ms.
+
+## Proposal: the next wins (ranked)
+
+After the heuristic fix, the quarry profile re-balanced — proving where to go
+next:
+
+| Function | Self (after) | What it is |
+|---|--:|---|
+| `relaxCore` (`search.ts`) | 35.2% | the heuristic — still #1, but 4× cheaper |
+| **`(anon)` (`compile.ts`)** | **25.3%** | **compiled precondition closures** |
+| `dyn` (`compile.ts`) | 9.3% | dynamic lit compare in pre/eff |
+| `goalSearch` (`search.ts`) | 8.0% | A* loop / child creation |
+| `slotOf` (`compile.ts`) | 4.8% | slot computation from bindings |
+| `fn` / `fluent` (`compile.ts`) | 5.2% | more formula eval |
+
+### 1. Applicable-action indexing — biggest remaining win (~30–40% of CPU)
+
+**Problem.** `goalSearch` expands a node by looping over **every** ground
+operator and testing its precondition (`src/search.ts`, the `for (const g of
+model.groundOps)` loop). Quarry does `1524 expansions × 136 ground ops ≈ 207k`
+precondition evaluations, **the vast majority of which fail** — that is the
+`(anon) compile.ts` 25.3% + `dyn` 9.3%.
+
+**Fix.** A successor generator that only yields *plausibly applicable* ops:
+
+- Index ground ops by their precondition atoms: `consumersOf[atomId] → ops`.
+  Maintain, per state, a count of satisfied precondition atoms per op
+  (decrement/increment as atoms flip between parent and child) so only ops whose
+  symbolic preconditions hold are even considered — the classic
+  match-tree / counter-based successor generator the SPEC already calls for
+  (§5.4 "indexed successor generation", §12).
+- Cheaper intermediate step with most of the benefit: index by **one selective
+  precondition atom per op** (e.g. `agentAt(from)` / `on(x,from)`), and skip any
+  op whose selector doesn't currently hold. Ops with no indexable (all-external)
+  precondition fall back to "always consider," preserving correctness — this
+  also finally speeds up Hanoi.
+
+**Expected:** removes most of the ~35% precondition cost → roughly **1.5–2×**
+overall; compounding, quarry ≈ **25–30 ms**.
+
+### 2. Grounding-time slot specialization (`slotOf` 4.8% + part of the closures)
+
+For a **ground** op the operand slots are constant, yet the compiled
+`slot(b)` closures recompute them every evaluation via nested
+`indexInType.get(...).get(gid)` map lookups (`Model.slotOf`). Specialize each
+ground op's pre/eff evaluators against its fixed bindings at grounding time
+(precomputed slot constants), as SPEC §5.5 ("monomorphic evaluator
+specialization") anticipates. Removes `slotOf` from the hot path and shrinks the
+precondition-closure cost. **Expected:** ~1.1–1.2×, and it stacks with #1.
+
+### 3. Heuristic, round two (`relaxCore` still 35%)
+
+Two independent options, only if #1/#2 aren't enough:
+
+- **Inverted-index worklist** for the fixpoint (Dijkstra-style relaxation over
+  `consumersOf` from #1) instead of re-scanning all ops each round. With only
+  ~2.8 rounds the upside is modest here but grows with operator count.
+- **`h_max` reuse:** under `hmax`+`w=1` the heuristic is recomputed for states
+  that differ trivially; landmark/`h_max` caching keyed on the changed atoms
+  could amortize it. (Note: `hCache` is currently keyed by **state hash only**,
+  ignoring which goal is being searched — fine within one search, but a latent
+  correctness risk across multiple inline goals in one HTN agenda. Worth a
+  goal-id in the key when this area is next touched.)
+
+### 4. Allocation / micro cleanups (small here, real for HTN-heavy & multi-agent)
+
+These don't show up in the GOAP-dominated quarry profile but matter for
+decomposition-heavy and `Scheduler` workloads:
+
+- **`Engine.expandTask` recomputes `model.freeBindings(method)` every
+  expansion** — re-enumerates and allocates binding arrays each time. Cache per
+  compiled method at compile time (free-param types are fixed).
+- **`seek` builds plans with `[step, ...sub.steps]` at every recursion level** —
+  O(n²) in plan length. Collect into one array (or parent pointers) and reverse
+  once.
+- **`Heap` swaps via array destructuring** `[a[i],a[p]] = [a[p],a[i]]`, which
+  allocates a 2-element array per swap. Use a temp local.
+- **`agendaSignature` builds a string per task expansion** for cycle detection;
+  a structural/numeric key avoids the allocation.
+
+### 5. Worth having regardless: regression gating
+
+The SPEC asks for benchmark-gated CI (§12). `npm run bench` is the start; wiring
+a small `tinybench` job that fails on >10% per-node regressions would lock in
+these wins.
+
+---
+
+*Reproduce:* `npm run bench` (numbers above: Node 22, single run; absolute ms
+vary by machine, ratios are stable).

--- a/PLAN-web-demo-and-block-stacking.md
+++ b/PLAN-web-demo-and-block-stacking.md
@@ -1,0 +1,262 @@
+# Plan: Web App Preview + 3D Block-Stacking Battle-Test
+
+> Status: **Proposal for review.** Produced from analysis of this repo (htn-ai v2) and the
+> external [`Glavin001/vibe-city`](https://github.com/Glavin001/vibe-city) repo on both `main`
+> and `feat/htn-block-stacking`. Covers tasks 3–4: *what scenarios to add to core tests* and
+> *what the web app should look like*. Nothing here is built yet; this is the design + phasing.
+
+## 0. TL;DR
+
+1. **Block-stacking battle-test (task 3):** add two tiers of scenarios that hit the planner's
+   biggest *untested* seams — (A) a richer **symbolic Blocks World** run through the reactive
+   `Planner` with **repair** and **multi-agent** variants, and (B) a **spatial "Staircase World"**
+   where positions, reachability, and build-order are discovered *by search* (not hand-rolled).
+2. **Web app preview (task 4):** a lightweight **Vite + React + react-three-fiber** demo app under
+   `examples/web/`, reusing vibe-city's visualization blueprint but driven by htn-ai v2's
+   **`TraceEvent` stream** + **deterministic replay** to deliver the **devtools inspector** the
+   ROADMAP already calls for (live decomposition graph, why-rejected, world-state diff,
+   time-travel scrubber). The core library stays zero-dependency and untouched.
+
+Both directly advance milestones already in `ROADMAP.md`/`SPEC.md`: **M-2 "the demo that markets
+itself"** (§205) and **M5 devtools inspector** (§187–189).
+
+---
+
+## 1. What the analysis established
+
+### 1.1 htn-ai v2 (this repo) — capabilities & gaps
+- **Browser-ready core:** pure ESM, **zero runtime dependencies**, no `node:*` imports. `tsup`
+  already emits `esm`/`cjs`/**`iife`** (`globalName: HtnAI`) + a `unpkg` entry. A web app can
+  import it directly (built package or a Vite path-alias to `src/index.ts`).
+- **Rich API surface:** typed fluents (`boolean|enum|int|float|entity|vec2|vec3`), lifted
+  operators (`pre`/`verify`/`eff`/`cost`/`duration`/`executor`), HTN methods & compounds, **axioms**
+  (derived predicates), goals (`task()` / `achieve()`), **scopes** (`deadline`/`maintain`/
+  `minHold`/`onExit`), budgeted/anytime/resumable `Planner.tick({ms})`, **suffix plan repair**,
+  **MTR replan-if-better**, a multi-agent **`Scheduler`**, and a **`TraceEvent`** observability
+  stream (`plan.*`, `step.*`, `scope.*`, `repair.*`, `replan.dirty`, `drift`).
+- **Deterministic:** seeded RNG (`createRng`) + injected `now()` ⇒ byte-identical replays — the
+  foundation for a time-travel inspector.
+- **Coverage gaps (the battle-test targets):**
+  - **Spatial/vector reasoning is the biggest gap.** `vec2`/`vec3` and `N.dist` exist but are only
+    smoke-tested — *no test lets geometry drive a precondition, cost, or heuristic.*
+  - **Blocks World is minimal** (3 blocks, relational `on`/`clear`, `planOnce` only) — never scaled,
+    never executed through a `Planner`, never repaired.
+  - **Multi-agent coordination is untested** — the `Scheduler` only runs *independent* agents; no
+    shared/contended world state, handoffs, or one agent invalidating another's plan.
+  - Thinner spots: relaxation quality on numeric/external conditions, `weight` tuning, deep nested
+    scopes × repair interaction.
+
+### 1.2 vibe-city `main` — reusable visualization blueprint
+- Ships **three** "bunker" demos over one scenario: `/bunker-htnai` (**htn-ai v1**, *not* our v2 API),
+  `/bunker-fluid` (FluidHTN C#→WASM), `/bunker` (mahler).
+- **Reuse the viz, not the domain code** (v1 ≠ v2 API). Directly transferable patterns:
+  - **Plan-then-animate** loop: plan once → iterate a token plan (`MOVE x`, `PICKUP_KEY`…) → `await`
+    one animation per step → flip world facts → React re-renders.
+  - **Controlled goal/initial-state editor** panel, **"Current State" fact HUD** (green/red booleans),
+    **in-scene plan overlay** (drei `<Line>` route + numbered label sprites), **node→Vec3 map**
+    bridging symbolic state to 3D, **auto-run on edit**.
+  - Stack: Next.js App Router, `@react-three/fiber@9`, `@react-three/drei@10`, `three@0.18x`,
+    Tailwind v4.
+- **Drop:** the WASM/Docker toolchain, the 3× duplicated ~600-line pages (→ one page + a pluggable
+  `planFn`), and all Rapier/CSG/navmesh/AI-SDK weight (none needed for planning viz).
+
+### 1.3 vibe-city `feat/htn-block-stacking` — the cautionary tale
+- "**Navcat Block Stacker**": an agent builds a **staircase** on an 8×8 grid to climb a goal tower.
+  Imports `htn-ai` v1 **but bypasses real HTN** — the winning method is a single `planonly` effect
+  wrapping a hand-rolled **greedy frontier-filling loop**; world state is a bare `grid[x][z]`
+  height-map (no block identities), navigation is `navcat`/recast navmesh.
+- **The tell:** a literal `// TODO(backtracking): enable this when the planner supports multi-step
+  lookahead/backtracking`. They hit the planner's limits and routed around it.
+- **Two genuinely-hard ingredients worth keeping:** (a) **state-dependent reachability** — every
+  pick/place changes what's walkable; (b) the physical **"must build support before you can stand/
+  place higher"** ordering constraint.
+- **Lesson for us:** model the world *natively* (real block identities, `on`/`clear`, conjunctive
+  goal, reachability as a planner-visible derived fact) and let **search/decomposition discover the
+  build order** — exactly the thing that battle-tests a planner.
+
+---
+
+## 2. Task 3 — Block-stacking battle-test scenarios
+
+Goal: add scenarios that force the planner through its untested seams, each asserted against
+ground-truth optima in the existing `uvu` style (cf. `tests/puzzles.ts`), and at least one runnable
+through the reactive `Planner` so the web app can visualize it. Proposed as **two tiers**.
+
+### Tier A — "Blocks World+" (symbolic; scales the classic)
+Extends the existing 3-block test (`tests/puzzles.ts`) along three axes. Pure relational
+(`on`/`clear`/`holding`/`handEmpty`) so optima are known and assertions are crisp.
+
+1. **Sussman anomaly (the canonical reorder trap).** Start `C on A`, `A`/`B` on table; goal
+   `A on B on C`. Naive subgoal order deadlocks; optimal is 3 moves. Verifies the search interleaves
+   subgoals correctly (delete-relaxation heuristic behavior on a known hard instance).
+2. **Scale the tower (search/heuristic stress).** Parameterized N-block instances (4/6/8 blocks,
+   e.g. full reversal of a stack) asserting optimal move counts and bounded node expansions —
+   exercises heuristic informativeness and the grounding-explosion guard.
+3. **Reactive execution + repair (the headline gap).** Run a build through `new Planner(model, …)`
+   with executors instead of `planOnce`, then **perturb mid-plan**: an executor for `place` flips a
+   `slipped` fluent (the block falls back to the table). Assert the planner emits `step.fail` →
+   `repair.attempt`/`repair.success` and still reaches the goal — the first test of **suffix repair
+   on a stacking domain**.
+4. **Two-arm multi-agent (coordination gap).** Two arms share one table (shared `ExecState`/
+   contended `clear`/`holding` fluents) driven by the `Scheduler`. Assert both make progress without
+   trampling each other (one arm's effect invalidating the other's plan → cross-agent replan). First
+   test of the `Scheduler` over **shared, contended state**.
+
+*Domain sketch (matches the verified v2 idiom in `tests/puzzles.ts`):*
+```ts
+// on(b) : entity (0/table), clear(b) : boolean, holding : entity, handEmpty : boolean
+operators: [
+  { name: "pick",    params: [{name:"x",type:"block"}],
+    pre: F.and(F.lit("handEmpty",[],true), F.lit("clear",["?x"]), F.lit("on",["?x"],0)),
+    eff: [E.set("holding",[], "?x"), E.set("handEmpty",[],false), E.set("clear",["?x"],false)] },
+  { name: "stack",   params: [{name:"x",type:"block"},{name:"to",type:"block"}],
+    pre: F.and(F.lit("holding",[],"?x"), F.lit("clear",["?to"]), F.ext("neq",["?x","?to"],[])),
+    eff: [E.set("on",["?x"],"?to"), E.set("clear",["?to"],false), E.set("clear",["?x"],true),
+          E.set("handEmpty",[],true), E.set("holding",[],0)] },
+  // … unstack / put-down symmetric
+]
+```
+
+### Tier B — "Staircase World" (spatial; the 3D headline scenario)
+A native-HTN reimagining of the Navcat demo. The world is a small grid; the agent must **build a
+staircase out of supply blocks to climb onto a goal tower** — but *order and navigation are
+discovered by the planner*, not scripted. This is the scenario the web app renders in 3D.
+
+**Why it battle-tests the planner (one scenario, many untested seams):**
+- **Spatial cost/heuristic:** movement cost via `N.dist` over `vec2`/`vec3` cell positions — first
+  test where **geometry drives the search**.
+- **State-dependent reachability:** `height(cell)` is an `int` fluent that operators mutate; whether
+  the agent can step `from→to` depends on `|height(to) − agentLevel| ≤ 1`. Placing a block *creates*
+  new reachable cells — modeled as a **planner-visible precondition/axiom**, not a hidden navmesh
+  rebuild. This is the genuinely-hard property the Navcat demo had but hid.
+- **Ordering constraint:** you can't stand at level 3 until the level-2 step exists ⇒ the build order
+  *emerges* from preconditions (the `TODO(backtracking)` the v1 demo punted on).
+- **Resource accounting:** finite `supply(cell)` crates; the planner must allocate and may exhaust a
+  crate and pick another.
+- **Decomposition + reactive execution:** HTN methods for `BuildColumnTo`/`AcquireBlock`/`ReachGoalTop`,
+  run through the `Planner` with `duration`s so the web app gets a real timeline; optional `deadline`
+  scope makes it a temporal test too.
+
+*Design choices to keep it tractable & deterministic:*
+- Grid as `cell` entities with a static `adj(cell,cell)` table (relational adjacency, like existing
+  tests) **plus** a `pos(cell):vec2` fluent so `N.dist` can drive movement cost — gets spatial
+  reasoning into the loop without full geometric pathfinding.
+- Reachability/"climbable" expressed as an **axiom** over `height` + `adj` (derived, re-evaluated as
+  heights change) — exercises the axiom system, which only `tests/core.ts` lightly touches.
+- Keep the first instance small (≈5×5, 3–4 stair steps, 2–3 supply crates) with a known optimal
+  step/cost count for assertions; scale up as a perf/anytime case.
+
+**Goal:** conjunction `height(step_i)=target_i ∀i  ∧  agentAt(goalTop) ∧ agentLevel=GOAL_HEIGHT`.
+
+### Where the code lives
+- Battle-tests: new `tests/blocks.ts` (Tier A) and `tests/spatial.ts` (Tier B), `uvu`-style,
+  asserted against optima — they run in CI (`npm test`) like the other suites.
+- **Shared scenario definitions** (so the web app and tests don't drift): a small
+  `scenarios/` module (plain TS, imports only `htn-ai` types) exporting each `DomainDoc` +
+  `WorldSetup` + `Registry` + the goal. Tests import it for assertions; the web app imports it for
+  visualization. *(Alternative: keep domains inline in tests and re-export; decision in §4.)*
+
+---
+
+## 3. Task 4 — Web app preview
+
+A demo that **shows what v2 can do that v1/competitors can't**: budgeted planning, repair,
+replan-if-better, scopes/deadlines, multi-agent, and an auditable trace — visualized live.
+
+### 3.1 Placement & stack (keep the core clean)
+- New top-level **`examples/web/`** with its **own `package.json`** — *not* part of the library's
+  build/test/CI, so the published `htn-ai` package stays zero-dependency.
+- **Vite + React + TypeScript + react-three-fiber + drei + Tailwind.** Vite (not Next.js) because
+  there's no SSR need, it's lighter, has instant HMR, and deploys to **GitHub Pages** trivially for a
+  public preview. (Next.js is the vibe-city choice; we don't need its weight here.)
+- Consume the library via a **Vite alias `htn-ai → ../../src/index.ts`** in dev (instant HMR when the
+  library changes) with a switch to the built package for the deployed build.
+- Optional: wire as an npm **workspace** so `examples/web` resolves `htn-ai` from the repo root
+  without publishing. (Adds a root `package.json` `workspaces` field; low risk, keeps CI green since
+  the web app isn't in the root test/build scripts.)
+
+### 3.2 The three panels (maps to ROADMAP M-2 demo + M5 inspector)
+1. **3D World view** (`@react-three/fiber`): renders the active scenario — Staircase World as the
+   flagship (grid, supply crates, goal tower, agent, carried block, growing staircase), plus simpler
+   ones (Blocks World as stacked cubes, Gripper, Bunker). Reuses vibe-city's **node→Vec3 map**,
+   **in-scene plan overlay** (`<Line>` route + numbered step labels), and **plan-then-animate**
+   playback for clarity.
+2. **Inspector** (the differentiator — fed by the `TraceEvent` stream):
+   - **Live decomposition graph** — HTN method/compound tree with the active branch highlighted
+     (React Flow + dagre/elkjs), per ROADMAP §187.
+   - **World-state fluent HUD** with type-aware rendering and **diff-on-change** highlighting.
+   - **Plan timeline** — steps with projected ETAs from `duration`s, current step + scope deadlines
+     marked; shows budgeted/anytime progress.
+   - **Trace log** — color-coded `plan.*`/`step.*`/`scope.violated`/`repair.*`/`replan.dirty`.
+   - **"Why rejected?"** — surfaced via `explainFailure`/`validatePlan` (the LLM-facing APIs).
+   - **Time-travel scrubber** — record the trace, scrub back/forth; deterministic (seed + injected
+     clock) so replays are exact. Answers ROADMAP's bar: *"why didn't the agent do X?" from the
+     inspector alone.*
+3. **Controls:** scenario picker, goal/initial-state editor (vibe-city's controlled-panel pattern),
+   **play/pause/step**, speed, a **planning-budget slider** (visibly demonstrate `tick({ms})`
+   resuming search across frames), seed, and **perturbation buttons** (inject a block "slip" / jam a
+   path → watch **repair** vs **replan** live), reset.
+
+### 3.3 How it drives the planner
+Two modes, both off the same scenario definitions:
+- **Playback mode** (simple, vibe-city-style): `planOnce` → animate the token plan. Best for first
+  impression and the plan overlay.
+- **Live mode** (the showcase): drive `planner.tick({ ms: budget })` from `useFrame` with an injected
+  clock; subscribe `trace:` to feed the inspector. This is what makes repair/replan/scopes/multi-agent
+  legible — none of which the vibe-city demos show.
+
+### 3.4 Phasing
+- **Phase 1 — MVP (proves it runs in-browser):** Vite scaffold + alias; Staircase World in 3D;
+  plan-then-animate playback; fluent HUD; plan list; scenario picker. Reuses the vibe-city blueprint
+  almost verbatim.
+- **Phase 2 — Inspector:** trace log + plan timeline + world-state diff + decomposition graph +
+  time-travel scrubber; switch the flagship to **live `tick` mode**.
+- **Phase 3 — Showcase & deploy:** budget slider, perturbation→repair demo, two-arm multi-agent via
+  `Scheduler`, more scenarios (Blocks World+, Gripper, Bunker), deploy to GitHub Pages. This is the
+  artifact for ROADMAP's "demo that markets itself."
+
+### 3.5 Relationship to the roadmap's package plan
+The inspector here is the prototype of the planned **`@htn-ai/devtools`**, and the React glue is the
+seed of **`@htn-ai/react`** (ROADMAP §228, SPEC §349). Building it in `examples/web/` first lets us
+extract those packages later without committing to the monorepo split now.
+
+---
+
+## 4. Open decisions (need your call)
+
+1. **Session scope:** is this session *plan-only* (this doc), or should I proceed to **implement**
+   (Tier-A tests first, then scaffold Phase-1 web app)?
+2. **Web framework:** **Vite** (recommended — light, HMR, GH Pages) vs **Next.js** (matches
+   vibe-city, heavier).
+3. **Shared scenarios:** factor domains into a `scenarios/` module shared by tests + web app
+   (DRY, recommended) vs keep them inline in tests and re-declare in the app.
+4. **Block-stacking emphasis:** lead with **Tier B Staircase World** (spatial, most visual, biggest
+   gap) or land **Tier A Blocks World+** first (smaller, pure-symbolic, fastest to ground-truth)?
+   Recommendation: **Tier A first** (quick CI-backed wins), **Tier B** as the web-app flagship.
+
+---
+
+## 5. Suggested file layout
+
+```
+HTN-AI/
+├─ src/…                         # unchanged, zero-dep core
+├─ scenarios/                    # NEW (optional): shared DomainDocs (blocks, staircase, …)
+├─ tests/
+│  ├─ blocks.ts                  # NEW: Tier A — Sussman, scale, repair, multi-agent
+│  └─ spatial.ts                 # NEW: Tier B — Staircase World, vec/dist, reachability axiom
+└─ examples/
+   └─ web/                       # NEW: Vite + React + r3f demo (own package.json)
+      ├─ src/scenes/             # 3D scenes per scenario
+      ├─ src/inspector/          # trace log, timeline, decomposition graph, scrubber
+      └─ vite.config.ts          # alias htn-ai → ../../src/index.ts
+```
+
+---
+
+## 6. Immediate next steps (on approval)
+1. Land **Tier A** `tests/blocks.ts` (Sussman + scale + repair + two-arm) — fast, CI-backed.
+2. Author **Staircase World** `DomainDoc` in `scenarios/`, prove optimal plan via `planOnce` in
+   `tests/spatial.ts`, then run it through `Planner` with executors.
+3. Scaffold **`examples/web/`** Phase 1 (3D Staircase + playback + HUD).
+4. Layer in the **inspector** (Phase 2) off the `TraceEvent` stream.

--- a/PLAN-web-demo-and-block-stacking.md
+++ b/PLAN-web-demo-and-block-stacking.md
@@ -1,9 +1,15 @@
 # Plan: Web App Preview + 3D Block-Stacking Battle-Test
 
-> Status: **Proposal for review.** Produced from analysis of this repo (htn-ai v2) and the
-> external [`Glavin001/vibe-city`](https://github.com/Glavin001/vibe-city) repo on both `main`
-> and `feat/htn-block-stacking`. Covers tasks 3–4: *what scenarios to add to core tests* and
-> *what the web app should look like*. Nothing here is built yet; this is the design + phasing.
+> Status: **Implemented on this branch.** Produced from analysis of this repo (htn-ai v2) and
+> the external [`Glavin001/vibe-city`](https://github.com/Glavin001/vibe-city) repo on both
+> `main` and `feat/htn-block-stacking`. Covers tasks 3–4: *what scenarios to add to core tests*
+> and *what the web app should look like*.
+>
+> **Shipped:** `scenarios/` (shared blocks + staircase domains), Tier A tests (`tests/blocks.ts`)
+> and Tier B tests (`tests/spatial.ts`) — suite now 67 tests — and the web preview
+> (`examples/web/`, Next.js static export + react-three-fiber). The block-stacking **goal was
+> refined to be a pure 3D position** (see §2 Tier B): the planner must *discover* it has to build
+> a staircase; the goal never prescribes block placement or any structure.
 
 ## 0. TL;DR
 
@@ -146,7 +152,13 @@ discovered by the planner*, not scripted. This is the scenario the web app rende
 - Keep the first instance small (≈5×5, 3–4 stair steps, 2–3 supply crates) with a known optimal
   step/cost count for assertions; scale up as a perf/anytime case.
 
-**Goal:** conjunction `height(step_i)=target_i ∀i  ∧  agentAt(goalTop) ∧ agentLevel=GOAL_HEIGHT`.
+**Goal (position-only — the planner discovers the "how"):** the goal is purely a **3D position** —
+`agentAt = targetCell ∧ agentY = TARGET_Y` (be at the target's x,z, up in the air at elevation
+TARGET_Y). It deliberately does **not** mention block placement or any column height. Because the
+only way to raise `agentY` is to stand on a column, and the only way to build higher is to first
+stand higher, the staircase + its build order *emerge from search*. (The shipped domain expresses
+the climb/place constraints as operator preconditions over `height`; reachability is local
+adjacency + a one-level climb limit rather than a transitive-path axiom, which keeps it tractable.)
 
 ### Where the code lives
 - Battle-tests: new `tests/blocks.ts` (Tier A) and `tests/spatial.ts` (Tier B), `uvu`-style,

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,25 +1,42 @@
 # Benchmarks
 
-Micro-benchmarks for the planning core. Run with:
-
 ```bash
-npm run bench
+npm run bench          # representative set, robust stats
+npm run bench:scale    # scaling sweeps across axes
+# lowest noise: prefix either with NODE_OPTIONS=--expose-gc
 ```
 
-- `bench.ts` — wall-clock + engine counters (decompositions / expansions /
-  heuristicEvals) across the heaviest GOAP/HTN workloads, including
-  scalable blocks-world and Towers-of-Hanoi instances. The
-  `ms/iter ÷ expansions` ratio is the headline number: it is the *per-node*
-  cost, which is what determines whether a domain fits a frame budget.
-- `profile.ts` — focused driver for the quarry search, for use under a CPU
-  profiler:
+## Methodology (signal over noise)
 
-  ```bash
-  NODE_OPTIONS="--cpu-prof --cpu-prof-dir=/tmp/prof --cpu-prof-interval=200" \
-    ITERS=300 npx tsx --tsconfig tsconfig.tests.json bench/profile.ts
-  ```
+`measure()` in `workloads.ts`:
 
-  (tsx runs the workload in a worker thread, so pick the largest
-  `.cpuprofile` — the others are the loader/main process.)
+- **warms up** so the JIT has settled before timing;
+- **auto-calibrates** the inner loop so each timed trial runs ≳ `targetMs`
+  (timer resolution & per-batch overhead become negligible);
+- runs **several independent trials** and reports the **min ms/iter** as the
+  headline — all interference (GC, scheduler preemption, CPU-freq dips) only
+  *adds* time, so the minimum is the sample least contaminated by it;
+- also prints **median** and **spread% = (median−min)/min** so the noise is
+  visible rather than hidden (tiny sub-0.1 ms workloads show large spread —
+  trust the min);
+- calls `global.gc()` between trials when run with `--expose-gc`, so GC pauses
+  fall outside the timed window.
 
-See [`../PERFORMANCE.md`](../PERFORMANCE.md) for the analysis these drive.
+The number that matters for a frame budget is **µs/node = min ÷ expansions** —
+per-node cost, independent of problem size.
+
+## Files
+
+- `workloads.ts` — shared, parametric workload builders + `measure()`.
+- `bench.ts` — representative set with min/median/spread/µs-node columns.
+- `scale.ts` — sweeps each workload along one axis (`×prev` = growth factor of
+  min-ms vs the previous size, so super-linear scaling is obvious):
+  - **hanoi disks** — exponential search depth + external predicate per node
+  - **blocks** — grounding O(n³) + state size, shallow search
+  - **nav grid** — relational adjacency: candidates/node grow with cells
+  - **htn tour** — HTN decomposition width (free-variable binding)
+  - **scheduler** — multi-agent round-robin
+  - **weight** — heuristic informativeness → expansions (fixed problem)
+- `profile.ts` — single-scenario driver for `--cpu-prof` (set `SCEN`, `ITERS`).
+
+See [`../PERFORMANCE.md`](../PERFORMANCE.md) for the analysis.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,25 @@
+# Benchmarks
+
+Micro-benchmarks for the planning core. Run with:
+
+```bash
+npm run bench
+```
+
+- `bench.ts` — wall-clock + engine counters (decompositions / expansions /
+  heuristicEvals) across the heaviest GOAP/HTN workloads, including
+  scalable blocks-world and Towers-of-Hanoi instances. The
+  `ms/iter ÷ expansions` ratio is the headline number: it is the *per-node*
+  cost, which is what determines whether a domain fits a frame budget.
+- `profile.ts` — focused driver for the quarry search, for use under a CPU
+  profiler:
+
+  ```bash
+  NODE_OPTIONS="--cpu-prof --cpu-prof-dir=/tmp/prof --cpu-prof-interval=200" \
+    ITERS=300 npx tsx --tsconfig tsconfig.tests.json bench/profile.ts
+  ```
+
+  (tsx runs the workload in a worker thread, so pick the largest
+  `.cpuprofile` — the others are the loader/main process.)
+
+See [`../PERFORMANCE.md`](../PERFORMANCE.md) for the analysis these drive.

--- a/bench/README.md
+++ b/bench/README.md
@@ -37,6 +37,8 @@ per-node cost, independent of problem size.
   - **htn tour** — HTN decomposition width (free-variable binding)
   - **scheduler** — multi-agent round-robin
   - **weight** — heuristic informativeness → expansions (fixed problem)
+- `huge.ts` — the larger pushed Scavenger instances (XL 4×3, HUGE 6×4); a
+  before/after gauge for the heuristic/successor optimizations on big grids.
 - `profile.ts` — single-scenario driver for `--cpu-prof` (set `SCEN`, `ITERS`).
 
 See [`../PERFORMANCE.md`](../PERFORMANCE.md) for the analysis.

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -1,0 +1,208 @@
+/**
+ * Performance benchmark harness for the htn-ai planner.
+ *
+ * Exercises the heaviest GOAP / HTN workloads, repeats each to get a stable
+ * wall-clock, and reports the engine's own counters (decompositions /
+ * expansions / heuristicEvals) so we can see *where* the cost is and how it
+ * scales. Run: `tsx --tsconfig tsconfig.tests.json bench/bench.ts`.
+ */
+import { DomainDoc, E, F, N, createModel, goal, planOnce, scoped, achieve, task, type PlanResult } from "../src/index";
+import {
+  quarryInstance,
+  quarryGoal,
+  scavengerInstance,
+  scavengerGoal,
+  scavengerModel,
+  staircaseInstance,
+  staircaseGoal,
+  staircaseModel,
+} from "../scenarios/staircase";
+
+function bench(name: string, run: () => PlanResult, iters: number): void {
+  // warm up
+  let last = run();
+  for (let i = 0; i < 2; i++) last = run();
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) last = run();
+  const dt = performance.now() - t0;
+  const per = dt / iters;
+  const s = last.stats;
+  const status = last.status;
+  console.log(
+    `${name.padEnd(34)} ${per.toFixed(3).padStart(9)} ms/iter  ` +
+      `[${status.padEnd(7)}] ` +
+      `dec=${String(s.decompositions).padStart(7)} ` +
+      `exp=${String(s.expansions).padStart(7)} ` +
+      `hEval=${String(s.heuristicEvals).padStart(7)} ` +
+      `steps=${last.plan?.steps.length ?? 0}`,
+  );
+}
+
+// ---------------------------------------------------------------- blocks world (scalable)
+
+function blocksWorldDoc(): DomainDoc {
+  return {
+    name: "blocks",
+    types: [{ name: "block" }],
+    fluents: [
+      { name: "on", params: [{ name: "b", type: "block" }], kind: "entity", entityType: "block" },
+      { name: "clear", params: [{ name: "b", type: "block" }], kind: "boolean", initial: true },
+    ],
+    operators: [
+      {
+        name: "block_to_block",
+        params: [
+          { name: "x", type: "block" },
+          { name: "from", type: "block" },
+          { name: "to", type: "block" },
+        ],
+        pre: F.and(
+          F.lit("clear", ["?x"]),
+          F.lit("clear", ["?to"]),
+          F.lit("on", ["?x"], "?from"),
+          F.ext("neq", ["?x", "?to"], []),
+        ),
+        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?from"], true), E.set("clear", ["?to"], false)],
+      },
+      {
+        name: "block_to_table",
+        params: [
+          { name: "x", type: "block" },
+          { name: "from", type: "block" },
+        ],
+        pre: F.and(F.lit("clear", ["?x"]), F.lit("on", ["?x"], "?from")),
+        eff: [E.set("on", ["?x"], 0), E.set("clear", ["?from"], true)],
+      },
+      {
+        name: "table_to_block",
+        params: [
+          { name: "x", type: "block" },
+          { name: "to", type: "block" },
+        ],
+        pre: F.and(F.lit("clear", ["?x"]), F.lit("clear", ["?to"]), F.lit("on", ["?x"], 0), F.ext("neq", ["?x", "?to"], [])),
+        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?to"], false)],
+      },
+    ],
+  };
+}
+
+// Stack N blocks reversed: start a-on-b-on-c-...-on-table → goal reversed tower.
+function blocksReverse(n: number): () => PlanResult {
+  const names = Array.from({ length: n }, (_, i) => `b${i}`);
+  const doc = blocksWorldDoc();
+  const model = createModel(
+    doc,
+    {
+      entities: Object.fromEntries(names.map((nm) => [nm, "block"])),
+      init: (w) => {
+        // initial tower: b0 on b1 on ... on b{n-1} on table
+        for (let i = 0; i < n - 1; i++) {
+          w.set("on", [names[i]], names[i + 1]);
+          w.set("clear", [names[i + 1]], false);
+        }
+      },
+    },
+    { predicates: { neq: (q) => q.args[0] !== q.args[1] } },
+  );
+  // goal: reverse the tower → b{n-1} on b{n-2} ... on b0
+  const goalLits = [];
+  for (let i = n - 1; i > 0; i--) goalLits.push(F.lit("on", [names[i]], names[i - 1]));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
+}
+
+// ---------------------------------------------------------------- hanoi (scalable)
+
+function hanoi(nDisks: number): () => PlanResult {
+  const disks = Array.from({ length: nDisks }, (_, i) => `d${i + 1}`);
+  const doc: DomainDoc = {
+    name: "hanoi",
+    types: [{ name: "disk" }, { name: "peg" }],
+    fluents: [
+      { name: "peg", params: [{ name: "d", type: "disk" }], kind: "entity", entityType: "peg" },
+      { name: "size", params: [{ name: "d", type: "disk" }], kind: "int" },
+    ],
+    operators: [
+      {
+        name: "move",
+        params: [
+          { name: "d", type: "disk" },
+          { name: "from", type: "peg" },
+          { name: "to", type: "peg" },
+        ],
+        pre: F.and(
+          F.lit("peg", ["?d"], "?from"),
+          F.ext("neq", ["?from", "?to"], []),
+          F.ext("canMoveTo", ["?d", "?to"], ["peg", "size"]),
+        ),
+        eff: [E.set("peg", ["?d"], "?to")],
+      },
+    ],
+  };
+  const model = createModel(
+    doc,
+    {
+      entities: { ...Object.fromEntries(disks.map((d) => [d, "disk"])), p1: "peg", p2: "peg", p3: "peg" },
+      init: (w) => disks.forEach((d, i) => { w.set("peg", [d], "p1"); w.set("size", [d], i + 1); }),
+    },
+    {
+      predicates: {
+        neq: (q) => q.args[0] !== q.args[1],
+        canMoveTo: (q) => {
+          const [d, to] = q.args;
+          const dPeg = q.get("peg", d);
+          const dSize = q.get("size", d);
+          for (const other of disks) {
+            const og = q.gid(other);
+            if (og === d) continue;
+            if (q.get("size", og) < dSize) {
+              const oPeg = q.get("peg", og);
+              if (oPeg === dPeg || oPeg === to + 1) return false;
+            }
+          }
+          return true;
+        },
+      },
+    },
+  );
+  const goalLits = disks.map((d) => F.lit("peg", [d], "p3"));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
+}
+
+// ---------------------------------------------------------------- scenarios
+
+const quarry = (() => {
+  const model = staircaseModel(quarryInstance());
+  return () => planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
+})();
+
+const quarryGreedy = (() => {
+  const model = staircaseModel(quarryInstance());
+  return () => planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 2, heuristic: "hadd" });
+})();
+
+const scavenger = (() => {
+  const model = scavengerModel(scavengerInstance());
+  return () => planOnce(model, model.createExecState(), { goals: [goal(scavengerGoal())], weight: 1, heuristic: "hmax" });
+})();
+
+const staircase = (() => {
+  const model = staircaseModel(staircaseInstance());
+  return () => planOnce(model, model.createExecState(), { goals: [goal(staircaseGoal())], weight: 1, heuristic: "hmax" });
+})();
+
+// ---------------------------------------------------------------- run
+
+console.log("=".repeat(100));
+console.log("htn-ai planner benchmark");
+console.log("=".repeat(100));
+
+bench("quarry (hmax, w=1, optimal)", quarry, 200);
+bench("quarry (hadd, w=2, greedy)", quarryGreedy, 200);
+bench("scavenger (hmax, w=1)", scavenger, 200);
+bench("staircase (hmax, w=1)", staircase, 500);
+bench("blocks reverse 4 (w=1)", blocksReverse(4), 200);
+bench("blocks reverse 5 (w=1)", blocksReverse(5), 50);
+bench("blocks reverse 6 (w=1)", blocksReverse(6), 20);
+bench("hanoi 3 (w=1)", hanoi(3), 500);
+bench("hanoi 4 (w=1)", hanoi(4), 100);
+bench("hanoi 5 (w=1)", hanoi(5), 20);

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -6,7 +6,20 @@
  * expansions / heuristicEvals) so we can see *where* the cost is and how it
  * scales. Run: `tsx --tsconfig tsconfig.tests.json bench/bench.ts`.
  */
-import { DomainDoc, E, F, N, createModel, goal, planOnce, scoped, achieve, task, type PlanResult } from "../src/index";
+import {
+  DomainDoc,
+  E,
+  F,
+  N,
+  Planner,
+  Scheduler,
+  createModel,
+  doTask,
+  goal,
+  planOnce,
+  task,
+  type PlanResult,
+} from "../src/index";
 import {
   quarryInstance,
   quarryGoal,
@@ -168,6 +181,67 @@ function hanoi(nDisks: number): () => PlanResult {
   return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
 }
 
+// ---------------------------------------------------------------- HTN decomposition (free-variable methods)
+
+// "Tour": visit every location once. The recursive method `tour` has a free
+// parameter `next: loc`, so each expansion enumerates K bindings (most pruned by
+// the not-visited precondition) — stresses freeBindings, method-pre eval, deep
+// seek recursion, agenda cycle detection and MTR. Pure decomposition, no goal search.
+function htnTour(k: number): () => PlanResult {
+  const locs = Array.from({ length: k }, (_, i) => `l${i}`);
+  const doc: DomainDoc = {
+    name: "tour",
+    types: [{ name: "loc" }],
+    fluents: [{ name: "visited", params: [{ name: "l", type: "loc" }], kind: "boolean", initial: false }],
+    compounds: [{ name: "Tour" }],
+    operators: [
+      {
+        name: "visit",
+        params: [{ name: "l", type: "loc" }],
+        pre: F.not(F.lit("visited", ["?l"])),
+        eff: [E.set("visited", ["?l"], true)],
+      },
+    ],
+    methods: [
+      {
+        name: "more",
+        task: "Tour",
+        params: [{ name: "next", type: "loc" }],
+        pre: F.not(F.lit("visited", ["?next"])),
+        subtasks: [doTask("visit", "?next"), doTask("Tour")],
+      },
+      { name: "done", task: "Tour", subtasks: [] },
+    ],
+  };
+  const model = createModel(doc, { entities: Object.fromEntries(locs.map((l) => [l, "loc"])) });
+  return () => planOnce(model, model.createExecState(), { goals: [task("Tour")] });
+}
+
+// ---------------------------------------------------------------- multi-agent scheduler
+
+// M independent agents each solving the staircase, driven round-robin to
+// completion through the Scheduler — stresses staggered budgeted planning.
+function schedulerRun(m: number): () => PlanResult {
+  return () => {
+    const sched = new Scheduler();
+    const planners: Planner[] = [];
+    let t = 0;
+    for (let i = 0; i < m; i++) {
+      const model = staircaseModel(staircaseInstance());
+      const p = new Planner(model, { goals: [goal(staircaseGoal())], now: () => t, seed: i });
+      planners.push(p);
+      sched.add(p);
+    }
+    for (let i = 0; i < 2000 && planners.some((p) => p.getStatus() !== "succeeded" && p.getStatus() !== "failed"); i++) {
+      t += 1;
+      sched.tick(5);
+    }
+    // shape a PlanResult-ish summary for the harness
+    const done = planners.every((p) => p.getStatus() === "succeeded");
+    return { status: done ? "success" : "failure", stats: { decompositions: 0, expansions: 0, heuristicEvals: 0 } } as PlanResult;
+  };
+}
+
 // ---------------------------------------------------------------- scenarios
 
 const quarry = (() => {
@@ -206,3 +280,6 @@ bench("blocks reverse 6 (w=1)", blocksReverse(6), 20);
 bench("hanoi 3 (w=1)", hanoi(3), 500);
 bench("hanoi 4 (w=1)", hanoi(4), 100);
 bench("hanoi 5 (w=1)", hanoi(5), 20);
+bench("htn tour 8 (decomposition)", htnTour(8), 2000);
+bench("htn tour 16 (decomposition)", htnTour(16), 500);
+bench("scheduler x8 (staircase)", schedulerRun(8), 100);

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -16,6 +16,7 @@ import {
   navGrid,
   htnTour,
   schedulerRun,
+  scavengerGrid,
   staircaseModel,
   goal,
   planOnce,
@@ -54,5 +55,6 @@ printRow(measure("staircase (hmax,w=1)", staircase));
 printRow(measure("blocks reverse 6", blocksReverse(6)));
 printRow(measure("hanoi 5", hanoi(5)));
 printRow(measure("nav grid 6x6", navGrid(6)));
+printRow(measure("scavenger grid 4x3 (hadd)", scavengerGrid(4, 3)));
 printRow(measure("htn tour 16", htnTour(16)));
 printRow(measure("scheduler x8", schedulerRun(8)));

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -1,25 +1,26 @@
 /**
- * Performance benchmark harness for the htn-ai planner.
+ * Representative benchmark with robust statistics (min / median / spread%).
+ * Run: `npm run bench`  (add `NODE_OPTIONS=--expose-gc` for the lowest noise).
  *
- * Exercises the heaviest GOAP / HTN workloads, repeats each to get a stable
- * wall-clock, and reports the engine's own counters (decompositions /
- * expansions / heuristicEvals) so we can see *where* the cost is and how it
- * scales. Run: `tsx --tsconfig tsconfig.tests.json bench/bench.ts`.
+ * Headline is the MIN ms/iter over several trials — the sample least
+ * contaminated by GC / scheduler / CPU-freq noise. `spread%` = (median−min)/min
+ * shows how noisy the measurement was; `µs/node` = min ÷ expansions is the
+ * size-normalized cost (what a frame budget actually cares about).
  */
 import {
-  DomainDoc,
-  E,
-  F,
-  N,
-  Planner,
-  Scheduler,
-  createModel,
-  doTask,
+  measure,
+  printHeader,
+  printRow,
+  blocksReverse,
+  hanoi,
+  navGrid,
+  htnTour,
+  schedulerRun,
+  staircaseModel,
   goal,
   planOnce,
-  task,
-  type PlanResult,
-} from "../src/index";
+  type Run,
+} from "./workloads";
 import {
   quarryInstance,
   quarryGoal,
@@ -28,258 +29,30 @@ import {
   scavengerModel,
   staircaseInstance,
   staircaseGoal,
-  staircaseModel,
 } from "../scenarios/staircase";
 
-function bench(name: string, run: () => PlanResult, iters: number): void {
-  // warm up
-  let last = run();
-  for (let i = 0; i < 2; i++) last = run();
-  const t0 = performance.now();
-  for (let i = 0; i < iters; i++) last = run();
-  const dt = performance.now() - t0;
-  const per = dt / iters;
-  const s = last.stats;
-  const status = last.status;
-  console.log(
-    `${name.padEnd(34)} ${per.toFixed(3).padStart(9)} ms/iter  ` +
-      `[${status.padEnd(7)}] ` +
-      `dec=${String(s.decompositions).padStart(7)} ` +
-      `exp=${String(s.expansions).padStart(7)} ` +
-      `hEval=${String(s.heuristicEvals).padStart(7)} ` +
-      `steps=${last.plan?.steps.length ?? 0}`,
-  );
-}
-
-// ---------------------------------------------------------------- blocks world (scalable)
-
-function blocksWorldDoc(): DomainDoc {
-  return {
-    name: "blocks",
-    types: [{ name: "block" }],
-    fluents: [
-      { name: "on", params: [{ name: "b", type: "block" }], kind: "entity", entityType: "block" },
-      { name: "clear", params: [{ name: "b", type: "block" }], kind: "boolean", initial: true },
-    ],
-    operators: [
-      {
-        name: "block_to_block",
-        params: [
-          { name: "x", type: "block" },
-          { name: "from", type: "block" },
-          { name: "to", type: "block" },
-        ],
-        pre: F.and(
-          F.lit("clear", ["?x"]),
-          F.lit("clear", ["?to"]),
-          F.lit("on", ["?x"], "?from"),
-          F.ext("neq", ["?x", "?to"], []),
-        ),
-        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?from"], true), E.set("clear", ["?to"], false)],
-      },
-      {
-        name: "block_to_table",
-        params: [
-          { name: "x", type: "block" },
-          { name: "from", type: "block" },
-        ],
-        pre: F.and(F.lit("clear", ["?x"]), F.lit("on", ["?x"], "?from")),
-        eff: [E.set("on", ["?x"], 0), E.set("clear", ["?from"], true)],
-      },
-      {
-        name: "table_to_block",
-        params: [
-          { name: "x", type: "block" },
-          { name: "to", type: "block" },
-        ],
-        pre: F.and(F.lit("clear", ["?x"]), F.lit("clear", ["?to"]), F.lit("on", ["?x"], 0), F.ext("neq", ["?x", "?to"], [])),
-        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?to"], false)],
-      },
-    ],
-  };
-}
-
-// Stack N blocks reversed: start a-on-b-on-c-...-on-table → goal reversed tower.
-function blocksReverse(n: number): () => PlanResult {
-  const names = Array.from({ length: n }, (_, i) => `b${i}`);
-  const doc = blocksWorldDoc();
-  const model = createModel(
-    doc,
-    {
-      entities: Object.fromEntries(names.map((nm) => [nm, "block"])),
-      init: (w) => {
-        // initial tower: b0 on b1 on ... on b{n-1} on table
-        for (let i = 0; i < n - 1; i++) {
-          w.set("on", [names[i]], names[i + 1]);
-          w.set("clear", [names[i + 1]], false);
-        }
-      },
-    },
-    { predicates: { neq: (q) => q.args[0] !== q.args[1] } },
-  );
-  // goal: reverse the tower → b{n-1} on b{n-2} ... on b0
-  const goalLits = [];
-  for (let i = n - 1; i > 0; i--) goalLits.push(F.lit("on", [names[i]], names[i - 1]));
-  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
-}
-
-// ---------------------------------------------------------------- hanoi (scalable)
-
-function hanoi(nDisks: number): () => PlanResult {
-  const disks = Array.from({ length: nDisks }, (_, i) => `d${i + 1}`);
-  const doc: DomainDoc = {
-    name: "hanoi",
-    types: [{ name: "disk" }, { name: "peg" }],
-    fluents: [
-      { name: "peg", params: [{ name: "d", type: "disk" }], kind: "entity", entityType: "peg" },
-      { name: "size", params: [{ name: "d", type: "disk" }], kind: "int" },
-    ],
-    operators: [
-      {
-        name: "move",
-        params: [
-          { name: "d", type: "disk" },
-          { name: "from", type: "peg" },
-          { name: "to", type: "peg" },
-        ],
-        pre: F.and(
-          F.lit("peg", ["?d"], "?from"),
-          F.ext("neq", ["?from", "?to"], []),
-          F.ext("canMoveTo", ["?d", "?to"], ["peg", "size"]),
-        ),
-        eff: [E.set("peg", ["?d"], "?to")],
-      },
-    ],
-  };
-  const model = createModel(
-    doc,
-    {
-      entities: { ...Object.fromEntries(disks.map((d) => [d, "disk"])), p1: "peg", p2: "peg", p3: "peg" },
-      init: (w) => disks.forEach((d, i) => { w.set("peg", [d], "p1"); w.set("size", [d], i + 1); }),
-    },
-    {
-      predicates: {
-        neq: (q) => q.args[0] !== q.args[1],
-        canMoveTo: (q) => {
-          const [d, to] = q.args;
-          const dPeg = q.get("peg", d);
-          const dSize = q.get("size", d);
-          for (const other of disks) {
-            const og = q.gid(other);
-            if (og === d) continue;
-            if (q.get("size", og) < dSize) {
-              const oPeg = q.get("peg", og);
-              if (oPeg === dPeg || oPeg === to + 1) return false;
-            }
-          }
-          return true;
-        },
-      },
-    },
-  );
-  const goalLits = disks.map((d) => F.lit("peg", [d], "p3"));
-  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
-}
-
-// ---------------------------------------------------------------- HTN decomposition (free-variable methods)
-
-// "Tour": visit every location once. The recursive method `tour` has a free
-// parameter `next: loc`, so each expansion enumerates K bindings (most pruned by
-// the not-visited precondition) — stresses freeBindings, method-pre eval, deep
-// seek recursion, agenda cycle detection and MTR. Pure decomposition, no goal search.
-function htnTour(k: number): () => PlanResult {
-  const locs = Array.from({ length: k }, (_, i) => `l${i}`);
-  const doc: DomainDoc = {
-    name: "tour",
-    types: [{ name: "loc" }],
-    fluents: [{ name: "visited", params: [{ name: "l", type: "loc" }], kind: "boolean", initial: false }],
-    compounds: [{ name: "Tour" }],
-    operators: [
-      {
-        name: "visit",
-        params: [{ name: "l", type: "loc" }],
-        pre: F.not(F.lit("visited", ["?l"])),
-        eff: [E.set("visited", ["?l"], true)],
-      },
-    ],
-    methods: [
-      {
-        name: "more",
-        task: "Tour",
-        params: [{ name: "next", type: "loc" }],
-        pre: F.not(F.lit("visited", ["?next"])),
-        subtasks: [doTask("visit", "?next"), doTask("Tour")],
-      },
-      { name: "done", task: "Tour", subtasks: [] },
-    ],
-  };
-  const model = createModel(doc, { entities: Object.fromEntries(locs.map((l) => [l, "loc"])) });
-  return () => planOnce(model, model.createExecState(), { goals: [task("Tour")] });
-}
-
-// ---------------------------------------------------------------- multi-agent scheduler
-
-// M independent agents each solving the staircase, driven round-robin to
-// completion through the Scheduler — stresses staggered budgeted planning.
-function schedulerRun(m: number): () => PlanResult {
-  return () => {
-    const sched = new Scheduler();
-    const planners: Planner[] = [];
-    let t = 0;
-    for (let i = 0; i < m; i++) {
-      const model = staircaseModel(staircaseInstance());
-      const p = new Planner(model, { goals: [goal(staircaseGoal())], now: () => t, seed: i });
-      planners.push(p);
-      sched.add(p);
-    }
-    for (let i = 0; i < 2000 && planners.some((p) => p.getStatus() !== "succeeded" && p.getStatus() !== "failed"); i++) {
-      t += 1;
-      sched.tick(5);
-    }
-    // shape a PlanResult-ish summary for the harness
-    const done = planners.every((p) => p.getStatus() === "succeeded");
-    return { status: done ? "success" : "failure", stats: { decompositions: 0, expansions: 0, heuristicEvals: 0 } } as PlanResult;
-  };
-}
-
-// ---------------------------------------------------------------- scenarios
-
-const quarry = (() => {
+const quarry: Run = (() => {
   const model = staircaseModel(quarryInstance());
   return () => planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
 })();
-
-const quarryGreedy = (() => {
-  const model = staircaseModel(quarryInstance());
-  return () => planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 2, heuristic: "hadd" });
-})();
-
-const scavenger = (() => {
+const scavenger: Run = (() => {
   const model = scavengerModel(scavengerInstance());
   return () => planOnce(model, model.createExecState(), { goals: [goal(scavengerGoal())], weight: 1, heuristic: "hmax" });
 })();
-
-const staircase = (() => {
+const staircase: Run = (() => {
   const model = staircaseModel(staircaseInstance());
   return () => planOnce(model, model.createExecState(), { goals: [goal(staircaseGoal())], weight: 1, heuristic: "hmax" });
 })();
 
-// ---------------------------------------------------------------- run
-
-console.log("=".repeat(100));
-console.log("htn-ai planner benchmark");
-console.log("=".repeat(100));
-
-bench("quarry (hmax, w=1, optimal)", quarry, 200);
-bench("quarry (hadd, w=2, greedy)", quarryGreedy, 200);
-bench("scavenger (hmax, w=1)", scavenger, 200);
-bench("staircase (hmax, w=1)", staircase, 500);
-bench("blocks reverse 4 (w=1)", blocksReverse(4), 200);
-bench("blocks reverse 5 (w=1)", blocksReverse(5), 50);
-bench("blocks reverse 6 (w=1)", blocksReverse(6), 20);
-bench("hanoi 3 (w=1)", hanoi(3), 500);
-bench("hanoi 4 (w=1)", hanoi(4), 100);
-bench("hanoi 5 (w=1)", hanoi(5), 20);
-bench("htn tour 8 (decomposition)", htnTour(8), 2000);
-bench("htn tour 16 (decomposition)", htnTour(16), 500);
-bench("scheduler x8 (staircase)", schedulerRun(8), 100);
+console.log("=".repeat(86));
+console.log(`htn-ai benchmark — min of N trials${(globalThis as { gc?: unknown }).gc ? " (gc between trials)" : " (run with NODE_OPTIONS=--expose-gc for lower noise)"}`);
+console.log("=".repeat(86));
+printHeader();
+printRow(measure("quarry (hmax,w=1)", quarry));
+printRow(measure("scavenger (hmax,w=1)", scavenger));
+printRow(measure("staircase (hmax,w=1)", staircase));
+printRow(measure("blocks reverse 6", blocksReverse(6)));
+printRow(measure("hanoi 5", hanoi(5)));
+printRow(measure("nav grid 6x6", navGrid(6)));
+printRow(measure("htn tour 16", htnTour(16)));
+printRow(measure("scheduler x8", schedulerRun(8)));

--- a/bench/huge.ts
+++ b/bench/huge.ts
@@ -1,0 +1,24 @@
+import { goal, planOnce, type Model } from "../src/index";
+import {
+  scavengerModel, scavengerBigInstance, scavengerBigGoal,
+  scavengerHugeInstance, scavengerHugeGoal,
+} from "../scenarios/staircase";
+
+function timeRun(label: string, model: Model, req: any, trials: number) {
+  planOnce(model, model.createExecState(), req); // warm up
+  let res = planOnce(model, model.createExecState(), req);
+  const s: number[] = [];
+  for (let t = 0; t < trials; t++) {
+    const st = model.createExecState();
+    const t0 = performance.now();
+    res = planOnce(model, st, req);
+    s.push(performance.now() - t0);
+  }
+  s.sort((a, b) => a - b);
+  console.log(`${label}: min ${s[0].toFixed(0)}ms  median ${s[s.length >> 1].toFixed(0)}ms  [${res.status}] exp=${res.stats.expansions} steps=${res.plan?.steps.length}`);
+}
+
+const xl = scavengerModel(scavengerBigInstance());
+const huge = scavengerModel(scavengerHugeInstance());
+timeRun("Scavenger XL   (4x3, h3, hadd w=5)", xl, { goals: [goal(scavengerBigGoal())], weight: 5, heuristic: "hadd", maxNodes: 500_000 }, 7);
+timeRun("Scavenger HUGE (6x4, h3, hadd w=6)", huge, { goals: [goal(scavengerHugeGoal())], weight: 6, heuristic: "hadd", maxNodes: 200_000 }, 3);

--- a/bench/profile.ts
+++ b/bench/profile.ts
@@ -1,0 +1,14 @@
+/** Focused profiling driver: just the heavy quarry search, many iters. */
+import { createModel, goal, planOnce } from "../src/index";
+import { quarryInstance, quarryGoal, staircaseModel } from "../scenarios/staircase";
+
+const model = staircaseModel(quarryInstance());
+const N = Number(process.env.ITERS ?? 80);
+const t0 = performance.now();
+let exp = 0;
+for (let i = 0; i < N; i++) {
+  const r = planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
+  exp = r.stats.expansions;
+}
+const dt = performance.now() - t0;
+console.log(`quarry x${N}: ${dt.toFixed(0)}ms total, ${(dt / N).toFixed(2)}ms/iter, ${exp} expansions`);

--- a/bench/profile.ts
+++ b/bench/profile.ts
@@ -1,14 +1,64 @@
-/** Focused profiling driver: just the heavy quarry search, many iters. */
-import { createModel, goal, planOnce } from "../src/index";
-import { quarryInstance, quarryGoal, staircaseModel } from "../scenarios/staircase";
+/** Profiling driver. SCEN=quarry|hanoi|scavenger, ITERS=n. */
+import { DomainDoc, E, F, createModel, goal, planOnce } from "../src/index";
+import { quarryInstance, quarryGoal, scavengerInstance, scavengerGoal, scavengerModel, staircaseModel } from "../scenarios/staircase";
 
-const model = staircaseModel(quarryInstance());
-const N = Number(process.env.ITERS ?? 80);
+function hanoiModel(nDisks: number) {
+  const disks = Array.from({ length: nDisks }, (_, i) => `d${i + 1}`);
+  const doc: DomainDoc = {
+    name: "hanoi",
+    types: [{ name: "disk" }, { name: "peg" }],
+    fluents: [
+      { name: "peg", params: [{ name: "d", type: "disk" }], kind: "entity", entityType: "peg" },
+      { name: "size", params: [{ name: "d", type: "disk" }], kind: "int" },
+    ],
+    operators: [
+      {
+        name: "move",
+        params: [{ name: "d", type: "disk" }, { name: "from", type: "peg" }, { name: "to", type: "peg" }],
+        pre: F.and(F.lit("peg", ["?d"], "?from"), F.ext("neq", ["?from", "?to"], []), F.ext("canMoveTo", ["?d", "?to"], ["peg", "size"])),
+        eff: [E.set("peg", ["?d"], "?to")],
+      },
+    ],
+  };
+  const model = createModel(
+    doc,
+    {
+      entities: { ...Object.fromEntries(disks.map((d) => [d, "disk"])), p1: "peg", p2: "peg", p3: "peg" },
+      init: (w) => disks.forEach((d, i) => { w.set("peg", [d], "p1"); w.set("size", [d], i + 1); }),
+    },
+    {
+      predicates: {
+        neq: (q) => q.args[0] !== q.args[1],
+        canMoveTo: (q) => {
+          const [d, to] = q.args;
+          const dPeg = q.get("peg", d);
+          const dSize = q.get("size", d);
+          for (const other of disks) {
+            const og = q.gid(other);
+            if (og === d) continue;
+            if (q.get("size", og) < dSize) {
+              const oPeg = q.get("peg", og);
+              if (oPeg === dPeg || oPeg === to + 1) return false;
+            }
+          }
+          return true;
+        },
+      },
+    },
+  );
+  const goalLits = disks.map((d) => F.lit("peg", [d], "p3"));
+  return { model, req: { goals: [goal(F.and(...goalLits))], weight: 1 as const } };
+}
+
+const SCEN = process.env.SCEN ?? "quarry";
+const N = Number(process.env.ITERS ?? 200);
+let run: () => { stats: { expansions: number } };
+if (SCEN === "hanoi") { const { model, req } = hanoiModel(Number(process.env.DISKS ?? 5)); run = () => planOnce(model, model.createExecState(), req); }
+else if (SCEN === "scavenger") { const m = scavengerModel(scavengerInstance()); run = () => planOnce(m, m.createExecState(), { goals: [goal(scavengerGoal())], weight: 1, heuristic: "hmax" }); }
+else { const m = staircaseModel(quarryInstance()); run = () => planOnce(m, m.createExecState(), { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" }); }
+
 const t0 = performance.now();
 let exp = 0;
-for (let i = 0; i < N; i++) {
-  const r = planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
-  exp = r.stats.expansions;
-}
+for (let i = 0; i < N; i++) exp = run().stats.expansions;
 const dt = performance.now() - t0;
-console.log(`quarry x${N}: ${dt.toFixed(0)}ms total, ${(dt / N).toFixed(2)}ms/iter, ${exp} expansions`);
+console.log(`${SCEN} x${N}: ${dt.toFixed(0)}ms total, ${(dt / N).toFixed(2)}ms/iter, ${exp} expansions`);

--- a/bench/scale.ts
+++ b/bench/scale.ts
@@ -1,0 +1,75 @@
+/**
+ * Scaling sweeps: grow each workload along one axis and watch how cost grows.
+ * Run: `npm run bench:scale`  (add `NODE_OPTIONS=--expose-gc` for lower noise).
+ *
+ * Each row is the MIN ms over several trials (noise-resistant). `µs/node` =
+ * ms ÷ expansions isolates per-node cost from problem size; `×prev` is the
+ * growth factor of min-ms vs the previous size, so super-linear scaling is
+ * visible at a glance. Axes are chosen to stress different engine hot paths:
+ *
+ *   hanoi disks   — exponential search depth + external predicate per node
+ *   blocks        — grounding O(n³) + state size, shallow search
+ *   nav grid      — relational adjacency: successor candidates per node ∝ cells
+ *   htn tour      — HTN decomposition width (free-variable method binding)
+ *   scheduler     — multi-agent round-robin planning
+ *   weight        — heuristic informativeness → expansions (same problem)
+ */
+import { measure, blocksReverse, hanoi, navGrid, htnTour, schedulerRun, staircaseModel, goal, planOnce, type Run, type Sample } from "./workloads";
+import { quarryInstance, quarryGoal } from "../scenarios/staircase";
+
+function sweep(title: string, axis: string, sizes: number[], make: (n: number) => Run, opts = {}): void {
+  console.log(`\n${title}`);
+  console.log(`${axis.padEnd(10)}${"min ms".padStart(12)}${"µs/node".padStart(11)}${"exp/dec".padStart(11)}${"×prev".padStart(9)}  status`);
+  console.log("-".repeat(64));
+  let prev = 0;
+  for (const n of sizes) {
+    let s: Sample;
+    try {
+      s = measure(`${axis}=${n}`, make(n), opts);
+    } catch (e) {
+      console.log(`${String(n).padEnd(10)}  (skipped: ${(e as Error).message.slice(0, 40)})`);
+      continue;
+    }
+    const ratio = prev > 0 ? s.minMs / prev : 0;
+    console.log(
+      String(n).padEnd(10) +
+        s.minMs.toFixed(4).padStart(12) +
+        (s.perNodeUs === null ? "—" : s.perNodeUs.toFixed(2)).padStart(11) +
+        String(s.expansions || s.decompositions).padStart(11) +
+        (ratio ? `${ratio.toFixed(2)}×` : "—").padStart(9) +
+        `  [${s.status}]`,
+    );
+    prev = s.minMs;
+  }
+}
+
+function quarryWeighted(weight: number, heuristic: "hmax" | "hadd"): Run {
+  const model = staircaseModel(quarryInstance());
+  return () => planOnce(model, model.createExecState(), { goals: [goal(quarryGoal())], weight, heuristic });
+}
+
+console.log("=".repeat(64));
+console.log(`htn-ai scaling sweeps${(globalThis as { gc?: unknown }).gc ? " (gc between trials)" : " (tip: NODE_OPTIONS=--expose-gc)"}`);
+console.log("=".repeat(64));
+
+sweep("Hanoi — search depth (2^n−1) + external predicate", "disks", [3, 4, 5, 6, 7, 8], hanoi, { targetMs: 30 });
+sweep("Blocks — grounding O(n³) + state size", "blocks", [4, 6, 8, 10, 12], blocksReverse);
+sweep("Nav grid — relational adjacency / branching", "K", [4, 6, 8, 10, 12], navGrid, { targetMs: 30 });
+sweep("HTN tour — decomposition width", "locs", [8, 16, 32, 64, 128], htnTour);
+sweep("Scheduler — multi-agent round-robin", "agents", [1, 2, 4, 8, 16, 32], schedulerRun, { targetMs: 30 });
+
+// heuristic informativeness on a fixed problem (expansions move, not size)
+console.log("\nQuarry — heuristic / weight (fixed problem; expansions vary)");
+console.log(`${"config".padEnd(16)}${"min ms".padStart(12)}${"µs/node".padStart(11)}${"exp".padStart(9)}  status`);
+console.log("-".repeat(56));
+for (const [label, run] of [
+  ["hmax w=1 (opt)", quarryWeighted(1, "hmax")],
+  ["hadd w=1", quarryWeighted(1, "hadd")],
+  ["hadd w=1.4", quarryWeighted(1.4, "hadd")],
+  ["hadd w=2", quarryWeighted(2, "hadd")],
+] as const) {
+  const s = measure(label, run);
+  console.log(
+    label.padEnd(16) + s.minMs.toFixed(4).padStart(12) + (s.perNodeUs?.toFixed(2) ?? "—").padStart(11) + String(s.expansions).padStart(9) + `  [${s.status}]`,
+  );
+}

--- a/bench/scale.ts
+++ b/bench/scale.ts
@@ -14,7 +14,7 @@
  *   scheduler     — multi-agent round-robin planning
  *   weight        — heuristic informativeness → expansions (same problem)
  */
-import { measure, blocksReverse, hanoi, navGrid, htnTour, schedulerRun, staircaseModel, goal, planOnce, type Run, type Sample } from "./workloads";
+import { measure, blocksReverse, hanoi, navGrid, htnTour, schedulerRun, scavengerGrid, staircaseModel, goal, planOnce, type Run, type Sample } from "./workloads";
 import { quarryInstance, quarryGoal } from "../scenarios/staircase";
 
 function sweep(title: string, axis: string, sizes: number[], make: (n: number) => Run, opts = {}): void {
@@ -57,6 +57,22 @@ sweep("Blocks — grounding O(n³) + state size", "blocks", [4, 6, 8, 10, 12], b
 sweep("Nav grid — relational adjacency / branching", "K", [4, 6, 8, 10, 12], navGrid, { targetMs: 30 });
 sweep("HTN tour — decomposition width", "locs", [8, 16, 32, 64, 128], htnTour);
 sweep("Scheduler — multi-agent round-robin", "agents", [1, 2, 4, 8, 16, 32], schedulerRun, { targetMs: 30 });
+
+// Pushed "big/huge" scavenger family: larger spatial GOAP, grounding grows ~cells²
+console.log("\nScavenger grid — large spatial GOAP (greedy hadd w=6, h3 goal); cells = W×D");
+console.log(`${"W×D".padEnd(8)}${"cells".padStart(7)}${"min ms".padStart(11)}${"µs/node".padStart(11)}${"exp".padStart(8)}${"×prev".padStart(9)}  status`);
+console.log("-".repeat(60));
+let prevSg = 0;
+for (const [w, d] of [[3, 3], [4, 3], [5, 3], [6, 3], [6, 4]] as const) {
+  const s = measure(`${w}x${d}`, scavengerGrid(w, d), { targetMs: 40, trials: 5 });
+  const ratio = prevSg > 0 ? s.minMs / prevSg : 0;
+  console.log(
+    `${w}×${d}`.padEnd(8) + String(w * d).padStart(7) + s.minMs.toFixed(2).padStart(11) +
+      (s.perNodeUs?.toFixed(2) ?? "—").padStart(11) + String(s.expansions).padStart(8) +
+      (ratio ? `${ratio.toFixed(2)}×` : "—").padStart(9) + `  [${s.status}]`,
+  );
+  prevSg = s.minMs;
+}
 
 // heuristic informativeness on a fixed problem (expansions move, not size)
 console.log("\nQuarry — heuristic / weight (fixed problem; expansions vary)");

--- a/bench/workloads.ts
+++ b/bench/workloads.ts
@@ -14,7 +14,10 @@
  *    fall outside the timed window.
  */
 import { DomainDoc, E, F, N, Planner, Scheduler, createModel, doTask, goal, planOnce, task, type PlanResult } from "../src/index";
-import { staircaseInstance, staircaseGoal, staircaseModel } from "../scenarios/staircase";
+import {
+  staircaseInstance, staircaseGoal, staircaseModel,
+  scavengerModel, scavengerGridInstance,
+} from "../scenarios/staircase";
 
 export type Run = () => PlanResult;
 
@@ -271,6 +274,15 @@ export function schedulerRun(m: number): Run {
     const done = planners.every((p) => p.getStatus() === "succeeded");
     return { status: done ? "success" : "failure", stats: { decompositions: 0, expansions: 0, heuristicEvals: 0 } } as PlanResult;
   };
+}
+
+/** Scavenger on a W×D grid (the pushed "big/huge" spatial GOAP family). Greedy
+ *  hadd. Search cost grows ~ground-ops (heuristic sweeps every op), so this is a
+ *  realistic large-domain scaling axis. */
+export function scavengerGrid(w: number, d: number, goalHeight = 3, weight = 6): Run {
+  const model = scavengerModel(scavengerGridInstance(w, d));
+  const goalF = F.and(F.lit("agentAt", [], `c${w - 1}_0`), F.eq(N.fl("agentY"), N.c(goalHeight)));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(goalF)], weight, heuristic: "hadd", maxNodes: 500_000 });
 }
 
 export { staircaseModel, staircaseInstance, staircaseGoal, goal, planOnce, N };

--- a/bench/workloads.ts
+++ b/bench/workloads.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared benchmark workloads + a robust measurement helper.
+ *
+ * Measurement methodology (for signal over CPU noise):
+ *  - warm up so the JIT has settled before timing;
+ *  - auto-calibrate the inner loop so each timed trial runs ≳ targetMs (timer
+ *    resolution & per-batch overhead become negligible);
+ *  - run several independent trials and report the MIN ms/iter as the headline —
+ *    all interference (GC, scheduler preemption, CPU-freq dips) only *adds* time,
+ *    so the minimum is the sample least contaminated by it;
+ *  - also report the median and spread% = (median−min)/min so the noise is
+ *    visible, not hidden;
+ *  - call global.gc() between trials when run with `node --expose-gc` so GC pauses
+ *    fall outside the timed window.
+ */
+import { DomainDoc, E, F, N, Planner, Scheduler, createModel, doTask, goal, planOnce, task, type PlanResult } from "../src/index";
+import { staircaseInstance, staircaseGoal, staircaseModel } from "../scenarios/staircase";
+
+export type Run = () => PlanResult;
+
+export interface Sample {
+  label: string;
+  minMs: number;
+  medianMs: number;
+  spreadPct: number;
+  perNodeUs: number | null;
+  expansions: number;
+  decompositions: number;
+  status: string;
+}
+
+export interface MeasureOpts {
+  trials?: number;
+  targetMs?: number;
+  maxInner?: number;
+}
+
+const maybeGc = (globalThis as { gc?: () => void }).gc;
+
+export function measure(label: string, run: Run, opts: MeasureOpts = {}): Sample {
+  const { trials = 9, targetMs = 40, maxInner = 200_000 } = opts;
+
+  // warm up (JIT)
+  let last = run();
+  for (let i = 0; i < 5; i++) last = run();
+
+  // calibrate inner-loop count so each trial ≳ targetMs
+  const c0 = performance.now();
+  last = run();
+  const single = Math.max(performance.now() - c0, 1e-4);
+  const inner = Math.max(1, Math.min(maxInner, Math.ceil(targetMs / single)));
+
+  const perIter: number[] = [];
+  for (let t = 0; t < trials; t++) {
+    if (maybeGc) maybeGc();
+    const s = performance.now();
+    for (let i = 0; i < inner; i++) last = run();
+    perIter.push((performance.now() - s) / inner);
+  }
+  perIter.sort((a, b) => a - b);
+  const minMs = perIter[0];
+  const medianMs = perIter[(perIter.length - 1) >> 1];
+  const spreadPct = ((medianMs - minMs) / minMs) * 100;
+  const expansions = last.stats.expansions;
+  const decompositions = last.stats.decompositions;
+  const perNodeUs = expansions > 0 ? (minMs * 1000) / expansions : null;
+  return { label, minMs, medianMs, spreadPct, perNodeUs, expansions, decompositions, status: last.status };
+}
+
+export function printHeader(): void {
+  console.log(
+    "workload".padEnd(30) +
+      "min ms".padStart(11) +
+      "median".padStart(10) +
+      "spread".padStart(8) +
+      "µs/node".padStart(10) +
+      "exp".padStart(9) +
+      "  status",
+  );
+  console.log("-".repeat(86));
+}
+
+export function printRow(s: Sample): void {
+  console.log(
+    s.label.padEnd(30) +
+      s.minMs.toFixed(4).padStart(11) +
+      s.medianMs.toFixed(4).padStart(10) +
+      `${s.spreadPct.toFixed(0)}%`.padStart(8) +
+      (s.perNodeUs === null ? "—" : s.perNodeUs.toFixed(2)).padStart(10) +
+      String(s.expansions || s.decompositions).padStart(9) +
+      `  [${s.status}]`,
+  );
+}
+
+// ============================================================ workload builders
+
+/** Blocks world (3-op move formulation, neq external). Reverse an N-tower. */
+export function blocksReverse(n: number): Run {
+  const names = Array.from({ length: n }, (_, i) => `b${i}`);
+  const doc: DomainDoc = {
+    name: "blocks",
+    types: [{ name: "block" }],
+    fluents: [
+      { name: "on", params: [{ name: "b", type: "block" }], kind: "entity", entityType: "block" },
+      { name: "clear", params: [{ name: "b", type: "block" }], kind: "boolean", initial: true },
+    ],
+    operators: [
+      {
+        name: "block_to_block",
+        params: [{ name: "x", type: "block" }, { name: "from", type: "block" }, { name: "to", type: "block" }],
+        pre: F.and(F.lit("clear", ["?x"]), F.lit("clear", ["?to"]), F.lit("on", ["?x"], "?from"), F.ext("neq", ["?x", "?to"], [])),
+        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?from"], true), E.set("clear", ["?to"], false)],
+      },
+      {
+        name: "block_to_table",
+        params: [{ name: "x", type: "block" }, { name: "from", type: "block" }],
+        pre: F.and(F.lit("clear", ["?x"]), F.lit("on", ["?x"], "?from")),
+        eff: [E.set("on", ["?x"], 0), E.set("clear", ["?from"], true)],
+      },
+      {
+        name: "table_to_block",
+        params: [{ name: "x", type: "block" }, { name: "to", type: "block" }],
+        pre: F.and(F.lit("clear", ["?x"]), F.lit("clear", ["?to"]), F.lit("on", ["?x"], 0), F.ext("neq", ["?x", "?to"], [])),
+        eff: [E.set("on", ["?x"], "?to"), E.set("clear", ["?to"], false)],
+      },
+    ],
+  };
+  const model = createModel(
+    doc,
+    {
+      entities: Object.fromEntries(names.map((nm) => [nm, "block"])),
+      init: (w) => {
+        for (let i = 0; i < n - 1; i++) {
+          w.set("on", [names[i]], names[i + 1]);
+          w.set("clear", [names[i + 1]], false);
+        }
+      },
+    },
+    { predicates: { neq: (q) => q.args[0] !== q.args[1] } },
+  );
+  const goalLits = [];
+  for (let i = n - 1; i > 0; i--) goalLits.push(F.lit("on", [names[i]], names[i - 1]));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
+}
+
+/** Towers of Hanoi (external canMoveTo predicate; plan length 2^n − 1). */
+export function hanoi(nDisks: number): Run {
+  const disks = Array.from({ length: nDisks }, (_, i) => `d${i + 1}`);
+  const doc: DomainDoc = {
+    name: "hanoi",
+    types: [{ name: "disk" }, { name: "peg" }],
+    fluents: [
+      { name: "peg", params: [{ name: "d", type: "disk" }], kind: "entity", entityType: "peg" },
+      { name: "size", params: [{ name: "d", type: "disk" }], kind: "int" },
+    ],
+    operators: [
+      {
+        name: "move",
+        params: [{ name: "d", type: "disk" }, { name: "from", type: "peg" }, { name: "to", type: "peg" }],
+        pre: F.and(F.lit("peg", ["?d"], "?from"), F.ext("neq", ["?from", "?to"], []), F.ext("canMoveTo", ["?d", "?to"], ["peg", "size"])),
+        eff: [E.set("peg", ["?d"], "?to")],
+      },
+    ],
+  };
+  const model = createModel(
+    doc,
+    {
+      entities: { ...Object.fromEntries(disks.map((d) => [d, "disk"])), p1: "peg", p2: "peg", p3: "peg" },
+      init: (w) => disks.forEach((d, i) => { w.set("peg", [d], "p1"); w.set("size", [d], i + 1); }),
+    },
+    {
+      predicates: {
+        neq: (q) => q.args[0] !== q.args[1],
+        canMoveTo: (q) => {
+          const [d, to] = q.args;
+          const dPeg = q.get("peg", d);
+          const dSize = q.get("size", d);
+          for (const other of disks) {
+            const og = q.gid(other);
+            if (og === d) continue;
+            if (q.get("size", og) < dSize) {
+              const oPeg = q.get("peg", og);
+              if (oPeg === dPeg || oPeg === to + 1) return false;
+            }
+          }
+          return true;
+        },
+      },
+    },
+  );
+  const goalLits = disks.map((d) => F.lit("peg", [d], "p3"));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(F.and(...goalLits))], weight: 1 });
+}
+
+/** Grid navigation: K×K cells, 4-connected, reach the far corner (relational adj). */
+export function navGrid(k: number): Run {
+  const id = (x: number, y: number) => `c_${x}_${y}`;
+  const cells: string[] = [];
+  for (let y = 0; y < k; y++) for (let x = 0; x < k; x++) cells.push(id(x, y));
+  const doc: DomainDoc = {
+    name: "nav",
+    types: [{ name: "cell" }],
+    fluents: [
+      { name: "at", kind: "entity", entityType: "cell" },
+      { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+      { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
+    ],
+    operators: [
+      {
+        name: "move",
+        params: [{ name: "from", type: "cell" }, { name: "to", type: "cell" }],
+        pre: F.and(F.lit("at", [], "?from"), F.lit("adj", ["?from", "?to"])),
+        eff: [E.set("at", [], "?to")],
+        cost: 1,
+      },
+    ],
+  };
+  const model = createModel(doc, {
+    entities: Object.fromEntries(cells.map((c) => [c, "cell"])),
+    init: (w) => {
+      for (let y = 0; y < k; y++) for (let x = 0; x < k; x++) {
+        w.set("pos", [id(x, y)], [x, y]);
+        for (const [dx, dy] of [[1, 0], [0, 1]] as const) {
+          const nx = x + dx, ny = y + dy;
+          if (nx < k && ny < k) { w.set("adj", [id(x, y), id(nx, ny)], true); w.set("adj", [id(nx, ny), id(x, y)], true); }
+        }
+      }
+      w.set("at", [], id(0, 0));
+    },
+  });
+  const goalF = F.lit("at", [], id(k - 1, k - 1));
+  return () => planOnce(model, model.createExecState(), { goals: [goal(goalF)], weight: 1, heuristic: "hmax" });
+}
+
+/** HTN decomposition: visit K locations (recursive method with a free parameter). */
+export function htnTour(k: number): Run {
+  const locs = Array.from({ length: k }, (_, i) => `l${i}`);
+  const doc: DomainDoc = {
+    name: "tour",
+    types: [{ name: "loc" }],
+    fluents: [{ name: "visited", params: [{ name: "l", type: "loc" }], kind: "boolean", initial: false }],
+    compounds: [{ name: "Tour" }],
+    operators: [
+      { name: "visit", params: [{ name: "l", type: "loc" }], pre: F.not(F.lit("visited", ["?l"])), eff: [E.set("visited", ["?l"], true)] },
+    ],
+    methods: [
+      { name: "more", task: "Tour", params: [{ name: "next", type: "loc" }], pre: F.not(F.lit("visited", ["?next"])), subtasks: [doTask("visit", "?next"), doTask("Tour")] },
+      { name: "done", task: "Tour", subtasks: [] },
+    ],
+  };
+  const model = createModel(doc, { entities: Object.fromEntries(locs.map((l) => [l, "loc"])) });
+  return () => planOnce(model, model.createExecState(), { goals: [task("Tour")] });
+}
+
+/** Multi-agent: M staircase planners driven round-robin to completion. */
+export function schedulerRun(m: number): Run {
+  return () => {
+    const sched = new Scheduler();
+    const planners: Planner[] = [];
+    let t = 0;
+    for (let i = 0; i < m; i++) {
+      const model = staircaseModel(staircaseInstance());
+      const p = new Planner(model, { goals: [goal(staircaseGoal())], now: () => t, seed: i });
+      planners.push(p);
+      sched.add(p);
+    }
+    for (let i = 0; i < 4000 && planners.some((p) => p.getStatus() !== "succeeded" && p.getStatus() !== "failed"); i++) {
+      t += 1;
+      sched.tick(5);
+    }
+    const done = planners.every((p) => p.getStatus() === "succeeded");
+    return { status: done ? "success" : "failure", stats: { decompositions: 0, expansions: 0, heuristicEvals: 0 } } as PlanResult;
+  };
+}
+
+export { staircaseModel, staircaseInstance, staircaseGoal, goal, planOnce, N };

--- a/bench/workloads.ts
+++ b/bench/workloads.ts
@@ -205,7 +205,7 @@ export function navGrid(k: number): Run {
     types: [{ name: "cell" }],
     fluents: [
       { name: "at", kind: "entity", entityType: "cell" },
-      { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+      { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false, static: true },
       { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
     ],
     operators: [

--- a/examples/web/.gitignore
+++ b/examples/web/.gitignore
@@ -1,0 +1,12 @@
+# dependencies
+node_modules
+
+# next.js
+.next
+out
+next-env.d.ts
+
+# misc
+*.tsbuildinfo
+.DS_Store
+.vercel

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -34,6 +34,11 @@ reactive `Planner`** in the browser (the app never re-implements planning):
   insufficient, so the planner harvests the pillar — using loose blocks as
   stepping stones to reach its top — and stacks a 3-level structure to climb up.
   Solved with a greedier search weight (~0.5s).
+- **Scavenger HUGE (stress · ~9s)** — a 6×4 grid (24 cells) littered with blocks;
+  a deliberate stress test, ≈10× the compute of the others (~9s to plan, the page
+  is busy while it searches). Demonstrates the planner solving a large symbolic
+  problem from a position-only goal. Search is hard-capped (`maxNodes`) so it can
+  never run away. (Benchmarkable headless via `HTN_BENCH=1 npm test`.)
 - **Blocks World (Sussman)** ([`../../scenarios/blocks.ts`](../../scenarios/blocks.ts)) —
   the classic Sussman anomaly: `C on A`, `A`/`B` on the table, goal `A-on-B-on-C`.
   The naive order deadlocks, so the planner interleaves subgoals.

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -22,6 +22,13 @@ reactive `Planner`** in the browser (the app never re-implements planning):
   planner finds the optimal route to collect from both depots and build a 3-step
   staircase (1→2→3) to climb up — solved optimally by pure GOAP (~1.5k node
   expansions; see [`../../tests/spatial.ts`](../../tests/spatial.ts)).
+- **Scavenger (collect & harvest)** — blocks lie **scattered on the ground**
+  (no depots). You can only take the **top** of a stack, and only if you're high
+  enough to reach it (`stand ≥ height−1`), so a 2-pillar's top block is out of
+  reach from the ground. From a position-only goal the planner grabs a loose
+  block, **builds a step, climbs it, harvests the pillar's top block**, and uses
+  the blocks to reach a coordinate up in the air. Placement is free — the planner
+  decides where the steps go.
 - **Blocks World (Sussman)** ([`../../scenarios/blocks.ts`](../../scenarios/blocks.ts)) —
   the classic Sussman anomaly: `C on A`, `A`/`B` on the table, goal `A-on-B-on-C`.
   The naive order deadlocks, so the planner interleaves subgoals.

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -16,6 +16,12 @@ reactive `Planner`** in the browser (the app never re-implements planning):
   blocks from the supply depot, build a staircase, and climb it.
 - **Climb the ledge** — a 2-high wall the agent can't scale directly (you ascend
   one level at a time); the planner builds a single support step and walks over.
+- **Quarry (advanced)** — a grid world: reach the top of a **height-4 pillar**.
+  Six blocks are **scattered across two depots**, a **wall pillar** is impassable,
+  and the agent can only climb one level at a time. From a position-only goal the
+  planner finds the optimal route to collect from both depots and build a 3-step
+  staircase (1→2→3) to climb up — solved optimally by pure GOAP (~1.5k node
+  expansions; see [`../../tests/spatial.ts`](../../tests/spatial.ts)).
 - **Blocks World (Sussman)** ([`../../scenarios/blocks.ts`](../../scenarios/blocks.ts)) —
   the classic Sussman anomaly: `C on A`, `A`/`B` on the table, goal `A-on-B-on-C`.
   The naive order deadlocks, so the planner interleaves subgoals.

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -6,19 +6,23 @@ implementation of "Task 4" in [`../../PLAN-web-demo-and-block-stacking.md`](../.
 
 ## What it shows
 
-The flagship scene is **Staircase World** (shared domain in
-[`../../scenarios/staircase.ts`](../../scenarios/staircase.ts)):
+Three scenes, selectable from the scenario dropdown, each driving the **real
+reactive `Planner`** in the browser (the app never re-implements planning):
 
-- The goal is a pure **3D coordinate** — *"be up in the air at (x, y, z)"*. It
-  does **not** tell the agent to place blocks or build anything.
-- The only way to gain height is to stand on blocks, and the only way to go
-  higher is to stack more — so the planner **discovers** it must carry blocks
-  from the supply depot, build a staircase, and climb it.
-- The app drives the **real reactive `Planner`** tick-by-tick (it does not
-  re-implement planning), captures a world snapshot after every executed step,
-  and animates the agent through them. The right-hand panel shows the live world
-  state, the **plan the search discovered**, and the planner's **`TraceEvent`
-  stream** (so repair/replan show up when they happen).
+- **Staircase** (flagship, [`../../scenarios/staircase.ts`](../../scenarios/staircase.ts)) —
+  the goal is a pure **3D coordinate** (*"be up in the air at (x, y, z)"*). It does
+  **not** tell the agent to place blocks or build anything; because the only way
+  to gain height is to stand on blocks, the planner **discovers** it must carry
+  blocks from the supply depot, build a staircase, and climb it.
+- **Climb the ledge** — a 2-high wall the agent can't scale directly (you ascend
+  one level at a time); the planner builds a single support step and walks over.
+- **Blocks World (Sussman)** ([`../../scenarios/blocks.ts`](../../scenarios/blocks.ts)) —
+  the classic Sussman anomaly: `C on A`, `A`/`B` on the table, goal `A-on-B-on-C`.
+  The naive order deadlocks, so the planner interleaves subgoals.
+
+The right-hand panel shows the live world state, the **plan the search
+discovered**, and the planner's **`TraceEvent` stream** (so repair/replan show up
+when they happen).
 
 ## Run it
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -29,6 +29,11 @@ reactive `Planner`** in the browser (the app never re-implements planning):
   block, **builds a step, climbs it, harvests the pillar's top block**, and uses
   the blocks to reach a coordinate up in the air. Placement is free — the planner
   decides where the steps go.
+- **Scavenger XL (taller, harder)** — a bigger 4×3 grid, a **height-3** goal, and
+  seven scattered blocks (five loose + a 2-pillar). Loose blocks alone are
+  insufficient, so the planner harvests the pillar — using loose blocks as
+  stepping stones to reach its top — and stacks a 3-level structure to climb up.
+  Solved with a greedier search weight (~0.5s).
 - **Blocks World (Sussman)** ([`../../scenarios/blocks.ts`](../../scenarios/blocks.ts)) —
   the classic Sussman anomaly: `C on A`, `A`/`B` on the table, goal `A-on-B-on-C`.
   The naive order deadlocks, so the planner interleaves subgoals.

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -1,0 +1,57 @@
+# htn-ai — Web Preview (Staircase World)
+
+A small Next.js + [react-three-fiber](https://github.com/pmndrs/react-three-fiber)
+app that **visualizes the `htn-ai` planner running in the browser**. It is the
+implementation of "Task 4" in [`../../PLAN-web-demo-and-block-stacking.md`](../../PLAN-web-demo-and-block-stacking.md).
+
+## What it shows
+
+The flagship scene is **Staircase World** (shared domain in
+[`../../scenarios/staircase.ts`](../../scenarios/staircase.ts)):
+
+- The goal is a pure **3D coordinate** — *"be up in the air at (x, y, z)"*. It
+  does **not** tell the agent to place blocks or build anything.
+- The only way to gain height is to stand on blocks, and the only way to go
+  higher is to stack more — so the planner **discovers** it must carry blocks
+  from the supply depot, build a staircase, and climb it.
+- The app drives the **real reactive `Planner`** tick-by-tick (it does not
+  re-implement planning), captures a world snapshot after every executed step,
+  and animates the agent through them. The right-hand panel shows the live world
+  state, the **plan the search discovered**, and the planner's **`TraceEvent`
+  stream** (so repair/replan show up when they happen).
+
+## Run it
+
+```bash
+cd examples/web
+npm install
+npm run dev      # http://localhost:3000
+```
+
+The library is imported straight from source via a webpack alias
+(`htn-ai → ../../src/index.ts`) and the shared scenarios via `@scenarios/*`, so
+changes to the core library hot-reload here with no rebuild.
+
+## Build / deploy
+
+```bash
+npm run build    # static export to ./out  (Next.js `output: "export"`)
+```
+
+The output in `out/` is a fully static site — deploy to Vercel, GitHub Pages, or
+any static host. A [`vercel.json`](./vercel.json) is included. On Vercel, set the
+project **Root Directory** to `examples/web` (the app lives in a subfolder of the
+library repo).
+
+## How it maps to the library
+
+| UI piece | htn-ai feature |
+|---|---|
+| Agent building + climbing | `Planner.tick()` executing the discovered plan |
+| "Plan · discovered by search" | the `Plan` from goal search over `goto`/`pick`/`place` operators |
+| World-state panel | `model.read(state, fluent, …)` over typed fluents |
+| Trace events panel | the `trace:` `TraceEvent` stream (`plan.*`, `step.*`, `repair.*`, …) |
+| Goal = a 3D coordinate | a position-only goal (`agentAt ∧ agentY`), not a prescriptive structure |
+
+This is an intentionally small seed of the planned `@htn-ai/devtools` inspector
+and `@htn-ai/react` adapter described in `ROADMAP.md`.

--- a/examples/web/app/globals.css
+++ b/examples/web/app/globals.css
@@ -1,0 +1,228 @@
+:root {
+  --bg: #0b0e14;
+  --panel: #11151f;
+  --panel-2: #161b27;
+  --border: #232a3a;
+  --text: #e6e9ef;
+  --muted: #8b94a7;
+  --accent: #38bdf8;
+  --accent-2: #f59e0b;
+  --good: #34d399;
+  --bad: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  height: 100vh;
+  width: 100vw;
+}
+
+@media (max-width: 860px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: 60vh 40vh;
+  }
+}
+
+.stage {
+  position: relative;
+  min-width: 0;
+}
+
+.stage .title {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.stage .title h1 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.2px;
+}
+
+.stage .title p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+  max-width: 460px;
+}
+
+.panel {
+  background: var(--panel);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.card {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.card h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.spread {
+  justify-content: space-between;
+}
+
+button {
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+button.primary {
+  background: var(--accent);
+  color: #04121b;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+select,
+input[type="range"] {
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: 13px;
+}
+
+.kv {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  padding: 3px 0;
+}
+
+.kv .k {
+  color: var(--muted);
+}
+
+.mono {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+}
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.step {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: var(--muted);
+  display: flex;
+  gap: 8px;
+}
+
+.step.active {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text);
+}
+
+.step.done {
+  color: #5d6478;
+}
+
+.step .idx {
+  color: #4b5468;
+  min-width: 22px;
+  text-align: right;
+}
+
+.pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.pill.good {
+  color: var(--good);
+  border-color: rgba(52, 211, 153, 0.4);
+}
+
+.pill.bad {
+  color: var(--bad);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.pill.busy {
+  color: var(--accent-2);
+  border-color: rgba(245, 158, 11, 0.4);
+}
+
+.legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  margin-right: 5px;
+  vertical-align: middle;
+}

--- a/examples/web/app/layout.tsx
+++ b/examples/web/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "htn-ai — Staircase World",
+  description:
+    "Browser preview of the htn-ai real-time planner: an agent discovers how to stack blocks into a staircase to reach a 3D coordinate up in the air.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -7,7 +7,7 @@ import { runBlocks, type BlocksRun } from "../lib/runBlocks";
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
 const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 
-type ScenarioId = "staircase" | "ledge" | "blocks";
+type ScenarioId = "staircase" | "ledge" | "quarry" | "blocks";
 
 type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun };
 
@@ -21,6 +21,11 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string }> = {
     name: "Climb the ledge",
     blurb:
       "A 2-high wall the agent can't climb directly (you ascend one level at a time). The planner figures out it must build a single step, then walk up and over.",
+  },
+  quarry: {
+    name: "Quarry (advanced)",
+    blurb:
+      "A grid world: reach the top of a height-4 pillar. Blocks are scattered across two depots and a wall blocks the way. The planner finds the optimal route to collect from both depots and build a 3-step staircase (1→2→3) to climb up — all from a position-only goal.",
   },
   blocks: {
     name: "Blocks World (Sussman)",

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -7,7 +7,7 @@ import { runBlocks, type BlocksRun } from "../lib/runBlocks";
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
 const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 
-type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "blocks";
+type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "blocks";
 
 type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun };
 
@@ -31,6 +31,11 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string }> = {
     name: "Scavenger (collect & harvest)",
     blurb:
       "Blocks lie scattered on the ground — no depots. You can only take the TOP of a stack, and only if you're high enough to reach it: a 2-pillar's top block is out of reach from the ground. So the planner grabs a loose block, builds a step, climbs it, harvests the pillar's top, and uses the blocks to reach a position up in the air.",
+  },
+  scavengerBig: {
+    name: "Scavenger XL (taller, harder)",
+    blurb:
+      "A bigger 4×3 grid with a taller height-3 goal and seven blocks scattered around (five loose + a 2-pillar). Loose blocks alone aren't enough, so the planner must harvest the pillar — cleverly standing on loose blocks as stepping stones to reach its top — and stack a 3-level structure to climb up.",
   },
   blocks: {
     name: "Blocks World (Sussman)",

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -1,65 +1,89 @@
 "use client";
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
-import { runScenario, traceSummary, type RunResult, type ScenarioId } from "../lib/run";
+import { runScenario, traceSummary, type RunResult } from "../lib/run";
+import { runBlocks, type BlocksRun } from "../lib/runBlocks";
 
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
+const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 
-const SCENARIO_LABELS: Record<ScenarioId, { name: string; blurb: string }> = {
+type ScenarioId = "staircase" | "ledge" | "blocks";
+
+type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun };
+
+const SCENARIOS: Record<ScenarioId, { name: string; blurb: string }> = {
   staircase: {
     name: "Staircase",
     blurb:
-      "Goal: stand at a coordinate up in the air. The only way to gain height is to stack boxes — so the planner discovers it must carry blocks from the depot and build a staircase, then climb it.",
+      "Goal: stand at a coordinate up in the air. The only way to gain height is to stack boxes — so the planner discovers it must carry blocks from the depot, build a staircase, and climb it.",
   },
   ledge: {
     name: "Climb the ledge",
     blurb:
       "A 2-high wall the agent can't climb directly (you ascend one level at a time). The planner figures out it must build a single step, then walk up and over.",
   },
+  blocks: {
+    name: "Blocks World (Sussman)",
+    blurb:
+      "The classic Sussman anomaly: C on A, A and B on the table; goal A-on-B-on-C. The naive order deadlocks, so the planner must interleave subgoals — unstack C first, then build the tower.",
+  },
 };
+
+function buildRun(id: ScenarioId): Run {
+  if (id === "blocks") return { kind: "blocks", data: runBlocks() };
+  return { kind: "grid", data: runScenario(id) };
+}
 
 export default function Page() {
   const [scenario, setScenario] = useState<ScenarioId>("staircase");
-  const [run, setRun] = useState<RunResult | null>(null);
+  const [run, setRun] = useState<Run | null>(null);
   const [step, setStep] = useState(0);
   const [playing, setPlaying] = useState(true);
   const [speed, setSpeed] = useState(750);
 
   useEffect(() => {
-    const r = runScenario(scenario);
-    setRun(r);
+    setRun(buildRun(scenario));
     setStep(0);
     setPlaying(true);
   }, [scenario]);
 
+  const frameCount = run ? run.data.frames.length : 0;
+  const lastStep = Math.max(frameCount - 1, 0);
+
   useEffect(() => {
     if (!playing || !run) return;
-    if (step >= run.frames.length - 1) {
+    if (step >= lastStep) {
       setPlaying(false);
       return;
     }
     const id = setTimeout(() => setStep((s) => s + 1), speed);
     return () => clearTimeout(id);
-  }, [playing, step, run, speed]);
+  }, [playing, step, run, speed, lastStep]);
 
-  const frame = run?.frames[step] ?? null;
-  const lastStep = run ? run.frames.length - 1 : 0;
-  const reached = run != null && step === lastStep && run.status === "succeeded";
-  const summary = useMemo(() => (run ? traceSummary(run.trace) : []), [run]);
-  const interesting = useMemo(
-    () => summary.filter((s) => /repair|replan|fail|scope|drift/.test(s.label)),
-    [summary],
-  );
+  const status = run?.data.status ?? "…";
+  const trace = run?.data.trace ?? [];
+  const summary = useMemo(() => traceSummary(trace), [trace]);
+  const interesting = useMemo(() => summary.filter((s) => /repair|replan|fail|scope|drift/.test(s.label)), [summary]);
+  const reached = run != null && step === lastStep && status === "succeeded";
 
   return (
     <div className="app">
       <div className="stage">
         <div className="title">
-          <h1>htn-ai · Staircase World</h1>
-          <p>{SCENARIO_LABELS[scenario].blurb}</p>
+          <h1>htn-ai · {SCENARIOS[scenario].name}</h1>
+          <p>{SCENARIOS[scenario].blurb}</p>
         </div>
-        {run && frame && (
-          <StaircaseScene frame={frame} instance={run.instance} target={run.target} reached={reached} />
+        {run?.kind === "grid" && (
+          <StaircaseScene
+            key="grid"
+            frame={run.data.frames[step]}
+            instance={run.data.instance}
+            target={run.data.target}
+            reached={reached}
+          />
+        )}
+        {run?.kind === "blocks" && (
+          <BlocksScene key="blocks" frame={run.data.frames[step]} blocks={run.data.blocks} reached={reached} />
         )}
       </div>
 
@@ -68,13 +92,13 @@ export default function Page() {
           <h2>Scenario</h2>
           <div className="row spread">
             <select value={scenario} onChange={(e) => setScenario(e.target.value as ScenarioId)}>
-              {(Object.keys(SCENARIO_LABELS) as ScenarioId[]).map((id) => (
+              {(Object.keys(SCENARIOS) as ScenarioId[]).map((id) => (
                 <option key={id} value={id}>
-                  {SCENARIO_LABELS[id].name}
+                  {SCENARIOS[id].name}
                 </option>
               ))}
             </select>
-            <StatusPill status={run?.status ?? "…"} />
+            <StatusPill status={status} />
           </div>
         </div>
 
@@ -98,7 +122,7 @@ export default function Page() {
             </button>
           </div>
           <div className="row" style={{ marginTop: 10 }}>
-            <span className="k mono" style={{ color: "var(--muted)" }}>
+            <span className="mono" style={{ color: "var(--muted)" }}>
               speed
             </span>
             <input
@@ -117,49 +141,34 @@ export default function Page() {
         </div>
 
         <div className="card">
-          <h2>Goal · 3D position</h2>
-          {run && (
+          <h2>Goal</h2>
+          {run?.kind === "grid" && (
             <div className="mono">
-              reach&nbsp;
+              be at 3D position&nbsp;
               <span style={{ color: "var(--accent-2)" }}>
-                ({run.target.x}, {run.target.y}, {run.target.z})
+                ({run.data.target.x}, {run.data.target.y}, {run.data.target.z})
               </span>
               <div style={{ color: "var(--muted)", marginTop: 4 }}>x, y(up), z — y &gt; 0 means in the air</div>
+            </div>
+          )}
+          {run?.kind === "blocks" && (
+            <div className="mono">
+              <span style={{ color: "var(--accent-2)" }}>on(A,B) ∧ on(B,C)</span>
+              <div style={{ color: "var(--muted)", marginTop: 4 }}>a tower: {run.data.goalText}</div>
             </div>
           )}
         </div>
 
         <div className="card">
           <h2>World state</h2>
-          {frame && (
-            <>
-              <div className="kv">
-                <span className="k">agent at</span>
-                <span className="mono">
-                  {frame.agentCell} · y={frame.agentY}
-                </span>
-              </div>
-              <div className="kv">
-                <span className="k">holding block</span>
-                <span className={`pill ${frame.holding ? "busy" : ""}`}>{frame.holding ? "yes" : "no"}</span>
-              </div>
-              {run!.instance.cells.map((c) => (
-                <div className="kv" key={c.name}>
-                  <span className="k">{c.name}</span>
-                  <span className="mono">
-                    height {frame.heights[c.name] ?? 0}
-                    {(frame.supplies[c.name] ?? 0) > 0 ? `  ·  supply ${frame.supplies[c.name]}` : ""}
-                  </span>
-                </div>
-              ))}
-            </>
-          )}
+          {run?.kind === "grid" && <GridState run={run.data} step={step} />}
+          {run?.kind === "blocks" && <BlocksState run={run.data} step={step} />}
         </div>
 
         <div className="card">
           <h2>Plan · discovered by search</h2>
           <div className="steps">
-            {run?.frames.slice(1).map((f, i) => {
+            {run?.data.frames.slice(1).map((f, i) => {
               const idx = i + 1;
               const cls = idx === step ? "active" : idx < step ? "done" : "";
               return (
@@ -169,7 +178,7 @@ export default function Page() {
                 </div>
               );
             })}
-            {run && run.frames.length <= 1 && <div className="step">no actions</div>}
+            {run && frameCount <= 1 && <div className="step">no actions</div>}
           </div>
         </div>
 
@@ -192,30 +201,59 @@ export default function Page() {
             </div>
           )}
         </div>
-
-        <div className="card">
-          <h2>Legend</h2>
-          <div className="legend">
-            <span>
-              <span className="swatch" style={{ background: "#38bdf8" }} />
-              agent
-            </span>
-            <span>
-              <span className="swatch" style={{ background: "#f59e0b" }} />
-              block / supply
-            </span>
-            <span>
-              <span className="swatch" style={{ background: "#3f7cc4" }} />
-              placed block
-            </span>
-            <span>
-              <span className="swatch" style={{ background: "#fbbf24" }} />
-              target coord
-            </span>
-          </div>
-        </div>
       </aside>
     </div>
+  );
+}
+
+function GridState({ run, step }: { run: RunResult; step: number }) {
+  const frame = run.frames[step];
+  if (!frame) return null;
+  return (
+    <>
+      <div className="kv">
+        <span className="k">agent at</span>
+        <span className="mono">
+          {frame.agentCell} · y={frame.agentY}
+        </span>
+      </div>
+      <div className="kv">
+        <span className="k">holding block</span>
+        <span className={`pill ${frame.holding ? "busy" : ""}`}>{frame.holding ? "yes" : "no"}</span>
+      </div>
+      {run.instance.cells.map((c) => (
+        <div className="kv" key={c.name}>
+          <span className="k">{c.name}</span>
+          <span className="mono">
+            height {frame.heights[c.name] ?? 0}
+            {(frame.supplies[c.name] ?? 0) > 0 ? `  ·  supply ${frame.supplies[c.name]}` : ""}
+          </span>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function BlocksState({ run, step }: { run: BlocksRun; step: number }) {
+  const frame = run.frames[step];
+  if (!frame) return null;
+  return (
+    <>
+      <div className="kv">
+        <span className="k">gripper</span>
+        <span className={`pill ${frame.held ? "busy" : ""}`}>
+          {frame.held ? `holding ${frame.held.toUpperCase()}` : "empty"}
+        </span>
+      </div>
+      {run.blocks.map((b) => (
+        <div className="kv" key={b}>
+          <span className="k">{b.toUpperCase()}</span>
+          <span className="mono">
+            {frame.held === b ? "in gripper" : `on ${frame.on[b] === "table" ? "table" : frame.on[b].toUpperCase()}`}
+          </span>
+        </div>
+      ))}
+    </>
   );
 }
 

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState } from "react";
+import { runScenario, traceSummary, type RunResult, type ScenarioId } from "../lib/run";
+
+const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
+
+const SCENARIO_LABELS: Record<ScenarioId, { name: string; blurb: string }> = {
+  staircase: {
+    name: "Staircase",
+    blurb:
+      "Goal: stand at a coordinate up in the air. The only way to gain height is to stack boxes — so the planner discovers it must carry blocks from the depot and build a staircase, then climb it.",
+  },
+  ledge: {
+    name: "Climb the ledge",
+    blurb:
+      "A 2-high wall the agent can't climb directly (you ascend one level at a time). The planner figures out it must build a single step, then walk up and over.",
+  },
+};
+
+export default function Page() {
+  const [scenario, setScenario] = useState<ScenarioId>("staircase");
+  const [run, setRun] = useState<RunResult | null>(null);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(true);
+  const [speed, setSpeed] = useState(750);
+
+  useEffect(() => {
+    const r = runScenario(scenario);
+    setRun(r);
+    setStep(0);
+    setPlaying(true);
+  }, [scenario]);
+
+  useEffect(() => {
+    if (!playing || !run) return;
+    if (step >= run.frames.length - 1) {
+      setPlaying(false);
+      return;
+    }
+    const id = setTimeout(() => setStep((s) => s + 1), speed);
+    return () => clearTimeout(id);
+  }, [playing, step, run, speed]);
+
+  const frame = run?.frames[step] ?? null;
+  const lastStep = run ? run.frames.length - 1 : 0;
+  const reached = run != null && step === lastStep && run.status === "succeeded";
+  const summary = useMemo(() => (run ? traceSummary(run.trace) : []), [run]);
+  const interesting = useMemo(
+    () => summary.filter((s) => /repair|replan|fail|scope|drift/.test(s.label)),
+    [summary],
+  );
+
+  return (
+    <div className="app">
+      <div className="stage">
+        <div className="title">
+          <h1>htn-ai · Staircase World</h1>
+          <p>{SCENARIO_LABELS[scenario].blurb}</p>
+        </div>
+        {run && frame && (
+          <StaircaseScene frame={frame} instance={run.instance} target={run.target} reached={reached} />
+        )}
+      </div>
+
+      <aside className="panel">
+        <div className="card">
+          <h2>Scenario</h2>
+          <div className="row spread">
+            <select value={scenario} onChange={(e) => setScenario(e.target.value as ScenarioId)}>
+              {(Object.keys(SCENARIO_LABELS) as ScenarioId[]).map((id) => (
+                <option key={id} value={id}>
+                  {SCENARIO_LABELS[id].name}
+                </option>
+              ))}
+            </select>
+            <StatusPill status={run?.status ?? "…"} />
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>Playback</h2>
+          <div className="row">
+            <button className="primary" onClick={() => setPlaying((p) => !p)} disabled={!run}>
+              {playing ? "⏸ Pause" : "▶ Play"}
+            </button>
+            <button onClick={() => setStep((s) => Math.min(s + 1, lastStep))} disabled={!run || step >= lastStep}>
+              Step ⟩
+            </button>
+            <button
+              onClick={() => {
+                setStep(0);
+                setPlaying(true);
+              }}
+              disabled={!run}
+            >
+              ⟲ Reset
+            </button>
+          </div>
+          <div className="row" style={{ marginTop: 10 }}>
+            <span className="k mono" style={{ color: "var(--muted)" }}>
+              speed
+            </span>
+            <input
+              type="range"
+              min={120}
+              max={1400}
+              step={20}
+              value={1520 - speed}
+              onChange={(e) => setSpeed(1520 - Number(e.target.value))}
+              style={{ flex: 1 }}
+            />
+            <span className="mono">
+              {step}/{lastStep}
+            </span>
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>Goal · 3D position</h2>
+          {run && (
+            <div className="mono">
+              reach&nbsp;
+              <span style={{ color: "var(--accent-2)" }}>
+                ({run.target.x}, {run.target.y}, {run.target.z})
+              </span>
+              <div style={{ color: "var(--muted)", marginTop: 4 }}>x, y(up), z — y &gt; 0 means in the air</div>
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <h2>World state</h2>
+          {frame && (
+            <>
+              <div className="kv">
+                <span className="k">agent at</span>
+                <span className="mono">
+                  {frame.agentCell} · y={frame.agentY}
+                </span>
+              </div>
+              <div className="kv">
+                <span className="k">holding block</span>
+                <span className={`pill ${frame.holding ? "busy" : ""}`}>{frame.holding ? "yes" : "no"}</span>
+              </div>
+              {run!.instance.cells.map((c) => (
+                <div className="kv" key={c.name}>
+                  <span className="k">{c.name}</span>
+                  <span className="mono">
+                    height {frame.heights[c.name] ?? 0}
+                    {(frame.supplies[c.name] ?? 0) > 0 ? `  ·  supply ${frame.supplies[c.name]}` : ""}
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div className="card">
+          <h2>Plan · discovered by search</h2>
+          <div className="steps">
+            {run?.frames.slice(1).map((f, i) => {
+              const idx = i + 1;
+              const cls = idx === step ? "active" : idx < step ? "done" : "";
+              return (
+                <div className={`step ${cls}`} key={idx}>
+                  <span className="idx">{idx}</span>
+                  <span>{f.action}</span>
+                </div>
+              );
+            })}
+            {run && run.frames.length <= 1 && <div className="step">no actions</div>}
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>Trace events</h2>
+          <div className="legend" style={{ marginBottom: 8 }}>
+            {summary.map((s) => (
+              <span key={s.label} className="mono">
+                {s.label}:{s.count}
+              </span>
+            ))}
+          </div>
+          {interesting.length > 0 ? (
+            <div className="mono" style={{ color: "var(--accent-2)" }}>
+              reactive events: {interesting.map((s) => `${s.label}×${s.count}`).join(", ")}
+            </div>
+          ) : (
+            <div className="mono" style={{ color: "var(--muted)" }}>
+              clean run — no repair/replan needed
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <h2>Legend</h2>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "#38bdf8" }} />
+              agent
+            </span>
+            <span>
+              <span className="swatch" style={{ background: "#f59e0b" }} />
+              block / supply
+            </span>
+            <span>
+              <span className="swatch" style={{ background: "#3f7cc4" }} />
+              placed block
+            </span>
+            <span>
+              <span className="swatch" style={{ background: "#fbbf24" }} />
+              target coord
+            </span>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const cls = status === "succeeded" ? "good" : status === "failed" ? "bad" : "busy";
+  return <span className={`pill ${cls}`}>{status}</span>;
+}

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
-import { runScenario, traceSummary, type RunResult } from "../lib/run";
+import { runScenario, scenarioHeavyMs, traceSummary, type RunResult } from "../lib/run";
 import { runBlocks, type BlocksRun } from "../lib/runBlocks";
 
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
 const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 
-type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "blocks";
+type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge" | "blocks";
 
 type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun };
 
@@ -37,6 +37,11 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string }> = {
     blurb:
       "A bigger 4×3 grid with a taller height-3 goal and seven blocks scattered around (five loose + a 2-pillar). Loose blocks alone aren't enough, so the planner must harvest the pillar — cleverly standing on loose blocks as stepping stones to reach its top — and stack a 3-level structure to climb up.",
   },
+  scavengerHuge: {
+    name: "Scavenger HUGE (stress · ~9s)",
+    blurb:
+      "A 6×4 grid (24 cells) littered with blocks — a deliberate stress test, ≈10× the compute of the others (~9s to plan; the page is busy while it searches). It shows the planner solving a large symbolic problem from a position-only goal. Search is hard-capped so it can't run away.",
+  },
   blocks: {
     name: "Blocks World (Sussman)",
     blurb:
@@ -52,14 +57,25 @@ function buildRun(id: ScenarioId): Run {
 export default function Page() {
   const [scenario, setScenario] = useState<ScenarioId>("staircase");
   const [run, setRun] = useState<Run | null>(null);
+  const [computing, setComputing] = useState(true);
   const [step, setStep] = useState(0);
   const [playing, setPlaying] = useState(true);
   const [speed, setSpeed] = useState(750);
 
   useEffect(() => {
-    setRun(buildRun(scenario));
+    setComputing(true);
+    setRun(null);
     setStep(0);
-    setPlaying(true);
+    // Defer the (possibly heavy, synchronous) plan+rollout so React paints the
+    // "Planning…" state first. The big stress scenario blocks for ~9s; search is
+    // hard-capped (maxNodes) so it can never run away.
+    const id = setTimeout(() => {
+      const r = buildRun(scenario);
+      setRun(r);
+      setComputing(false);
+      setPlaying(true);
+    }, 30);
+    return () => clearTimeout(id);
   }, [scenario]);
 
   const frameCount = run ? run.data.frames.length : 0;
@@ -99,6 +115,30 @@ export default function Page() {
         )}
         {run?.kind === "blocks" && (
           <BlocksScene key="blocks" frame={run.data.frames[step]} blocks={run.data.blocks} reached={reached} />
+        )}
+        {computing && (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "column",
+              gap: 8,
+              color: "var(--muted)",
+              background: "rgba(11,14,20,0.55)",
+              zIndex: 3,
+            }}
+          >
+            <div style={{ fontSize: 16, color: "var(--text)" }}>⏳ Planning…</div>
+            {scenarioHeavyMs(scenario) > 0 && (
+              <div style={{ fontSize: 12 }}>
+                heavy stress scenario — the planner is searching (~{Math.round(scenarioHeavyMs(scenario) / 1000)}s); the
+                page is busy meanwhile
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -7,7 +7,7 @@ import { runBlocks, type BlocksRun } from "../lib/runBlocks";
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
 const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 
-type ScenarioId = "staircase" | "ledge" | "quarry" | "blocks";
+type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "blocks";
 
 type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun };
 
@@ -26,6 +26,11 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string }> = {
     name: "Quarry (advanced)",
     blurb:
       "A grid world: reach the top of a height-4 pillar. Blocks are scattered across two depots and a wall blocks the way. The planner finds the optimal route to collect from both depots and build a 3-step staircase (1→2→3) to climb up — all from a position-only goal.",
+  },
+  scavenger: {
+    name: "Scavenger (collect & harvest)",
+    blurb:
+      "Blocks lie scattered on the ground — no depots. You can only take the TOP of a stack, and only if you're high enough to reach it: a 2-pillar's top block is out of reach from the ground. So the planner grabs a loose block, builds a step, climbs it, harvests the pillar's top, and uses the blocks to reach a position up in the air.",
   },
   blocks: {
     name: "Blocks World (Sussman)",

--- a/examples/web/components/BlocksScene.tsx
+++ b/examples/web/components/BlocksScene.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { GizmoHelper, GizmoViewport, Grid, OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { BlocksFrame } from "../lib/runBlocks";
+
+const PALETTE = ["#60a5fa", "#f472b6", "#34d399", "#fbbf24", "#a78bfa", "#fb7185"];
+
+const letterCache = new Map<string, THREE.CanvasTexture>();
+function letterTexture(ch: string): THREE.CanvasTexture {
+  const key = ch.toUpperCase();
+  const cached = letterCache.get(key);
+  if (cached) return cached;
+  const c = document.createElement("canvas");
+  c.width = c.height = 128;
+  const ctx = c.getContext("2d")!;
+  ctx.clearRect(0, 0, 128, 128);
+  ctx.font = "bold 90px ui-sans-serif, system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.lineWidth = 12;
+  ctx.strokeStyle = "rgba(7,10,16,0.92)";
+  ctx.strokeText(key, 64, 70);
+  ctx.fillStyle = "#ffffff";
+  ctx.fillText(key, 64, 70);
+  const tex = new THREE.CanvasTexture(c);
+  tex.anisotropy = 4;
+  letterCache.set(key, tex);
+  return tex;
+}
+
+function Block({ target, color, label, held, reached }: { target: THREE.Vector3; color: string; label: string; held: boolean; reached: boolean }) {
+  const ref = useRef<THREE.Group>(null);
+  useEffect(() => {
+    ref.current?.position.copy(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useFrame((_, dt) => {
+    ref.current?.position.lerp(target, 1 - Math.pow(0.0015, Math.min(dt, 0.05)));
+  });
+  return (
+    <group ref={ref}>
+      <mesh castShadow receiveShadow>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial
+          color={color}
+          emissive={held ? "#1f2937" : reached ? "#064e3b" : "#000000"}
+          emissiveIntensity={held ? 0.5 : reached ? 0.5 : 0}
+          roughness={0.6}
+          metalness={0.05}
+        />
+      </mesh>
+      <sprite scale={[0.85, 0.85, 0.85]} renderOrder={20}>
+        <spriteMaterial map={letterTexture(label)} depthTest={false} transparent />
+      </sprite>
+    </group>
+  );
+}
+
+function Scene({ frame, blocks, reached }: { frame: BlocksFrame; blocks: string[]; reached: boolean }) {
+  const colorOf = useMemo(() => {
+    const sorted = [...blocks].sort();
+    const m: Record<string, string> = {};
+    sorted.forEach((b, i) => (m[b] = PALETTE[i % PALETTE.length]));
+    return m;
+  }, [blocks]);
+
+  const targets = useMemo(() => {
+    const m: Record<string, THREE.Vector3> = {};
+    for (const b of blocks) {
+      const [x, depth] = frame.positions[b] ?? [0, 0];
+      m[b] = new THREE.Vector3(x, depth + 0.5, 0);
+    }
+    return m;
+  }, [frame, blocks]);
+
+  return (
+    <>
+      <PerspectiveCamera makeDefault position={[3.5, 3.6, 6.5]} fov={42} />
+      <OrbitControls target={[0, 1, 0]} enablePan minDistance={3} maxDistance={24} maxPolarAngle={Math.PI / 2.1} />
+      <ambientLight intensity={0.55} />
+      <directionalLight position={[5, 9, 4]} intensity={1.15} castShadow shadow-mapSize={[1024, 1024]} />
+      <hemisphereLight args={["#9db7ff", "#0b0e14", 0.4]} />
+
+      {/* the table */}
+      <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[14, 10]} />
+        <meshStandardMaterial color="#10151f" />
+      </mesh>
+      <Grid args={[20, 20]} cellColor="#1c2436" sectionColor="#283350" fadeDistance={26} infiniteGrid />
+
+      {blocks.map((b) => (
+        <Block key={b} target={targets[b]} color={colorOf[b]} label={b} held={frame.held === b} reached={reached} />
+      ))}
+
+      <GizmoHelper alignment="bottom-right" margin={[64, 64]}>
+        <GizmoViewport axisColors={["#f87171", "#34d399", "#38bdf8"]} labelColor="#0b0e14" />
+      </GizmoHelper>
+    </>
+  );
+}
+
+export default function BlocksScene(props: { frame: BlocksFrame; blocks: string[]; reached: boolean }) {
+  return (
+    <Canvas shadows dpr={[1, 2]} gl={{ antialias: true }} style={{ background: "linear-gradient(180deg,#0d1320,#0b0e14)" }}>
+      <Scene {...props} />
+    </Canvas>
+  );
+}

--- a/examples/web/components/StaircaseScene.tsx
+++ b/examples/web/components/StaircaseScene.tsx
@@ -1,0 +1,155 @@
+"use client";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { GizmoHelper, GizmoViewport, Grid, OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { StaircaseInstance } from "@scenarios/staircase";
+import type { Frame } from "../lib/run";
+
+const AGENT_R = 0.32;
+
+interface SceneProps {
+  frame: Frame;
+  instance: StaircaseInstance;
+  target: { x: number; z: number; y: number; cell: string };
+  reached: boolean;
+}
+
+function Agent({ target, holding }: { target: THREE.Vector3; holding: boolean }) {
+  const ref = useRef<THREE.Group>(null);
+  useEffect(() => {
+    ref.current?.position.copy(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useFrame((_, dt) => {
+    const g = ref.current;
+    if (!g) return;
+    g.position.lerp(target, 1 - Math.pow(0.0015, Math.min(dt, 0.05)));
+  });
+  return (
+    <group ref={ref}>
+      <mesh castShadow>
+        <sphereGeometry args={[AGENT_R, 28, 28]} />
+        <meshStandardMaterial color="#38bdf8" emissive="#0b3b4d" emissiveIntensity={0.6} roughness={0.4} />
+      </mesh>
+      {holding && (
+        <mesh position={[0, AGENT_R + 0.35, 0]} castShadow>
+          <boxGeometry args={[0.42, 0.42, 0.42]} />
+          <meshStandardMaterial color="#f59e0b" emissive="#7a4d00" emissiveIntensity={0.4} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+function TargetMarker({ pos, reached }: { pos: THREE.Vector3; reached: boolean }) {
+  const ref = useRef<THREE.Mesh>(null);
+  useFrame((state) => {
+    const m = ref.current;
+    if (!m) return;
+    const s = 1 + Math.sin(state.clock.elapsedTime * 3) * 0.08;
+    m.scale.setScalar(s);
+    m.rotation.y += 0.01;
+  });
+  const color = reached ? "#34d399" : "#fbbf24";
+  return (
+    <group position={pos}>
+      <mesh ref={ref}>
+        <boxGeometry args={[0.85, 0.85, 0.85]} />
+        <meshBasicMaterial color={color} wireframe />
+      </mesh>
+      <pointLight color={color} intensity={reached ? 3 : 1.5} distance={4} />
+    </group>
+  );
+}
+
+function Column({ x, z, height, isTarget, isSupply }: { x: number; z: number; height: number; isTarget: boolean; isSupply: boolean }) {
+  const tile = isTarget ? "#3b2f12" : isSupply ? "#3a2a10" : "#1b2333";
+  const block = isTarget ? "#6366f1" : "#3f7cc4";
+  return (
+    <group position={[x, 0, z]}>
+      {/* cell tile on the ground */}
+      <mesh position={[0, 0.02, 0]} receiveShadow>
+        <boxGeometry args={[0.96, 0.04, 0.96]} />
+        <meshStandardMaterial color={tile} />
+      </mesh>
+      {/* stacked unit blocks */}
+      {Array.from({ length: height }).map((_, k) => (
+        <mesh key={k} position={[0, k + 0.5, 0]} castShadow receiveShadow>
+          <boxGeometry args={[0.9, 0.96, 0.9]} />
+          <meshStandardMaterial color={block} roughness={0.7} metalness={0.05} />
+        </mesh>
+      ))}
+      {isSupply && height === 0 && (
+        <mesh position={[0, 0.12, 0]}>
+          <boxGeometry args={[0.5, 0.16, 0.5]} />
+          <meshStandardMaterial color="#f59e0b" emissive="#5a3b00" emissiveIntensity={0.5} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+function Scene({ frame, instance, target, reached }: SceneProps) {
+  const cellPos = useMemo(() => {
+    const m = new Map<string, [number, number]>();
+    for (const c of instance.cells) m.set(c.name, [c.x, c.z]);
+    return m;
+  }, [instance]);
+  const supplyCells = useMemo(() => new Set(instance.cells.filter((c) => (c.supply ?? 0) > 0).map((c) => c.name)), [instance]);
+
+  const center = useMemo<[number, number, number]>(() => {
+    const xs = instance.cells.map((c) => c.x);
+    const zs = instance.cells.map((c) => c.z);
+    return [(Math.min(...xs) + Math.max(...xs)) / 2, 0.8, (Math.min(...zs) + Math.max(...zs)) / 2];
+  }, [instance]);
+
+  const [ax, az] = cellPos.get(frame.agentCell) ?? [0, 0];
+  const agentTarget = useMemo(() => new THREE.Vector3(ax, frame.agentY + AGENT_R + 0.02, az), [ax, az, frame.agentY]);
+  const markerPos = useMemo(() => new THREE.Vector3(target.x, target.y + 0.5, target.z), [target]);
+
+  return (
+    <>
+      <PerspectiveCamera makeDefault position={[center[0] + 4.5, 4.8, center[2] + 6]} fov={42} />
+      <OrbitControls target={center} enablePan minDistance={3} maxDistance={30} maxPolarAngle={Math.PI / 2.1} />
+      <ambientLight intensity={0.55} />
+      <directionalLight position={[6, 10, 4]} intensity={1.1} castShadow shadow-mapSize={[1024, 1024]} />
+      <hemisphereLight args={["#9db7ff", "#0b0e14", 0.4]} />
+
+      <Grid
+        args={[40, 40]}
+        position={[center[0], 0, center[2]]}
+        cellColor="#1c2436"
+        sectionColor="#283350"
+        fadeDistance={34}
+        infiniteGrid
+      />
+
+      {instance.cells.map((c) => (
+        <Column
+          key={c.name}
+          x={c.x}
+          z={c.z}
+          height={frame.heights[c.name] ?? 0}
+          isTarget={c.name === target.cell}
+          isSupply={supplyCells.has(c.name)}
+        />
+      ))}
+
+      <Agent target={agentTarget} holding={frame.holding} />
+      <TargetMarker pos={markerPos} reached={reached} />
+
+      <GizmoHelper alignment="bottom-right" margin={[64, 64]}>
+        <GizmoViewport axisColors={["#f87171", "#34d399", "#38bdf8"]} labelColor="#0b0e14" />
+      </GizmoHelper>
+    </>
+  );
+}
+
+export default function StaircaseScene(props: SceneProps) {
+  return (
+    <Canvas shadows dpr={[1, 2]} gl={{ antialias: true }} style={{ background: "linear-gradient(180deg,#0d1320,#0b0e14)" }}>
+      <Scene {...props} />
+    </Canvas>
+  );
+}

--- a/examples/web/components/StaircaseScene.tsx
+++ b/examples/web/components/StaircaseScene.tsx
@@ -63,9 +63,23 @@ function TargetMarker({ pos, reached }: { pos: THREE.Vector3; reached: boolean }
   );
 }
 
-function Column({ x, z, height, isTarget, isSupply }: { x: number; z: number; height: number; isTarget: boolean; isSupply: boolean }) {
-  const tile = isTarget ? "#3b2f12" : isSupply ? "#3a2a10" : "#1b2333";
-  const block = isTarget ? "#6366f1" : "#3f7cc4";
+function Column({
+  x,
+  z,
+  height,
+  isTarget,
+  isSupply,
+  isWall,
+}: {
+  x: number;
+  z: number;
+  height: number;
+  isTarget: boolean;
+  isSupply: boolean;
+  isWall: boolean;
+}) {
+  const tile = isWall ? "#0c0f16" : isTarget ? "#3b2f12" : isSupply ? "#3a2a10" : "#1b2333";
+  const block = isWall ? "#2b3140" : isTarget ? "#6366f1" : "#3f7cc4";
   return (
     <group position={[x, 0, z]}>
       {/* cell tile on the ground */}
@@ -73,11 +87,11 @@ function Column({ x, z, height, isTarget, isSupply }: { x: number; z: number; he
         <boxGeometry args={[0.96, 0.04, 0.96]} />
         <meshStandardMaterial color={tile} />
       </mesh>
-      {/* stacked unit blocks */}
+      {/* stacked unit blocks (a tall dark pillar for walls) */}
       {Array.from({ length: height }).map((_, k) => (
         <mesh key={k} position={[0, k + 0.5, 0]} castShadow receiveShadow>
           <boxGeometry args={[0.9, 0.96, 0.9]} />
-          <meshStandardMaterial color={block} roughness={0.7} metalness={0.05} />
+          <meshStandardMaterial color={block} roughness={isWall ? 0.95 : 0.7} metalness={0.05} />
         </mesh>
       ))}
       {isSupply && height === 0 && (
@@ -97,11 +111,12 @@ function Scene({ frame, instance, target, reached }: SceneProps) {
     return m;
   }, [instance]);
   const supplyCells = useMemo(() => new Set(instance.cells.filter((c) => (c.supply ?? 0) > 0).map((c) => c.name)), [instance]);
+  const wallCells = useMemo(() => new Set(instance.cells.filter((c) => c.wall).map((c) => c.name)), [instance]);
 
   const center = useMemo<[number, number, number]>(() => {
     const xs = instance.cells.map((c) => c.x);
     const zs = instance.cells.map((c) => c.z);
-    return [(Math.min(...xs) + Math.max(...xs)) / 2, 0.8, (Math.min(...zs) + Math.max(...zs)) / 2];
+    return [(Math.min(...xs) + Math.max(...xs)) / 2, 1.2, (Math.min(...zs) + Math.max(...zs)) / 2];
   }, [instance]);
 
   const [ax, az] = cellPos.get(frame.agentCell) ?? [0, 0];
@@ -110,7 +125,7 @@ function Scene({ frame, instance, target, reached }: SceneProps) {
 
   return (
     <>
-      <PerspectiveCamera makeDefault position={[center[0] + 4.5, 4.8, center[2] + 6]} fov={42} />
+      <PerspectiveCamera makeDefault position={[center[0] + 5, 6, center[2] + 7.5]} fov={42} />
       <OrbitControls target={center} enablePan minDistance={3} maxDistance={30} maxPolarAngle={Math.PI / 2.1} />
       <ambientLight intensity={0.55} />
       <directionalLight position={[6, 10, 4]} intensity={1.1} castShadow shadow-mapSize={[1024, 1024]} />
@@ -133,6 +148,7 @@ function Scene({ frame, instance, target, reached }: SceneProps) {
           height={frame.heights[c.name] ?? 0}
           isTarget={c.name === target.cell}
           isSupply={supplyCells.has(c.name)}
+          isWall={wallCells.has(c.name)}
         />
       ))}
 

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -1,0 +1,102 @@
+"use client";
+/**
+ * The bridge between the htn-ai library and the 3D view. We build a model from
+ * a shared scenario, drive the *real* reactive Planner tick-by-tick, and capture
+ * a world snapshot after every executed step — plus the full TraceEvent stream.
+ * The scene then animates through these frames. Nothing here re-implements
+ * planning; it just observes the planner running in the browser.
+ */
+import { Planner, goal, type TraceEvent } from "htn-ai";
+import {
+  GOAL_HEIGHT,
+  ledgeGoal,
+  ledgeInstance,
+  staircaseGoal,
+  staircaseInstance,
+  staircaseModel,
+  type StaircaseInstance,
+} from "@scenarios/staircase";
+
+export type ScenarioId = "staircase" | "ledge";
+
+export interface Frame {
+  /** column heights per cell */
+  heights: Record<string, number>;
+  /** remaining supply per cell */
+  supplies: Record<string, number>;
+  agentCell: string;
+  /** the agent's elevation — the ONLY thing the goal constrains (besides x,z) */
+  agentY: number;
+  holding: boolean;
+  /** label of the action that produced this frame ("start" for the initial one) */
+  action: string;
+}
+
+export interface RunResult {
+  scenario: ScenarioId;
+  instance: StaircaseInstance;
+  /** the 3D coordinate the agent must reach (x,z from the cell, y = elevation) */
+  target: { x: number; z: number; y: number; cell: string };
+  frames: Frame[];
+  status: string;
+  trace: TraceEvent[];
+}
+
+const SCENARIOS: Record<ScenarioId, { instance: () => StaircaseInstance; goal: () => ReturnType<typeof staircaseGoal>; target: { cell: string; y: number } }> = {
+  staircase: { instance: staircaseInstance, goal: staircaseGoal, target: { cell: "goal", y: GOAL_HEIGHT } },
+  ledge: { instance: () => ledgeInstance(1), goal: ledgeGoal, target: { cell: "ledge", y: 2 } },
+};
+
+export function runScenario(id: ScenarioId): RunResult {
+  const cfg = SCENARIOS[id];
+  const instance = cfg.instance();
+  const model = staircaseModel(instance);
+
+  const trace: TraceEvent[] = [];
+  let t = 0;
+  const planner = new Planner(model, {
+    goals: [goal(cfg.goal())],
+    now: () => t,
+    seed: 1,
+    trace: (e) => trace.push(e),
+  });
+
+  const cellNames = instance.cells.map((c) => c.name);
+  const snap = (action: string): Frame => ({
+    heights: Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "height", c) as number])),
+    supplies: Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "supply", c) as number])),
+    agentCell: model.read(planner.state, "agentAt") as string,
+    agentY: model.read(planner.state, "agentY") as number,
+    holding: model.read(planner.state, "holding") as boolean,
+    action,
+  });
+
+  const frames: Frame[] = [snap("start")];
+
+  for (let i = 0; i < 2000; i++) {
+    const status = planner.getStatus();
+    if (status === "succeeded" || status === "failed") break;
+    t += 1;
+    const before = trace.length;
+    planner.tick({ ms: 5 });
+    const done = trace.slice(before).find((e) => e.t === "step.done");
+    if (done && done.t === "step.done") frames.push(snap(done.label));
+  }
+
+  const targetCell = instance.cells.find((c) => c.name === cfg.target.cell)!;
+  return {
+    scenario: id,
+    instance,
+    target: { x: targetCell.x, z: targetCell.z, y: cfg.target.y, cell: cfg.target.cell },
+    frames,
+    status: planner.getStatus(),
+    trace,
+  };
+}
+
+/** Human-friendly counts for the trace summary panel. */
+export function traceSummary(trace: TraceEvent[]): { label: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const e of trace) counts.set(e.t, (counts.get(e.t) ?? 0) + 1);
+  return [...counts.entries()].map(([label, count]) => ({ label, count }));
+}

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -14,7 +14,10 @@ import {
   ledgeInstance,
   quarryGoal,
   quarryInstance,
+  SCAVENGER_BIG_GOAL_HEIGHT,
   SCAVENGER_GOAL_HEIGHT,
+  scavengerBigGoal,
+  scavengerBigInstance,
   scavengerGoal,
   scavengerInstance,
   scavengerModel,
@@ -25,7 +28,7 @@ import {
 } from "@scenarios/staircase";
 import type { Model } from "htn-ai";
 
-export type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger";
+export type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig";
 
 export interface Frame {
   /** column heights per cell */
@@ -55,6 +58,8 @@ interface ScenarioCfg {
   goal: () => ReturnType<typeof staircaseGoal>;
   model: (inst: StaircaseInstance) => Model;
   target: { cell: string; y: number };
+  /** weighted-A* weight; higher = greedier/faster search for larger instances */
+  weight?: number;
 }
 
 const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
@@ -62,6 +67,7 @@ const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
   ledge: { instance: () => ledgeInstance(1), goal: ledgeGoal, model: staircaseModel, target: { cell: "ledge", y: 2 } },
   quarry: { instance: quarryInstance, goal: quarryGoal, model: staircaseModel, target: { cell: "pillar", y: QUARRY_GOAL_HEIGHT } },
   scavenger: { instance: scavengerInstance, goal: scavengerGoal, model: scavengerModel, target: { cell: "goal", y: SCAVENGER_GOAL_HEIGHT } },
+  scavengerBig: { instance: scavengerBigInstance, goal: scavengerBigGoal, model: scavengerModel, target: { cell: "goal", y: SCAVENGER_BIG_GOAL_HEIGHT }, weight: 5 },
 };
 
 export function runScenario(id: ScenarioId): RunResult {
@@ -76,6 +82,7 @@ export function runScenario(id: ScenarioId): RunResult {
     goals: [goal(cfg.goal())],
     now: () => t,
     seed: 1,
+    weight: cfg.weight,
     trace: (e) => trace.push(e),
   });
 

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -9,15 +9,18 @@
 import { Planner, goal, type TraceEvent } from "htn-ai";
 import {
   GOAL_HEIGHT,
+  QUARRY_GOAL_HEIGHT,
   ledgeGoal,
   ledgeInstance,
+  quarryGoal,
+  quarryInstance,
   staircaseGoal,
   staircaseInstance,
   staircaseModel,
   type StaircaseInstance,
 } from "@scenarios/staircase";
 
-export type ScenarioId = "staircase" | "ledge";
+export type ScenarioId = "staircase" | "ledge" | "quarry";
 
 export interface Frame {
   /** column heights per cell */
@@ -45,6 +48,7 @@ export interface RunResult {
 const SCENARIOS: Record<ScenarioId, { instance: () => StaircaseInstance; goal: () => ReturnType<typeof staircaseGoal>; target: { cell: string; y: number } }> = {
   staircase: { instance: staircaseInstance, goal: staircaseGoal, target: { cell: "goal", y: GOAL_HEIGHT } },
   ledge: { instance: () => ledgeInstance(1), goal: ledgeGoal, target: { cell: "ledge", y: 2 } },
+  quarry: { instance: quarryInstance, goal: quarryGoal, target: { cell: "pillar", y: QUARRY_GOAL_HEIGHT } },
 };
 
 export function runScenario(id: ScenarioId): RunResult {
@@ -73,12 +77,12 @@ export function runScenario(id: ScenarioId): RunResult {
 
   const frames: Frame[] = [snap("start")];
 
-  for (let i = 0; i < 2000; i++) {
+  for (let i = 0; i < 4000; i++) {
     const status = planner.getStatus();
     if (status === "succeeded" || status === "failed") break;
     t += 1;
     const before = trace.length;
-    planner.tick({ ms: 5 });
+    planner.tick({ ms: 30 }); // generous budget; this loop runs offline, not per-frame
     const done = trace.slice(before).find((e) => e.t === "step.done");
     if (done && done.t === "step.done") frames.push(snap(done.label));
   }

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -16,9 +16,13 @@ import {
   quarryInstance,
   SCAVENGER_BIG_GOAL_HEIGHT,
   SCAVENGER_GOAL_HEIGHT,
+  SCAVENGER_HUGE,
   scavengerBigGoal,
   scavengerBigInstance,
   scavengerGoal,
+  scavengerHugeGoal,
+  scavengerHugeGoalCell,
+  scavengerHugeInstance,
   scavengerInstance,
   scavengerModel,
   staircaseGoal,
@@ -28,7 +32,7 @@ import {
 } from "@scenarios/staircase";
 import type { Model } from "htn-ai";
 
-export type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig";
+export type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge";
 
 export interface Frame {
   /** column heights per cell */
@@ -60,6 +64,10 @@ interface ScenarioCfg {
   target: { cell: string; y: number };
   /** weighted-A* weight; higher = greedier/faster search for larger instances */
   weight?: number;
+  /** hard search cap (safety net so a big instance can never run away in-browser) */
+  maxNodes?: number;
+  /** rough heads-up shown while planning, for the heavy ones */
+  heavyMs?: number;
 }
 
 const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
@@ -68,7 +76,21 @@ const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
   quarry: { instance: quarryInstance, goal: quarryGoal, model: staircaseModel, target: { cell: "pillar", y: QUARRY_GOAL_HEIGHT } },
   scavenger: { instance: scavengerInstance, goal: scavengerGoal, model: scavengerModel, target: { cell: "goal", y: SCAVENGER_GOAL_HEIGHT } },
   scavengerBig: { instance: scavengerBigInstance, goal: scavengerBigGoal, model: scavengerModel, target: { cell: "goal", y: SCAVENGER_BIG_GOAL_HEIGHT }, weight: 5 },
+  scavengerHuge: {
+    instance: scavengerHugeInstance,
+    goal: scavengerHugeGoal,
+    model: scavengerModel,
+    target: { cell: scavengerHugeGoalCell, y: SCAVENGER_HUGE.goalHeight },
+    weight: 6,
+    maxNodes: 8000,
+    heavyMs: 9000,
+  },
 };
+
+/** Rough heads-up (ms) for scenarios whose planning is slow enough to warn about. */
+export function scenarioHeavyMs(id: ScenarioId): number {
+  return SCENARIOS[id].heavyMs ?? 0;
+}
 
 export function runScenario(id: ScenarioId): RunResult {
   const cfg = SCENARIOS[id];
@@ -83,6 +105,7 @@ export function runScenario(id: ScenarioId): RunResult {
     now: () => t,
     seed: 1,
     weight: cfg.weight,
+    maxNodes: cfg.maxNodes,
     trace: (e) => trace.push(e),
   });
 

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -14,13 +14,18 @@ import {
   ledgeInstance,
   quarryGoal,
   quarryInstance,
+  SCAVENGER_GOAL_HEIGHT,
+  scavengerGoal,
+  scavengerInstance,
+  scavengerModel,
   staircaseGoal,
   staircaseInstance,
   staircaseModel,
   type StaircaseInstance,
 } from "@scenarios/staircase";
+import type { Model } from "htn-ai";
 
-export type ScenarioId = "staircase" | "ledge" | "quarry";
+export type ScenarioId = "staircase" | "ledge" | "quarry" | "scavenger";
 
 export interface Frame {
   /** column heights per cell */
@@ -45,16 +50,25 @@ export interface RunResult {
   trace: TraceEvent[];
 }
 
-const SCENARIOS: Record<ScenarioId, { instance: () => StaircaseInstance; goal: () => ReturnType<typeof staircaseGoal>; target: { cell: string; y: number } }> = {
-  staircase: { instance: staircaseInstance, goal: staircaseGoal, target: { cell: "goal", y: GOAL_HEIGHT } },
-  ledge: { instance: () => ledgeInstance(1), goal: ledgeGoal, target: { cell: "ledge", y: 2 } },
-  quarry: { instance: quarryInstance, goal: quarryGoal, target: { cell: "pillar", y: QUARRY_GOAL_HEIGHT } },
+interface ScenarioCfg {
+  instance: () => StaircaseInstance;
+  goal: () => ReturnType<typeof staircaseGoal>;
+  model: (inst: StaircaseInstance) => Model;
+  target: { cell: string; y: number };
+}
+
+const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
+  staircase: { instance: staircaseInstance, goal: staircaseGoal, model: staircaseModel, target: { cell: "goal", y: GOAL_HEIGHT } },
+  ledge: { instance: () => ledgeInstance(1), goal: ledgeGoal, model: staircaseModel, target: { cell: "ledge", y: 2 } },
+  quarry: { instance: quarryInstance, goal: quarryGoal, model: staircaseModel, target: { cell: "pillar", y: QUARRY_GOAL_HEIGHT } },
+  scavenger: { instance: scavengerInstance, goal: scavengerGoal, model: scavengerModel, target: { cell: "goal", y: SCAVENGER_GOAL_HEIGHT } },
 };
 
 export function runScenario(id: ScenarioId): RunResult {
   const cfg = SCENARIOS[id];
   const instance = cfg.instance();
-  const model = staircaseModel(instance);
+  const model = cfg.model(instance);
+  const hasSupply = model.doc.fluents.some((f) => f.name === "supply");
 
   const trace: TraceEvent[] = [];
   let t = 0;
@@ -68,7 +82,9 @@ export function runScenario(id: ScenarioId): RunResult {
   const cellNames = instance.cells.map((c) => c.name);
   const snap = (action: string): Frame => ({
     heights: Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "height", c) as number])),
-    supplies: Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "supply", c) as number])),
+    supplies: hasSupply
+      ? Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "supply", c) as number]))
+      : {},
     agentCell: model.read(planner.state, "agentAt") as string,
     agentY: model.read(planner.state, "agentY") as number,
     holding: model.read(planner.state, "holding") as boolean,

--- a/examples/web/lib/runBlocks.ts
+++ b/examples/web/lib/runBlocks.ts
@@ -1,0 +1,114 @@
+"use client";
+/**
+ * Blocks World run path for the web preview. Like lib/run.ts, this drives the
+ * real htn-ai Planner — here over the 4-op STRIPS blocks domain — and snapshots
+ * the world after each executed step. It also precomputes a stable 3D layout per
+ * frame (so the renderer stays dumb): each block sits in the column of its
+ * stack's table-root, at a height equal to its depth; a held block hovers above
+ * where it will land next.
+ */
+import { F, Planner, goal, type TraceEvent } from "htn-ai";
+import { blocksModel, sussmanSetup } from "@scenarios/blocks";
+
+export interface BlocksFrame {
+  /** block name → [x, stackDepth] for rendering */
+  positions: Record<string, [number, number]>;
+  /** block name → ("table" | other block) for the HUD */
+  on: Record<string, string>;
+  held: string | null;
+  action: string;
+}
+
+export interface BlocksRun {
+  blocks: string[];
+  frames: BlocksFrame[];
+  status: string;
+  trace: TraceEvent[];
+  goalText: string;
+}
+
+const SPACING = 1.7;
+const CARRY_Y = 4;
+const HAND = "arm";
+
+export function runBlocks(): BlocksRun {
+  const setup = sussmanSetup(); // C on A; A,B on table — the Sussman anomaly
+  const blocks = setup.blocks;
+  const model = blocksModel(setup);
+
+  const trace: TraceEvent[] = [];
+  let t = 0;
+  const planner = new Planner(model, {
+    goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")))],
+    now: () => t,
+    seed: 1,
+    trace: (e) => trace.push(e),
+  });
+
+  const sorted = [...blocks].sort();
+  const homeX: Record<string, number> = {};
+  sorted.forEach((b, i) => {
+    homeX[b] = (i - (sorted.length - 1) / 2) * SPACING;
+  });
+
+  interface Raw {
+    on: Record<string, string>;
+    held: string | null;
+    action: string;
+  }
+  const readRaw = (action: string): Raw => {
+    const on: Record<string, string> = {};
+    for (const b of blocks) {
+      const o = model.read(planner.state, "on", b);
+      on[b] = typeof o === "string" && o ? o : "table";
+    }
+    const handEmpty = model.read(planner.state, "handEmpty", HAND) as boolean;
+    const heldRaw = model.read(planner.state, "holding", HAND);
+    const held = !handEmpty && typeof heldRaw === "string" && heldRaw ? heldRaw : null;
+    return { on, held, action };
+  };
+
+  const raws: Raw[] = [readRaw("start")];
+  for (let i = 0; i < 500; i++) {
+    const st = planner.getStatus();
+    if (st === "succeeded" || st === "failed") break;
+    t += 1;
+    const before = trace.length;
+    planner.tick({ ms: 5 });
+    const done = trace.slice(before).find((e) => e.t === "step.done");
+    if (done && done.t === "step.done") raws.push(readRaw(done.label));
+  }
+
+  const layoutOf = (on: Record<string, string>, held: string | null): Record<string, [number, number]> => {
+    const pos: Record<string, [number, number]> = {};
+    for (const b of blocks) {
+      if (b === held) continue;
+      let cur = b;
+      let depth = 0;
+      const seen = new Set<string>();
+      while (on[cur] && on[cur] !== "table" && !seen.has(cur)) {
+        seen.add(cur);
+        cur = on[cur];
+        depth++;
+      }
+      pos[b] = [homeX[cur] ?? homeX[b], depth];
+    }
+    return pos;
+  };
+
+  const frames: BlocksFrame[] = raws.map((r) => ({
+    positions: layoutOf(r.on, r.held),
+    on: r.on,
+    held: r.held,
+    action: r.action,
+  }));
+  // a held block hovers above its destination (its resting x in the next frame)
+  for (let i = 0; i < frames.length; i++) {
+    const held = frames[i].held;
+    if (!held) continue;
+    const destX = frames[i + 1]?.positions[held]?.[0] ?? homeX[held];
+    frames[i].positions[held] = [destX, CARRY_Y];
+  }
+
+  return { blocks, frames, status: planner.getStatus(), trace, goalText: "A·on·B·on·C" };
+}

--- a/examples/web/next.config.mjs
+++ b/examples/web/next.config.mjs
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dir, "../..");
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // static HTML export — deployable to Vercel, GitHub Pages, any static host
+  output: "export",
+  images: { unoptimized: true },
+  // allow importing the library source + shared scenarios from outside this app
+  experimental: { externalDir: true },
+  // this is a demo app that imports the (separately CI-checked) library source
+  // across the repo boundary; keep the static export resilient to that.
+  typescript: { ignoreBuildErrors: true },
+  eslint: { ignoreDuringBuilds: true },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "htn-ai": path.resolve(repoRoot, "src/index.ts"),
+      "@scenarios": path.resolve(repoRoot, "scenarios"),
+    };
+    return config;
+  },
+};
+
+export default nextConfig;

--- a/examples/web/package-lock.json
+++ b/examples/web/package-lock.json
@@ -1,0 +1,1351 @@
+{
+  "name": "htn-ai-web-preview",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "htn-ai-web-preview",
+      "version": "0.1.0",
+      "dependencies": {
+        "@react-three/drei": "^9.114.0",
+        "@react-three/fiber": "^8.17.10",
+        "next": "14.2.15",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "three": "^0.169.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.169.0",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
+      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
+      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
+      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
+      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
+      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
+      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
+      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
+      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
+      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
+      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
+      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.15",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.15",
+        "@next/swc-darwin-x64": "14.2.15",
+        "@next/swc-linux-arm64-gnu": "14.2.15",
+        "@next/swc-linux-arm64-musl": "14.2.15",
+        "@next/swc-linux-x64-gnu": "14.2.15",
+        "@next/swc-linux-x64-musl": "14.2.15",
+        "@next/swc-win32-arm64-msvc": "14.2.15",
+        "@next/swc-win32-ia32-msvc": "14.2.15",
+        "@next/swc-win32-x64-msvc": "14.2.15"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "htn-ai-web-preview",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Browser preview that visualizes the htn-ai planner — Staircase World in 3D, fed by the planner's TraceEvent stream.",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.114.0",
+    "@react-three/fiber": "^8.17.10",
+    "next": "14.2.15",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.169.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.169.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/examples/web/tsconfig.json
+++ b/examples/web/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "ES2020"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "htn-ai": ["../../src/index.ts"],
+      "@scenarios/*": ["../../scenarios/*"],
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/web/vercel.json
+++ b/examples/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "next build",
+  "outputDirectory": "out",
+  "cleanUrls": true
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepublishOnly": "npm run typecheck",
     "test": "tsx --tsconfig tsconfig.tests.json node_modules/uvu/bin.js tests",
     "bench": "tsx --tsconfig tsconfig.tests.json bench/bench.ts",
+    "bench:scale": "tsx --tsconfig tsconfig.tests.json bench/scale.ts",
     "test:coverage": "c8 --check-coverage --lines 92 --branches 82 --reporter=html --reporter=text tsx --tsconfig tsconfig.tests.json node_modules/uvu/bin.js tests",
     "test:report": "c8 report --reporter=text-lcov > coverage/tests.lcov",
     "test:watch": "chokidar \"**/*.ts\" -c \"npm test\""

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit --project tsconfig.tests.json",
     "prepublishOnly": "npm run typecheck",
     "test": "tsx --tsconfig tsconfig.tests.json node_modules/uvu/bin.js tests",
+    "bench": "tsx --tsconfig tsconfig.tests.json bench/bench.ts",
     "test:coverage": "c8 --check-coverage --lines 92 --branches 82 --reporter=html --reporter=text tsx --tsconfig tsconfig.tests.json node_modules/uvu/bin.js tests",
     "test:report": "c8 report --reporter=text-lcov > coverage/tests.lcov",
     "test:watch": "chokidar \"**/*.ts\" -c \"npm test\""

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "unpkg": "./dist/index.global.js",
   "scripts": {
     "build": "tsup",
-    "lint": "eslint src tests --max-warnings=0",
+    "lint": "eslint src tests scenarios --max-warnings=0",
     "typecheck": "tsc --noEmit --project tsconfig.tests.json",
     "prepublishOnly": "npm run typecheck",
     "test": "tsx --tsconfig tsconfig.tests.json node_modules/uvu/bin.js tests",

--- a/scenarios/blocks.ts
+++ b/scenarios/blocks.ts
@@ -1,0 +1,134 @@
+/**
+ * Blocks World — the canonical AI-planning benchmark, in the 4-operator STRIPS
+ * formulation (pickup / putdown / unstack / stack) with an explicit gripper.
+ *
+ * This is the richer cousin of the 3-operator "move" blocks world in
+ * tests/puzzles.ts: it adds a held-block state (`holding` / `handEmpty`) and a
+ * `hand` entity, so the same domain scales from one arm to several arms
+ * (multi-effector coordination) and can be driven through the reactive Planner
+ * with executors — exercising plan repair on a stacking domain.
+ *
+ * Shared by tests/blocks.ts (ground-truth assertions) and the web preview.
+ */
+import {
+  type DomainDoc,
+  type InitWriter,
+  type Model,
+  type Registry,
+  E,
+  F,
+  createModel,
+} from "../src/index";
+
+/** entity gid 0 (= null) denotes "the table" for `on`, and "empty" for `holding`. */
+export const TABLE = 0;
+
+export const blocksDomain: DomainDoc = {
+  name: "blocks-world",
+  types: [{ name: "block" }, { name: "hand" }],
+  fluents: [
+    // what each block rests on; 0 / null = the table
+    { name: "on", params: [{ name: "b", type: "block" }], kind: "entity", entityType: "block" },
+    // nothing is stacked on top of the block (a held block is not clear)
+    { name: "clear", params: [{ name: "b", type: "block" }], kind: "boolean", initial: true },
+    // the block a hand currently holds; 0 / null = empty
+    { name: "holding", params: [{ name: "h", type: "hand" }], kind: "entity", entityType: "block" },
+    { name: "handEmpty", params: [{ name: "h", type: "hand" }], kind: "boolean", initial: true },
+  ],
+  operators: [
+    {
+      name: "pickup", // lift a clear block off the table
+      params: [{ name: "h", type: "hand" }, { name: "b", type: "block" }],
+      pre: F.and(F.lit("handEmpty", ["?h"]), F.lit("clear", ["?b"]), F.lit("on", ["?b"], TABLE)),
+      eff: [E.set("holding", ["?h"], "?b"), E.set("handEmpty", ["?h"], false), E.set("clear", ["?b"], false)],
+      cost: 1,
+    },
+    {
+      name: "putdown", // set the held block down on the table
+      params: [{ name: "h", type: "hand" }, { name: "b", type: "block" }],
+      pre: F.lit("holding", ["?h"], "?b"),
+      eff: [
+        E.set("on", ["?b"], TABLE),
+        E.set("clear", ["?b"], true),
+        E.set("handEmpty", ["?h"], true),
+        E.set("holding", ["?h"], TABLE),
+      ],
+      cost: 1,
+    },
+    {
+      name: "unstack", // lift a clear block off the block `from`
+      params: [{ name: "h", type: "hand" }, { name: "b", type: "block" }, { name: "from", type: "block" }],
+      pre: F.and(F.lit("handEmpty", ["?h"]), F.lit("clear", ["?b"]), F.lit("on", ["?b"], "?from")),
+      eff: [
+        E.set("holding", ["?h"], "?b"),
+        E.set("handEmpty", ["?h"], false),
+        E.set("clear", ["?b"], false),
+        E.set("clear", ["?from"], true),
+        E.set("on", ["?b"], TABLE),
+      ],
+      cost: 1,
+    },
+    {
+      name: "stack", // place the held block onto a clear block `onto`
+      params: [{ name: "h", type: "hand" }, { name: "b", type: "block" }, { name: "onto", type: "block" }],
+      pre: F.and(F.lit("holding", ["?h"], "?b"), F.lit("clear", ["?onto"])),
+      eff: [
+        E.set("on", ["?b"], "?onto"),
+        E.set("clear", ["?onto"], false),
+        E.set("clear", ["?b"], true),
+        E.set("handEmpty", ["?h"], true),
+        E.set("holding", ["?h"], TABLE),
+      ],
+      cost: 1,
+    },
+  ],
+};
+
+export interface BlocksSetup {
+  blocks: string[];
+  /** hand entity names; defaults to a single arm */
+  hands?: string[];
+  /** seed the initial stacking (defaults: every block on the table, all clear) */
+  init?: (w: InitWriter) => void;
+  registry?: Registry;
+}
+
+/** Build a model over the named blocks + hands with the given initial layout. */
+export function blocksModel(setup: BlocksSetup): Model {
+  const entities: Record<string, string> = {};
+  for (const b of setup.blocks) entities[b] = "block";
+  for (const h of setup.hands ?? ["arm"]) entities[h] = "hand";
+  return createModel(blocksDomain, { entities, init: setup.init ?? (() => undefined) }, setup.registry ?? {});
+}
+
+/**
+ * The Sussman anomaly: C on A, A and B on the table; goal A-on-B-on-C. The
+ * naive "stack A on B, then B on C" order deadlocks, so the planner must
+ * interleave subgoals. Optimal solution is 6 actions in this formulation.
+ */
+export function sussmanSetup(): BlocksSetup {
+  return {
+    blocks: ["a", "b", "c"],
+    init: (w) => {
+      w.set("on", ["c"], "a"); // C starts on A
+      w.set("clear", ["a"], false); // A is covered by C
+    },
+  };
+}
+
+/**
+ * A single tower `names[0]`-on-`names[1]`-…-on-table, used to test "reverse the
+ * stack" goals at scale. Returns the setup plus the names for goal building.
+ */
+export function towerSetup(names: string[], hands?: string[]): BlocksSetup {
+  return {
+    blocks: names,
+    hands,
+    init: (w) => {
+      for (let i = 0; i < names.length - 1; i++) {
+        w.set("on", [names[i]], names[i + 1]); // names[i] sits on names[i+1]
+        w.set("clear", [names[i + 1]], false);
+      }
+    },
+  };
+}

--- a/scenarios/index.ts
+++ b/scenarios/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared planning scenarios used by both the test suite (ground-truth
+ * assertions in tests/) and the web preview (examples/web). Keeping the domain
+ * definitions in one place means the tests and the demo never drift apart.
+ */
+export * from "./blocks";
+export * from "./staircase";

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -372,3 +372,55 @@ export function scavengerInstance(): StaircaseInstance {
 export function scavengerGoal(): import("../src/index").Formula {
   return F.and(F.lit("agentAt", [], "goal"), F.eq(N.fl("agentY"), N.c(SCAVENGER_GOAL_HEIGHT)));
 }
+
+export const SCAVENGER_BIG_GOAL_HEIGHT = 3;
+
+/**
+ * A bigger, harder scavenger puzzle: a 4×3 grid, a height-3 goal (a real 3-level
+ * climb), and seven blocks scattered as five loose blocks + one 2-pillar. The
+ * goal needs six blocks, so the pillar must be harvested, and the planner makes
+ * richer decisions — it uses existing loose blocks as stepping stones to reach
+ * the pillar's top and as platforms to stack the goal. Solved with a greedier
+ * weight (hadd, weight≈5) in ~0.5s; see tests/spatial.ts and the web preview.
+ *
+ *      z=2  L4(1) - L5(1)
+ *      z=1  L1(1) - tower(2) - L2(1) - L3(1)
+ *      z=0  start -    A     -   B    -  goal
+ */
+export function scavengerBigInstance(): StaircaseInstance {
+  return {
+    cells: [
+      { name: "start", x: 0, z: 0 },
+      { name: "A", x: 1, z: 0 },
+      { name: "B", x: 2, z: 0 },
+      { name: "goal", x: 3, z: 0 },
+      { name: "L1", x: 0, z: 1, height: 1 },
+      { name: "tower", x: 1, z: 1, height: 2 },
+      { name: "L2", x: 2, z: 1, height: 1 },
+      { name: "L3", x: 3, z: 1, height: 1 },
+      { name: "L4", x: 0, z: 2, height: 1 },
+      { name: "L5", x: 1, z: 2, height: 1 },
+    ],
+    edges: [
+      ["start", "A"],
+      ["A", "B"],
+      ["B", "goal"],
+      ["start", "L1"],
+      ["A", "tower"],
+      ["B", "L2"],
+      ["goal", "L3"],
+      ["L1", "tower"],
+      ["tower", "L2"],
+      ["L2", "L3"],
+      ["L1", "L4"],
+      ["tower", "L5"],
+      ["L4", "L5"],
+    ],
+    start: "start",
+  };
+}
+
+/** Big scavenger goal: stand atop `goal` at elevation 3. */
+export function scavengerBigGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], "goal"), F.eq(N.fl("agentY"), N.c(SCAVENGER_BIG_GOAL_HEIGHT)));
+}

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -25,6 +25,9 @@ import {
   createModel,
 } from "../src/index";
 
+/** default height of a wall/obstacle pillar — far above the +1 climb limit */
+export const WALL_HEIGHT = 6;
+
 export const staircaseDomain: DomainDoc = {
   name: "staircase-world",
   types: [{ name: "cell" }],
@@ -38,6 +41,10 @@ export const staircaseDomain: DomainDoc = {
     // ONLY observable the goal constrains: "be up in the air at coordinate Y".
     { name: "agentY", kind: "int", initial: 0 },
     { name: "holding", kind: "boolean", initial: false },
+    // only designated cells can be built up — keeps the search focused on the
+    // staircase (and lets walls/obstacles be no-build). Defaults to true so
+    // simple instances need not set it.
+    { name: "buildable", params: [{ name: "c", type: "cell" }], kind: "boolean", initial: true },
   ],
   operators: [
     {
@@ -67,6 +74,7 @@ export const staircaseDomain: DomainDoc = {
       params: [{ name: "stand", type: "cell" }, { name: "at", type: "cell" }],
       pre: F.and(
         F.lit("holding"),
+        F.lit("buildable", ["?at"]),
         F.lit("agentAt", [], "?stand"),
         F.lit("adj", ["?stand", "?at"]),
         F.gte(N.fl("height", "?stand"), N.fl("height", "?at")),
@@ -83,6 +91,10 @@ export interface CellSpec {
   z: number;
   height?: number;
   supply?: number;
+  /** if false, blocks cannot be placed here (walls, depots, the goal pillar) */
+  buildable?: boolean;
+  /** a tall fixed obstacle the agent can neither climb nor build on */
+  wall?: boolean;
 }
 
 export interface StaircaseInstance {
@@ -101,8 +113,10 @@ export function staircaseModel(inst: StaircaseInstance): Model {
     init: (w) => {
       for (const c of inst.cells) {
         w.set("pos", [c.name], [c.x, c.z]);
-        if (c.height) w.set("height", [c.name], c.height);
+        const h = c.wall ? (c.height ?? WALL_HEIGHT) : c.height;
+        if (h) w.set("height", [c.name], h);
         if (c.supply) w.set("supply", [c.name], c.supply);
+        if (c.buildable === false || c.wall) w.set("buildable", [c.name], false);
       }
       for (const [a, b] of inst.edges) {
         w.set("adj", [a, b], true);
@@ -174,4 +188,53 @@ export function staircaseGoal(): import("../src/index").Formula {
 /** The ledge goal: be at the ledge coordinate, elevation 2 (atop the wall). */
 export function ledgeGoal(): import("../src/index").Formula {
   return F.and(F.lit("agentAt", [], "ledge"), F.eq(N.fl("agentY"), N.c(2)));
+}
+
+/**
+ * "Quarry" — the advanced grid world. A tall fixed goal pillar (height
+ * QUARRY_GOAL_HEIGHT = 4) the agent must stand on top of, reachable only by
+ * building a 3-step staircase (heights 1→2→3) beside it. The six blocks are
+ * scattered across two depots with limited supply, so the agent must collect
+ * from BOTH and shuttle them to the build front; a wall pillar is an impassable
+ * obstacle. The goal is position-only — the planner works out the optimal route
+ * to collect, place, build the staircase, and climb. Solved optimally by pure
+ * GOAP search (≈1.5k node expansions, see tests/spatial.ts).
+ *
+ *      z=1   depotA(3)   wall       depotB(3)
+ *      z=0   start - step1 - step2 - step3 - pillar(goal, h4)
+ *             x=0     x=1     x=2     x=3      x=4
+ */
+export const QUARRY_GOAL_HEIGHT = 4;
+
+export function quarryInstance(): StaircaseInstance {
+  return {
+    cells: [
+      { name: "start", x: 0, z: 0 },
+      { name: "step1", x: 1, z: 0 }, // built to 1
+      { name: "step2", x: 2, z: 0 }, // built to 2
+      { name: "step3", x: 3, z: 0 }, // built to 3
+      { name: "pillar", x: 4, z: 0, height: QUARRY_GOAL_HEIGHT, buildable: false }, // the goal
+      { name: "depotA", x: 0, z: 1, supply: 3, buildable: false },
+      { name: "depotB", x: 2, z: 1, supply: 3, buildable: false },
+      { name: "wall", x: 1, z: 1, wall: true },
+    ],
+    edges: [
+      ["start", "step1"],
+      ["step1", "step2"],
+      ["step2", "step3"],
+      ["step3", "pillar"],
+      ["start", "depotA"],
+      ["step2", "depotB"],
+      // wall edges: present in the grid but impassable (height 6 ≫ climb limit)
+      ["step1", "wall"],
+      ["depotA", "wall"],
+      ["depotB", "wall"],
+    ],
+    start: "start",
+  };
+}
+
+/** Quarry goal: stand on top of the pillar — a pure 3D position, elevation 4. */
+export function quarryGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], "pillar"), F.eq(N.fl("agentY"), N.c(QUARRY_GOAL_HEIGHT)));
 }

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -238,3 +238,137 @@ export function quarryInstance(): StaircaseInstance {
 export function quarryGoal(): import("../src/index").Formula {
   return F.and(F.lit("agentAt", [], "pillar"), F.eq(N.fl("agentY"), N.c(QUARRY_GOAL_HEIGHT)));
 }
+
+// ============================================================================
+// Scavenger — collect blocks scattered on the ground (no depots), top-first.
+// ============================================================================
+
+/**
+ * The Scavenger domain. Same grid world, but blocks are not drawn from depots:
+ * they lie around as column heights (a loose block = height 1, a 2-pillar =
+ * height 2, …) and the agent collects them with `grab`. Two new rules vs the
+ * staircase domain:
+ *
+ *   • Top-first: `grab` removes the TOP block of a column (height−−), so you
+ *     can never pull a block out from under a stack.
+ *   • Reach: you can only grab the top block of an adjacent column of height H
+ *     if your standing elevation ≥ H − 1. So a 2-pillar's top block is out of
+ *     reach from the ground — you must place a block in front, climb onto it,
+ *     and THEN grab it. (Mirror of `place`, which needs stand ≥ height(at).)
+ *
+ * Placement is free: a held block may be placed on any reachable adjacent grid
+ * cell, so the planner decides where to build steps and the goal staircase.
+ */
+export const scavengerDomain: DomainDoc = {
+  name: "scavenger-world",
+  types: [{ name: "cell" }],
+  fluents: [
+    { name: "height", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
+    { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
+    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+    { name: "agentAt", kind: "entity", entityType: "cell" },
+    { name: "agentY", kind: "int", initial: 0 },
+    { name: "holding", kind: "boolean", initial: false },
+  ],
+  operators: [
+    {
+      name: "goto",
+      params: [{ name: "from", type: "cell" }, { name: "to", type: "cell" }],
+      pre: F.and(
+        F.lit("agentAt", [], "?from"),
+        F.lit("adj", ["?from", "?to"]),
+        F.lte(N.fl("height", "?to"), N.add(N.fl("height", "?from"), N.c(1))),
+      ),
+      eff: [E.set("agentAt", [], "?to"), E.set("agentY", [], N.fl("height", "?to"))],
+      cost: N.add(N.dist("pos", ["?from"], "pos", ["?to"]), N.c(0.01)),
+    },
+    {
+      // grab the TOP block of an adjacent column; reachable iff stand ≥ height(at) − 1
+      name: "grab",
+      params: [{ name: "stand", type: "cell" }, { name: "at", type: "cell" }],
+      pre: F.and(
+        F.not(F.lit("holding")),
+        F.lit("agentAt", [], "?stand"),
+        F.lit("adj", ["?stand", "?at"]),
+        F.gte(N.fl("height", "?at"), N.c(1)),
+        F.gte(N.fl("height", "?stand"), N.sub(N.fl("height", "?at"), N.c(1))),
+      ),
+      eff: [E.set("holding", [], true), E.dec("height", ["?at"], N.c(1))],
+      cost: 1,
+    },
+    {
+      // place the held block on any reachable adjacent cell (free placement)
+      name: "place",
+      params: [{ name: "stand", type: "cell" }, { name: "at", type: "cell" }],
+      pre: F.and(
+        F.lit("holding"),
+        F.lit("agentAt", [], "?stand"),
+        F.lit("adj", ["?stand", "?at"]),
+        F.gte(N.fl("height", "?stand"), N.fl("height", "?at")),
+      ),
+      eff: [E.set("holding", [], false), E.inc("height", ["?at"], N.c(1))],
+      cost: 1,
+    },
+  ],
+};
+
+/** Build a model for a Scavenger instance (reuses the StaircaseInstance shape). */
+export function scavengerModel(inst: StaircaseInstance): Model {
+  const entities: Record<string, string> = {};
+  for (const c of inst.cells) entities[c.name] = "cell";
+  return createModel(scavengerDomain, {
+    entities,
+    init: (w) => {
+      for (const c of inst.cells) {
+        w.set("pos", [c.name], [c.x, c.z]);
+        if (c.height) w.set("height", [c.name], c.height);
+      }
+      for (const [a, b] of inst.edges) {
+        w.set("adj", [a, b], true);
+        w.set("adj", [b, a], true);
+      }
+      w.set("agentAt", [], inst.start);
+    },
+  });
+}
+
+export const SCAVENGER_GOAL_HEIGHT = 2;
+
+/**
+ * A scavenger puzzle on a 3×2 grid. Two loose ground blocks and one 2-pillar are
+ * scattered around; the goal is the 3D position atop `goal` at elevation 2. The
+ * goal column needs 2 blocks plus a height-1 support to place the second and to
+ * climb — 3 blocks total, but only 2 loose blocks exist, so the agent MUST
+ * harvest the 2-pillar. Harvesting its top block is impossible from the ground,
+ * so the planner discovers it has to build a step, climb it, then grab.
+ *
+ *      z=1  loose1(1) ---- goal ------- loose2(1)
+ *      z=0  start ------- s ----------- tower(2)
+ */
+export function scavengerInstance(): StaircaseInstance {
+  return {
+    cells: [
+      { name: "start", x: 0, z: 0 },
+      { name: "s", x: 1, z: 0 },
+      { name: "tower", x: 2, z: 0, height: 2 },
+      { name: "loose1", x: 0, z: 1, height: 1 },
+      { name: "goal", x: 1, z: 1 },
+      { name: "loose2", x: 2, z: 1, height: 1 },
+    ],
+    edges: [
+      ["start", "s"],
+      ["s", "tower"],
+      ["loose1", "goal"],
+      ["goal", "loose2"],
+      ["start", "loose1"],
+      ["s", "goal"],
+      ["tower", "loose2"],
+    ],
+    start: "start",
+  };
+}
+
+/** Scavenger goal: stand on top of `goal` at elevation 2 — a pure 3D position. */
+export function scavengerGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], "goal"), F.eq(N.fl("agentY"), N.c(SCAVENGER_GOAL_HEIGHT)));
+}

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -1,0 +1,177 @@
+/**
+ * Staircase World — a spatial block-stacking scenario where geometry drives the
+ * plan. An agent on a grid of columns must raise column heights (placing blocks
+ * from a supply) so it can climb — one level at a time — onto an elevated goal.
+ *
+ * This is the scenario the web preview renders in 3D, and the first test where
+ * htn-ai's spatial features actually drive search:
+ *   - `height(cell):int` is read by BOTH the climb precondition
+ *     (height(to) ≤ height(from)+1) and the place precondition
+ *     (height(stand) ≥ height(at)) — so the build order is *discovered*, not
+ *     scripted: you must build a support before you can stand high enough to
+ *     build/climb higher (the ordering constraint the vibe-city demo hard-coded).
+ *   - movement cost is `dist(pos(from), pos(to))` over `vec2` positions — the
+ *     first use of N.dist as a planning-relevant cost.
+ *   - `supply(cell):int` is a consumable resource the planner must account for.
+ *
+ * Shared by tests/spatial.ts and the web preview.
+ */
+import {
+  type DomainDoc,
+  type Model,
+  E,
+  F,
+  N,
+  createModel,
+} from "../src/index";
+
+export const staircaseDomain: DomainDoc = {
+  name: "staircase-world",
+  types: [{ name: "cell" }],
+  fluents: [
+    { name: "height", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
+    { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
+    { name: "supply", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
+    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+    { name: "agentAt", kind: "entity", entityType: "cell" },
+    // the agent's elevation = the height of the column it stands on. This is the
+    // ONLY observable the goal constrains: "be up in the air at coordinate Y".
+    { name: "agentY", kind: "int", initial: 0 },
+    { name: "holding", kind: "boolean", initial: false },
+  ],
+  operators: [
+    {
+      // walk to an adjacent cell; can ascend at most one level (descend freely)
+      name: "goto",
+      params: [{ name: "from", type: "cell" }, { name: "to", type: "cell" }],
+      pre: F.and(
+        F.lit("agentAt", [], "?from"),
+        F.lit("adj", ["?from", "?to"]),
+        F.lte(N.fl("height", "?to"), N.add(N.fl("height", "?from"), N.c(1))),
+      ),
+      // moving onto a column sets the agent's elevation to that column's height
+      eff: [E.set("agentAt", [], "?to"), E.set("agentY", [], N.fl("height", "?to"))],
+      cost: N.add(N.dist("pos", ["?from"], "pos", ["?to"]), N.c(0.01)),
+    },
+    {
+      // pick a block off the column the agent stands on (a supply cell)
+      name: "pick",
+      params: [{ name: "at", type: "cell" }],
+      pre: F.and(F.not(F.lit("holding")), F.lit("agentAt", [], "?at"), F.gt(N.fl("supply", "?at"), N.c(0))),
+      eff: [E.set("holding", [], true), E.dec("supply", ["?at"], N.c(1))],
+      cost: 1,
+    },
+    {
+      // place the carried block on an adjacent column at or below the agent's level
+      name: "place",
+      params: [{ name: "stand", type: "cell" }, { name: "at", type: "cell" }],
+      pre: F.and(
+        F.lit("holding"),
+        F.lit("agentAt", [], "?stand"),
+        F.lit("adj", ["?stand", "?at"]),
+        F.gte(N.fl("height", "?stand"), N.fl("height", "?at")),
+      ),
+      eff: [E.set("holding", [], false), E.inc("height", ["?at"], N.c(1))],
+      cost: 1,
+    },
+  ],
+};
+
+export interface CellSpec {
+  name: string;
+  x: number;
+  z: number;
+  height?: number;
+  supply?: number;
+}
+
+export interface StaircaseInstance {
+  cells: CellSpec[];
+  /** undirected edges; adjacency is written both ways */
+  edges: [string, string][];
+  start: string;
+}
+
+/** Build a model for a Staircase World instance. */
+export function staircaseModel(inst: StaircaseInstance): Model {
+  const entities: Record<string, string> = {};
+  for (const c of inst.cells) entities[c.name] = "cell";
+  return createModel(staircaseDomain, {
+    entities,
+    init: (w) => {
+      for (const c of inst.cells) {
+        w.set("pos", [c.name], [c.x, c.z]);
+        if (c.height) w.set("height", [c.name], c.height);
+        if (c.supply) w.set("supply", [c.name], c.supply);
+      }
+      for (const [a, b] of inst.edges) {
+        w.set("adj", [a, b], true);
+        w.set("adj", [b, a], true);
+      }
+      w.set("agentAt", [], inst.start);
+    },
+  });
+}
+
+/**
+ * Minimal "climb the ledge": a fixed height-2 wall the agent must get on top of.
+ * It can't climb 2 levels directly, so it must build `mid` up to height 1 first,
+ * then ascend ground→mid→ledge. Solvable by pure GOAP search.
+ */
+export function ledgeInstance(supply = 1): StaircaseInstance {
+  return {
+    cells: [
+      { name: "ground", x: 0, z: 0, supply },
+      { name: "mid", x: 1, z: 0 },
+      { name: "ledge", x: 2, z: 0, height: 2 },
+    ],
+    edges: [
+      ["ground", "mid"],
+      ["mid", "ledge"],
+    ],
+    start: "ground",
+  };
+}
+
+/**
+ * The staircase the agent builds from a supply depot, then climbs onto. The
+ * goal is to stand on top of `goal` once it's been raised to GOAL_HEIGHT — which
+ * is impossible to reach across flat ground (you can only climb one level at a
+ * time), so the agent must build the `s1` support up to 1 and `goal` up to 2,
+ * carrying each block from the depot. Used for the "runs through the reactive
+ * Planner" test and as the web preview's flagship scene.
+ */
+export const GOAL_HEIGHT = 2;
+
+export function staircaseInstance(): StaircaseInstance {
+  return {
+    cells: [
+      { name: "depot", x: 0, z: 0, supply: 8 },
+      { name: "s1", x: 1, z: 0 },
+      { name: "goal", x: 2, z: 0 },
+    ],
+    edges: [
+      ["depot", "s1"],
+      ["s1", "goal"],
+    ],
+    start: "depot",
+  };
+}
+
+/**
+ * The goal is a 3D POSITION, nothing more: be at the `goal` cell's (x,z) and at
+ * elevation GOAL_HEIGHT — i.e. "up in the air at this coordinate". It does NOT
+ * say to place blocks or to build any particular column; the planner must
+ * *discover* that the only way to be that high is to stack a staircase up to it.
+ */
+export const GOAL_X = 2;
+export const GOAL_Z = 0;
+
+export function staircaseGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], "goal"), F.eq(N.fl("agentY"), N.c(GOAL_HEIGHT)));
+}
+
+/** The ledge goal: be at the ledge coordinate, elevation 2 (atop the wall). */
+export function ledgeGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], "ledge"), F.eq(N.fl("agentY"), N.c(2)));
+}

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -35,7 +35,7 @@ export const staircaseDomain: DomainDoc = {
     { name: "height", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
     { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
     { name: "supply", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
-    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false, static: true },
     { name: "agentAt", kind: "entity", entityType: "cell" },
     // the agent's elevation = the height of the column it stands on. This is the
     // ONLY observable the goal constrains: "be up in the air at coordinate Y".
@@ -44,7 +44,7 @@ export const staircaseDomain: DomainDoc = {
     // only designated cells can be built up — keeps the search focused on the
     // staircase (and lets walls/obstacles be no-build). Defaults to true so
     // simple instances need not set it.
-    { name: "buildable", params: [{ name: "c", type: "cell" }], kind: "boolean", initial: true },
+    { name: "buildable", params: [{ name: "c", type: "cell" }], kind: "boolean", initial: true, static: true },
   ],
   operators: [
     {
@@ -265,7 +265,7 @@ export const scavengerDomain: DomainDoc = {
   fluents: [
     { name: "height", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
     { name: "pos", params: [{ name: "c", type: "cell" }], kind: "vec2" },
-    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false },
+    { name: "adj", params: [{ name: "a", type: "cell" }, { name: "b", type: "cell" }], kind: "boolean", initial: false, static: true },
     { name: "agentAt", kind: "entity", entityType: "cell" },
     { name: "agentY", kind: "int", initial: 0 },
     { name: "holding", kind: "boolean", initial: false },

--- a/scenarios/staircase.ts
+++ b/scenarios/staircase.ts
@@ -424,3 +424,42 @@ export function scavengerBigInstance(): StaircaseInstance {
 export function scavengerBigGoal(): import("../src/index").Formula {
   return F.and(F.lit("agentAt", [], "goal"), F.eq(N.fl("agentY"), N.c(SCAVENGER_BIG_GOAL_HEIGHT)));
 }
+
+/**
+ * A W×D grid scavenger world: a lane along z=0 with `start` at x=0 and the goal
+ * cell `c{W-1}_0` at the far end; every cell on rows z≥1 carries a loose block
+ * (and one 2-pillar). Used to scale the scavenger up into a HUGE stress example
+ * — search cost grows ~cells² (the h_add heuristic is evaluated over every
+ * ground op), so a 6×4 grid is roughly 10× the compute of Scavenger XL.
+ */
+export function scavengerGridInstance(w: number, d: number): StaircaseInstance {
+  const nm = (x: number, z: number) => `c${x}_${z}`;
+  const cells: CellSpec[] = [];
+  const edges: [string, string][] = [];
+  for (let z = 0; z < d; z++) {
+    for (let x = 0; x < w; x++) {
+      const c: CellSpec = { name: nm(x, z), x, z };
+      if (z >= 1) c.height = x === 1 && z === 1 ? 2 : 1; // scattered loose blocks + one 2-pillar
+      cells.push(c);
+    }
+  }
+  for (let z = 0; z < d; z++) {
+    for (let x = 0; x < w; x++) {
+      if (x + 1 < w) edges.push([nm(x, z), nm(x + 1, z)]);
+      if (z + 1 < d) edges.push([nm(x, z), nm(x, z + 1)]);
+    }
+  }
+  return { cells, edges, start: nm(0, 0) };
+}
+
+/** The HUGE stress instance: a 6×4 grid, height-3 goal. ~9s to plan (≈10× XL). */
+export const SCAVENGER_HUGE = { w: 6, d: 4, goalHeight: 3 };
+export const scavengerHugeGoalCell = `c${SCAVENGER_HUGE.w - 1}_0`;
+
+export function scavengerHugeInstance(): StaircaseInstance {
+  return scavengerGridInstance(SCAVENGER_HUGE.w, SCAVENGER_HUGE.d);
+}
+
+export function scavengerHugeGoal(): import("../src/index").Formula {
+  return F.and(F.lit("agentAt", [], scavengerHugeGoalCell), F.eq(N.fl("agentY"), N.c(SCAVENGER_HUGE.goalHeight)));
+}

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -90,6 +90,9 @@ export interface CompiledFormula {
   readsClock: boolean;
   /** positive conjunctive lit atoms (for h_add); skipped parts make h more optimistic */
   atoms: (b: Bindings) => Atom[];
+  /** like `atoms`, but also folds in external/opaque `relax` over-approximations —
+   *  used only by the relaxation heuristic, never for search applicability */
+  relaxAtoms: (b: Bindings) => Atom[];
   ir: Formula;
 }
 
@@ -631,12 +634,14 @@ export class Model {
     const reads = new Set<number>();
     const readsClock = { v: false };
     const fn = this.buildFormula(formula, vars, context, reads, readsClock);
-    const atomFns = this.collectAtomFns(formula, vars, context);
+    const atomFns = this.collectAtomFns(formula, vars, context, false);
+    const relaxAtomFns = this.collectAtomFns(formula, vars, context, true);
     return {
       fn,
       reads,
       readsClock: readsClock.v,
       atoms: (b: Bindings) => atomFns.map((f) => f(b)),
+      relaxAtoms: (b: Bindings) => relaxAtomFns.map((f) => f(b)),
       ir: formula,
     };
   }
@@ -745,12 +750,17 @@ export class Model {
     }
   }
 
-  /** positive conjunctive lits → atom extractors (for heuristics); other parts skipped (optimistic) */
-  private collectAtomFns(formula: Formula, vars: Map<string, number>, context: string): ((b: Bindings) => Atom)[] {
+  /** positive conjunctive lits → atom extractors (for heuristics); other parts skipped (optimistic).
+   *  With includeHints, descends into external/opaque `relax` over-approximations. */
+  private collectAtomFns(formula: Formula, vars: Map<string, number>, context: string, includeHints: boolean): ((b: Bindings) => Atom)[] {
     const out: ((b: Bindings) => Atom)[] = [];
     const walk = (f: Formula): void => {
       if (f.f === "and") {
         f.parts.forEach(walk);
+        return;
+      }
+      if (includeHints && (f.f === "external" || f.f === "opaque")) {
+        if (f.relax) walk(f.relax); // fold the sound necessary condition into h
         return;
       }
       if (f.f !== "lit") return;
@@ -1173,7 +1183,10 @@ export class Model {
       return id;
     };
     for (const g of this.groundOps) {
-      g.preIds = Int32Array.from(g.preAtoms, intern);
+      // the relaxation sees real precondition lits *plus* any `relax`
+      // over-approximation atoms (preAtoms — used for search — stay real-only)
+      const relaxPre = g.op.pre ? g.op.pre.relaxAtoms(g.b) : [];
+      g.preIds = Int32Array.from(relaxPre, intern);
       g.addIds = Int32Array.from(g.addAtoms, intern);
     }
     this.relaxAtomCount = slots.length;

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -259,6 +259,13 @@ export class Model {
   public slotOwner!: Int32Array;
   public baseState!: Float64Array;
 
+  // reusable ExtQuery/ExtWriter so external/opaque predicate & numeric
+  // evaluation allocates nothing per call (was: a fresh 5-closure object each time)
+  private extState: Snap = undefined as unknown as Snap;
+  private extTarget: WritableState = undefined as unknown as WritableState;
+  private reuseQ: ExtQuery | null = null;
+  private reuseW: ExtWriter | null = null;
+
   constructor(doc: DomainDoc, setup: WorldSetup = {}, registry: Registry = {}) {
     const errors = validateDomain(doc).filter((d) => d.severity === "error");
     if (errors.length > 0) throw new DomainError(errors);
@@ -493,6 +500,64 @@ export class Model {
     };
   }
 
+  /** Slot for a dynamic (user-supplied) fluent ref, without the spread/rest +
+   *  `.map()` allocations of `slotOf` — for the reusable ExtQuery hot path. */
+  private slotOfArgs(name: string, a: (number | string)[]): number {
+    const cf = this.fluent(name);
+    let idx = 0;
+    for (let i = 0; i < cf.paramTypes.length; i++) {
+      const raw = a[i];
+      const gid = typeof raw === "string" ? this.entityId(raw) : raw;
+      const within = this.indexInType.get(cf.paramTypes[i])?.get(gid);
+      if (within === undefined) {
+        throw new Error(`Entity '${this.entityName(gid)}' is not of type '${cf.paramTypes[i]}' (fluent '${name}')`);
+      }
+      idx += within * cf.strides[i];
+    }
+    return cf.base + idx * cf.width;
+  }
+
+  /** Reusable ExtQuery bound to mutable model state (no per-call allocation).
+   *  External/opaque evaluation is a synchronous leaf call, so one shared,
+   *  re-pointed instance is safe. */
+  private queryFor(s: Snap, args: Bindings): ExtQuery {
+    this.extState = s;
+    let q = this.reuseQ;
+    if (q === null) {
+      q = this.reuseQ = {
+        args,
+        get: (fluent, ...a) => this.extState.get(this.slotOfArgs(fluent, a)),
+        vec: (fluent, ...a) => {
+          const cf = this.fluent(fluent);
+          const slot = this.slotOfArgs(fluent, a);
+          const out: number[] = [];
+          for (let i = 0; i < cf.width; i++) out.push(this.extState.get(slot + i));
+          return out;
+        },
+        clock: () => this.extState.get(CLOCK_SLOT),
+        gid: (name) => this.entityId(name),
+        name: (gid) => this.entityName(gid),
+      };
+    }
+    q.args = args;
+    return q;
+  }
+
+  /** Reusable ExtWriter (reads see the target being written). */
+  private writerFor(target: WritableState, args: Bindings): ExtWriter {
+    const q = this.queryFor(target, args); // sets extState = target ⇒ reads see writes
+    this.extTarget = target;
+    let w = this.reuseW;
+    if (w === null) {
+      w = this.reuseW = {
+        ...q,
+        set: (fluent, a, value) => this.extTarget.set(this.slotOfArgs(fluent, a), this.encodeValue(fluent, value)),
+      };
+    }
+    w.args = args;
+    return w;
+  }
+
   // ---------------- numeric expression compilation
 
   compileNum(expr: NumExpr, vars: Map<string, number>, context: string): CompiledNum {
@@ -551,7 +616,7 @@ export class Model {
         if (!fn) throw new Error(`Unregistered external numeric '${expr.name}' in ${context}`);
         for (const r of expr.reads) reads.add(this.fluent(r).id);
         const getArgs = this.argFn(this.resolveArgSources(expr.args, vars, context));
-        return (s, b) => fn(this.extQuery(s, getArgs(b)));
+        return (s, b) => fn(this.queryFor(s, getArgs(b)));
       }
     }
     throw new Error(`Unreachable numeric expression in ${context}`);
@@ -637,12 +702,12 @@ export class Model {
         if (!fn) throw new Error(`Unregistered external predicate '${formula.name}' in ${context}`);
         for (const r of formula.reads) reads.add(this.fluent(r).id);
         const getArgs = this.argFn(this.resolveArgSources(formula.args, vars, context));
-        return (s, b) => fn(this.extQuery(s, getArgs(b)));
+        return (s, b) => fn(this.queryFor(s, getArgs(b)));
       }
       case "opaque": {
         const fn = this.registry.predicates[formula.name];
         if (!fn) throw new Error(`Unregistered opaque predicate '${formula.name}' in ${context}`);
-        return (s, b) => fn(this.extQuery(s, b));
+        return (s, b) => fn(this.queryFor(s, b));
       }
     }
     throw new Error(`Unreachable formula in ${context}`);
@@ -728,7 +793,7 @@ export class Model {
         }
         appliers.push((target, b, mask) => {
           if ((mask & timingBit) === 0) return;
-          fn(this.extWriter(target, b));
+          fn(this.writerFor(target, b));
         });
         continue;
       }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -172,6 +172,8 @@ export interface CompiledMethod {
   pre: CompiledFormula | null;
   utility: CompiledNum | null;
   subtasks: CompiledSubtask[];
+  /** memoized free-parameter binding enumeration (types are fixed at compile time) */
+  freeBindingsCache?: Bindings[];
 }
 
 interface CompiledFluent {
@@ -241,6 +243,15 @@ export class Model {
   public relaxAtomValue: Float64Array = new Float64Array(0);
   public relaxAtomFuzzy: Uint8Array = new Uint8Array(0);
   private readonly relaxAtomIndex = new Map<string, number>();
+
+  // ---- successor generator: index each ground op by its most-selective
+  //      precondition atom so search considers only plausibly-applicable ops
+  //      (selector holds) instead of scanning all ground operators per node.
+  /** ops with no positive-lit precondition — always candidates */
+  public succAlwaysOps: GroundOp[] = [];
+  /** distinct selector slots; succSelTables[k] maps required value → gid-sorted ops */
+  public succSelSlots: Int32Array = new Int32Array(0);
+  public succSelTables: Map<number, GroundOp[]>[] = [];
 
   public slotCount = 1; // slot 0 = clock
   public slotOwner!: Int32Array;
@@ -972,6 +983,44 @@ export class Model {
       }
     }
     this.buildRelaxTables();
+    this.buildSuccessorIndex();
+  }
+
+  /** Index ground ops by their most-selective precondition atom. Positive-lit
+   *  preconditions are necessary conditions, so an op whose selector atom does
+   *  not hold is inapplicable — letting search skip it without an evaluation. */
+  private buildSuccessorIndex(): void {
+    // distinct required values per slot ≈ selectivity (positional fluents
+    // partition finely; booleans shared by every binding do not)
+    const valuesBySlot = new Map<number, Set<number>>();
+    for (const g of this.groundOps) {
+      for (const a of g.preAtoms) {
+        let s = valuesBySlot.get(a.slot);
+        if (!s) valuesBySlot.set(a.slot, (s = new Set()));
+        s.add(a.value);
+      }
+    }
+    const selectivity = (slot: number): number => valuesBySlot.get(slot)?.size ?? 0;
+
+    this.succAlwaysOps = [];
+    const tables = new Map<number, Map<number, GroundOp[]>>();
+    for (const g of this.groundOps) {
+      if (g.preAtoms.length === 0) {
+        this.succAlwaysOps.push(g); // no indexable precondition — always consider
+        continue;
+      }
+      let sel = g.preAtoms[0];
+      for (let i = 1; i < g.preAtoms.length; i++) {
+        if (selectivity(g.preAtoms[i].slot) > selectivity(sel.slot)) sel = g.preAtoms[i];
+      }
+      let table = tables.get(sel.slot);
+      if (!table) tables.set(sel.slot, (table = new Map()));
+      let list = table.get(sel.value);
+      if (!list) table.set(sel.value, (list = []));
+      list.push(g); // groundOps iterated in gid order ⇒ each bucket stays gid-sorted
+    }
+    this.succSelSlots = Int32Array.from(tables.keys());
+    this.succSelTables = Array.from(this.succSelSlots, (s) => tables.get(s) as Map<number, GroundOp[]>);
   }
 
   /** Intern every distinct (slot,value) atom over the ground operators and emit
@@ -1011,9 +1060,14 @@ export class Model {
     return id === undefined ? -1 : id;
   }
 
-  /** Enumerate bindings for a method's free parameters. */
+  /** Enumerate bindings for a method's free parameters (memoized — fixed types). */
   freeBindings(method: CompiledMethod): Bindings[] {
-    return this.enumerateBindings(method.freeParams.map((p) => p.type));
+    let cache = method.freeBindingsCache;
+    if (cache === undefined) {
+      cache = this.enumerateBindings(method.freeParams.map((p) => p.type));
+      method.freeBindingsCache = cache;
+    }
+    return cache;
   }
 
   // ---------------- introspection helpers

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -252,6 +252,8 @@ export class Model {
   /** distinct selector slots; succSelTables[k] maps required value → gid-sorted ops */
   public succSelSlots: Int32Array = new Int32Array(0);
   public succSelTables: Map<number, GroundOp[]>[] = [];
+  /** true when candidates can come from >1 bucket and must be re-sorted into gid order */
+  public succNeedsSort = false;
 
   public slotCount = 1; // slot 0 = clock
   public slotOwner!: Int32Array;
@@ -441,10 +443,26 @@ export class Model {
     const sources = this.resolveArgSources(args, vars, context);
     if (sources.every((s) => "c" in s)) {
       const slot = this.slotOf(name, ...sources.map((s) => (s as { c: number }).c));
-      return () => slot;
+      return () => slot; // fully ground ⇒ constant slot, resolved once
     }
-    const getArgs = this.argFn(sources);
-    return (b: Bindings) => this.slotOf(name, ...getArgs(b));
+    // variable args: precompute the fluent layout + per-param index maps so the
+    // hot closure does no name lookup, no per-type map lookup, and no array
+    // allocation (the previous `slotOf(name, ...getArgs(b))` allocated two).
+    const cf = this.fluent(name);
+    const np = cf.paramTypes.length;
+    const idxMaps = cf.paramTypes.map((t) => this.indexInType.get(t) as Map<number, number>);
+    const strides = cf.strides;
+    const base = cf.base;
+    const width = cf.width;
+    return (b: Bindings) => {
+      let idx = 0;
+      for (let i = 0; i < np; i++) {
+        const src = sources[i];
+        const gid = "c" in src ? (src as { c: number }).c : b[(src as { v: number }).v];
+        idx += (idxMaps[i].get(gid) as number) * strides[i];
+      }
+      return base + idx * width;
+    };
   }
 
   private extQuery(s: Snap, args: Bindings): ExtQuery {
@@ -1021,6 +1039,9 @@ export class Model {
     }
     this.succSelSlots = Int32Array.from(tables.keys());
     this.succSelTables = Array.from(this.succSelSlots, (s) => tables.get(s) as Map<number, GroundOp[]>);
+    // a single bucket is already gid-sorted; only multiple contributing sources
+    // (≥2 selector slots, or always-ops mixed with a selector) can interleave
+    this.succNeedsSort = !(this.succAlwaysOps.length === 0 && this.succSelSlots.length <= 1);
   }
 
   /** Intern every distinct (slot,value) atom over the ground operators and emit

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -239,6 +239,8 @@ export class Model {
   public groundOps: GroundOp[] = [];
   /** fluents any operator writes non-atomically — relaxation treats them as optimistically settable */
   public readonly relaxFuzzyWrites = new Set<number>();
+  /** fluents no operator effect writes — their precondition lits are compile-time constants */
+  public readonly staticFluents = new Set<number>();
 
   // ---- relaxation heuristic tables: distinct (slot,value) atoms interned to
   //      dense ids at compile time so h_add/h_max runs over typed arrays with no
@@ -1097,6 +1099,26 @@ export class Model {
 
   private groundOperators(): void {
     this.groundOps = [];
+    // fluents the author DECLARED static are immutable after init, so any
+    // precondition lit over them is a compile-time constant. (We cannot infer
+    // this from "no operator writes it" — the host can mutate world fluents
+    // between plans, e.g. has_vehicle; it must be a promise, validated here.)
+    const written = new Set<number>();
+    for (const op of this.operators) for (const w of op.effects.writes) written.add(w);
+    for (const f of this.fluents) {
+      if (!f.decl.static) continue;
+      if (written.has(f.id)) {
+        throw new Error(`Fluent '${f.decl.name}' is declared static but an operator effect writes it`);
+      }
+      this.staticFluents.add(f.id);
+    }
+    const base = this.baseState;
+    const owner = this.slotOwner;
+    const staticAtomFails = (a: Atom): boolean => {
+      const o = owner[a.slot];
+      return o >= 0 && this.staticFluents.has(o) && base[a.slot] !== a.value;
+    };
+
     for (const op of this.operators) {
       const checks = op.argOnlyChecks;
       for (const b of this.enumerateBindings(op.paramTypes)) {
@@ -1112,11 +1134,25 @@ export class Model {
           }
         }
         if (!ok) continue;
+        const preAtoms = op.pre ? op.pre.atoms(b) : [];
+        // static-fluent prune (relevance analysis): a precondition over a static
+        // fluent (adjacency, maps, alignment, …) that is false in the initial
+        // state can NEVER hold, so this grounding is dead — drop it. Sound for the
+        // heuristic too: such an atom is unreachable in the relaxation (static ⇒
+        // never added, current value = base value), so the op never fires there.
+        let dead = false;
+        for (let i = 0; i < preAtoms.length; i++) {
+          if (staticAtomFails(preAtoms[i])) {
+            dead = true;
+            break;
+          }
+        }
+        if (dead) continue;
         this.groundOps.push({
           gid: this.groundOps.length,
           op,
           b,
-          preAtoms: op.pre ? op.pre.atoms(b) : [],
+          preAtoms,
           addAtoms: op.effects.addAtoms(b),
         });
       }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -137,6 +137,10 @@ export interface GroundOp {
   b: Bindings;
   preAtoms: Atom[];
   addAtoms: Atom[];
+  /** compile-time interned relaxation-atom ids (parallel to pre/addAtoms); drive
+   *  the allocation-free h_add/h_max core. Filled by Model.buildRelaxTables(). */
+  preIds?: Int32Array;
+  addIds?: Int32Array;
 }
 
 export interface CompiledScopeTmpl {
@@ -227,6 +231,16 @@ export class Model {
   public groundOps: GroundOp[] = [];
   /** fluents any operator writes non-atomically — relaxation treats them as optimistically settable */
   public readonly relaxFuzzyWrites = new Set<number>();
+
+  // ---- relaxation heuristic tables: distinct (slot,value) atoms interned to
+  //      dense ids at compile time so h_add/h_max runs over typed arrays with no
+  //      per-atom string keys or maps on the hot path (see search.ts/relaxCore).
+  /** number of distinct atoms appearing in any ground op's pre/add sets */
+  public relaxAtomCount = 0;
+  public relaxAtomSlot: Int32Array = new Int32Array(0);
+  public relaxAtomValue: Float64Array = new Float64Array(0);
+  public relaxAtomFuzzy: Uint8Array = new Uint8Array(0);
+  private readonly relaxAtomIndex = new Map<string, number>();
 
   public slotCount = 1; // slot 0 = clock
   public slotOwner!: Int32Array;
@@ -957,6 +971,44 @@ export class Model {
         });
       }
     }
+    this.buildRelaxTables();
+  }
+
+  /** Intern every distinct (slot,value) atom over the ground operators and emit
+   *  the typed-array tables + per-op id arrays the relaxation heuristic runs on. */
+  private buildRelaxTables(): void {
+    const slots: number[] = [];
+    const values: number[] = [];
+    const index = this.relaxAtomIndex;
+    const intern = (a: Atom): number => {
+      const key = `${a.slot}:${a.value}`;
+      let id = index.get(key);
+      if (id === undefined) {
+        id = slots.length;
+        index.set(key, id);
+        slots.push(a.slot);
+        values.push(a.value);
+      }
+      return id;
+    };
+    for (const g of this.groundOps) {
+      g.preIds = Int32Array.from(g.preAtoms, intern);
+      g.addIds = Int32Array.from(g.addAtoms, intern);
+    }
+    this.relaxAtomCount = slots.length;
+    this.relaxAtomSlot = Int32Array.from(slots);
+    this.relaxAtomValue = Float64Array.from(values);
+    this.relaxAtomFuzzy = new Uint8Array(this.relaxAtomCount);
+    for (let id = 0; id < this.relaxAtomCount; id++) {
+      const owner = this.slotOwner[slots[id]];
+      this.relaxAtomFuzzy[id] = owner >= 0 && this.relaxFuzzyWrites.has(owner) ? 1 : 0;
+    }
+  }
+
+  /** interned relaxation-atom id for (slot,value), or -1 if no ground op references it */
+  relaxAtomId(slot: number, value: number): number {
+    const id = this.relaxAtomIndex.get(`${slot}:${value}`);
+    return id === undefined ? -1 : id;
   }
 
   /** Enumerate bindings for a method's free parameters. */

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -93,6 +93,10 @@ export interface CompiledFormula {
   /** like `atoms`, but also folds in external/opaque `relax` over-approximations —
    *  used only by the relaxation heuristic, never for search applicability */
   relaxAtoms: (b: Bindings) => Atom[];
+  /** true when `atoms` fully captures the formula (a conjunction of encodable,
+   *  non-axiom positive lits) — so an atom-level check is the whole precondition
+   *  and the compiled closure can be skipped once the atoms hold */
+  atomsComplete: boolean;
   ir: Formula;
 }
 
@@ -644,8 +648,24 @@ export class Model {
       readsClock: readsClock.v,
       atoms: (b: Bindings) => atomFns.map((f) => f(b)),
       relaxAtoms: (b: Bindings) => relaxAtomFns.map((f) => f(b)),
+      atomsComplete: this.formulaAtomsComplete(formula, vars, context),
       ir: formula,
     };
+  }
+
+  /** Does `atoms()` fully capture this formula? True iff it's a conjunction of
+   *  encodable, non-axiom positive lits (no not/or/cmp/external/opaque/axiom). */
+  private formulaAtomsComplete(f: Formula, vars: Map<string, number>, context: string): boolean {
+    if (f.f === "and") return f.parts.every((p) => this.formulaAtomsComplete(p, vars, context));
+    if (f.f !== "lit" || this.axioms.has(f.fluent)) return false;
+    const cf = this.fluentByName.get(f.fluent);
+    if (!cf) return false;
+    try {
+      this.encodeLitValue(cf, f.value, vars, context); // must be representable as an atom
+    } catch {
+      return false;
+    }
+    return true;
   }
 
   private buildFormula(

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -129,6 +129,9 @@ export interface CompiledOperator {
   cost: CompiledNum;
   duration: CompiledNum;
   executor: string | undefined;
+  /** precondition checks over arg-only externals (declared empty read set ⇒
+   *  constant per ground binding); evaluated once at grounding to prune ops */
+  argOnlyChecks: ((b: Bindings) => boolean)[];
 }
 
 export interface GroundOp {
@@ -901,6 +904,8 @@ export class Model {
       const params = decl.params ?? [];
       const vars = new Map(params.map((p, i) => [varKey(p.name), i]));
       const ctxName = `operators/${decl.name}`;
+      const argOnlyChecks: ((b: Bindings) => boolean)[] = [];
+      if (decl.pre) this.collectArgOnlyChecks(decl.pre, vars, `${ctxName}/pre`, argOnlyChecks);
       const op: CompiledOperator = {
         id: this.operators.length,
         name: decl.name,
@@ -915,10 +920,38 @@ export class Model {
             ? this.compileNum(num(decl.duration), vars, `${ctxName}/duration`)
             : { fn: () => 0, reads: new Set() },
         executor: decl.executor,
+        argOnlyChecks,
       };
       this.operators.push(op);
       this.operatorByName.set(decl.name, op);
       for (const f of op.effects.fuzzyWrites) this.relaxFuzzyWrites.add(f);
+    }
+  }
+
+  /** Snap over the (post-init) base world, for evaluating arg-only externals. */
+  private baseSnap(): Snap {
+    if (!this._baseSnap) this._baseSnap = { get: (slot: number) => this.baseState[slot] };
+    return this._baseSnap;
+  }
+  private _baseSnap: Snap | null = null;
+
+  /**
+   * Collect prunable precondition checks: an external predicate with a declared
+   * **empty read set** is a pure function of its arguments, so it is constant per
+   * ground binding and can be evaluated once at grounding. Only sound in
+   * conjunctive position (top-level `and` / bare external) — never under
+   * `not`/`or`, and never for opaque predicates (which declare nothing).
+   */
+  private collectArgOnlyChecks(f: Formula, vars: Map<string, number>, ctx: string, out: ((b: Bindings) => boolean)[]): void {
+    if (f.f === "and") {
+      for (const p of f.parts) this.collectArgOnlyChecks(p, vars, ctx, out);
+      return;
+    }
+    if (f.f === "external" && f.reads.length === 0) {
+      const fn = this.registry.predicates[f.name] as ExternalPredicate | undefined;
+      if (!fn) return;
+      const argFn = this.argFn(this.resolveArgSources(f.args, vars, ctx));
+      out.push((b) => fn(this.queryFor(this.baseSnap(), argFn(b))));
     }
   }
 
@@ -1055,7 +1088,20 @@ export class Model {
   private groundOperators(): void {
     this.groundOps = [];
     for (const op of this.operators) {
+      const checks = op.argOnlyChecks;
       for (const b of this.enumerateBindings(op.paramTypes)) {
+        // metadata-driven prune: skip bindings an arg-only external rejects (e.g.
+        // neq(x,x)) — they can never apply, so they enter neither search nor the
+        // relaxation. The relaxation already treats externals optimistically, so
+        // dropping these invalid groundings leaves the heuristic unchanged.
+        let ok = true;
+        for (let i = 0; i < checks.length; i++) {
+          if (!checks[i](b)) {
+            ok = false;
+            break;
+          }
+        }
+        if (!ok) continue;
         this.groundOps.push({
           gid: this.groundOps.length,
           op,

--- a/src/ir.ts
+++ b/src/ir.ts
@@ -118,8 +118,12 @@ export type Formula =
   | { f: "not"; part: Formula }
   | { f: "lit"; fluent: string; args: Term[]; value?: Term } // boolean fluents: omitted value = true
   | { f: "cmp"; op: CmpOp; a: NumExpr; b: NumExpr }
-  | { f: "external"; name: string; args: Term[]; reads: string[] }
-  | { f: "opaque"; name: string };
+  // `relax`: an optional T1 over-approximation — a formula the predicate's truth
+  // *implies* (a sound necessary condition). The relaxation heuristic folds its
+  // conjunctive lits in as extra preconditions, so the black box stops being
+  // invisible to h (and stays admissible iff the implication genuinely holds).
+  | { f: "external"; name: string; args: Term[]; reads: string[]; relax?: Formula }
+  | { f: "opaque"; name: string; relax?: Formula };
 
 /** Formula helpers. */
 export const F = {
@@ -139,8 +143,8 @@ export const F = {
   gte: (a: NumLike, b: NumLike): Formula => F.cmp(">=", a, b),
   gt: (a: NumLike, b: NumLike): Formula => F.cmp(">", a, b),
   eq: (a: NumLike, b: NumLike): Formula => F.cmp("==", a, b),
-  ext: (name: string, args: TermLike[], reads: string[]): Formula => ({ f: "external", name, args: terms(args), reads }),
-  opaque: (name: string): Formula => ({ f: "opaque", name }),
+  ext: (name: string, args: TermLike[], reads: string[], relax?: Formula): Formula => ({ f: "external", name, args: terms(args), reads, ...(relax ? { relax } : {}) }),
+  opaque: (name: string, relax?: Formula): Formula => ({ f: "opaque", name, ...(relax ? { relax } : {}) }),
   true: (): Formula => ({ f: "and", parts: [] }),
 };
 
@@ -408,6 +412,8 @@ function checkFormula(
       return;
     case "external":
     case "opaque":
+      // validate the optional relaxation over-approximation (a real T1 formula)
+      if (formula.relax) checkFormula(formula.relax, vars, idx, `${path}/relax`, out, axiomStack);
       return;
   }
 }

--- a/src/ir.ts
+++ b/src/ir.ts
@@ -37,6 +37,14 @@ export interface FluentDecl {
   entityType?: TypeName;
   /** default initial value (boolean=false, numbers=0, enum=values[0], entity=null) */
   initial?: number | boolean | string | [number, number] | [number, number, number];
+  /**
+   * Declares this fluent IMMUTABLE after the initial state — never changed by any
+   * operator *or the host*. Lets the compiler treat precondition lits over it as
+   * compile-time constants and prune ground operators whose static precondition
+   * can never hold (adjacency, maps, alignment, type tables). Unsound to set on a
+   * fluent that actually changes; validated against operator effects.
+   */
+  static?: boolean;
 }
 
 // ---------------------------------------------------------------- terms

--- a/src/search.ts
+++ b/src/search.ts
@@ -730,7 +730,9 @@ export class Engine {
           }
         }
         if (!preOk) continue;
-        if (g.op.pre && !g.op.pre.fn(node.state, g.b)) continue;
+        // when the atoms ARE the whole precondition, the fast-reject above already
+        // proved applicability — skip the compiled closure entirely
+        if (g.op.pre && !g.op.pre.atomsComplete && !g.op.pre.fn(node.state, g.b)) continue;
         const child = node.state.child();
         g.op.effects.apply(child, g.b, TIMINGS_PLANNING);
         const dur = g.op.duration.fn(node.state, g.b);

--- a/src/search.ts
+++ b/src/search.ts
@@ -194,75 +194,126 @@ class Heap {
   }
 }
 
-// ---------------------------------------------------------------- h_add relaxation heuristic
+// ---------------------------------------------------------------- h_add / h_max relaxation heuristic
 
-function atomKey(a: Atom): string {
-  return `${a.slot}:${a.value}`;
+/** A goal atom resolved against the model's interned relaxation atoms. */
+interface GoalAtomDesc {
+  /** interned relaxation-atom id, or -1 if no ground operator references this atom */
+  id: number;
+  slot: number;
+  value: number;
+  fuzzy: boolean;
+}
+
+/** Resolve goal atoms to interned descriptors once (cold path, per goal search). */
+function goalDescs(model: Model, goalAtoms: Atom[]): GoalAtomDesc[] {
+  const out: GoalAtomDesc[] = new Array(goalAtoms.length);
+  for (let i = 0; i < goalAtoms.length; i++) {
+    const a = goalAtoms[i];
+    const owner = model.slotOwner[a.slot];
+    out[i] = {
+      id: model.relaxAtomId(a.slot, a.value),
+      slot: a.slot,
+      value: a.value,
+      fuzzy: owner >= 0 && model.relaxFuzzyWrites.has(owner),
+    };
+  }
+  return out;
 }
 
 /**
- * Delete-relaxation heuristic over ground operators (unit action costs).
- * mode "add": h_add — informative but may overestimate (inadmissible).
- * mode "max": h_max — admissible; pair with weight 1 for optimal plans.
- * Numeric/external/negative conditions are treated optimistically.
+ * Delete-relaxation heuristic over ground operators (unit action costs), computed
+ * over compile-time interned atom ids into a reusable numeric cost buffer — no
+ * per-atom string keys or maps on the hot path.
+ *
+ *   add=true  → h_add (informative, may overestimate / inadmissible)
+ *   add=false → h_max (admissible; pair with weight 1 for optimal plans)
+ *
+ * Numeric/external/negative conditions are treated optimistically: a "fuzzy"
+ * atom (written non-atomically by some operator) can take any value at cost 1 and
+ * is never called unreachable. Semantics match the original Map-based version.
  */
-export function hAdd(model: Model, s: Snap, goalAtoms: Atom[], mode: "add" | "max" = "add"): number {
-  if (goalAtoms.length === 0) return 0;
-  const cost = new Map<string, number>();
-  let missing = 0;
-  for (const a of goalAtoms) {
-    if (s.get(a.slot) === a.value) cost.set(atomKey(a), 0);
-    else missing++;
+function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDesc[], add: boolean): number {
+  const n = model.relaxAtomCount;
+  const slot = model.relaxAtomSlot;
+  const val = model.relaxAtomValue;
+  const fuzzy = model.relaxAtomFuzzy;
+
+  // seed: an atom that currently holds costs 0, everything else starts unreachable
+  for (let id = 0; id < n; id++) cost[id] = s.get(slot[id]) === val[id] ? 0 : Infinity;
+
+  // already satisfied? (mirrors the original missing===0 early-out)
+  let allHold = true;
+  for (let i = 0; i < goals.length; i++) {
+    const g = goals[i];
+    if (!(g.id >= 0 ? cost[g.id] === 0 : s.get(g.slot) === g.value)) {
+      allHold = false;
+      break;
+    }
   }
-  if (missing === 0) return 0;
+  if (allHold) return 0;
 
-  // fluents written non-atomically (NumExpr/inc/dec/external effects) can take
-  // any value under the relaxation — never call their atoms unreachable
-  const fuzzy = (a: Atom): boolean => model.relaxFuzzyWrites.has(model.slotOwner[a.slot]);
-
-  const atomCost = (a: Atom): number => {
-    if (s.get(a.slot) === a.value) return 0;
-    const c = cost.get(atomKey(a));
-    if (c !== undefined) return c;
-    return fuzzy(a) ? 1 : Infinity;
-  };
-
+  // relaxed fixpoint: an op fires once all its preconditions are reachable,
+  // lifting its add atoms to (combined precondition cost) + 1
+  const ops = model.groundOps;
   let changed = true;
   let rounds = 0;
   while (changed && rounds < 64) {
     changed = false;
     rounds++;
-    for (const g of model.groundOps) {
-      if (g.addAtoms.length === 0) continue;
+    for (let oi = 0; oi < ops.length; oi++) {
+      const addIds = ops[oi].addIds as Int32Array;
+      if (addIds.length === 0) continue;
+      const preIds = ops[oi].preIds as Int32Array;
       let pc = 0;
-      for (const p of g.preAtoms) {
-        const c = atomCost(p);
+      let inf = false;
+      for (let i = 0; i < preIds.length; i++) {
+        const pid = preIds[i];
+        let c = cost[pid];
+        if (c === Infinity) c = fuzzy[pid] ? 1 : Infinity;
         if (c === Infinity) {
-          pc = Infinity;
+          inf = true;
           break;
         }
-        pc = mode === "add" ? pc + c : Math.max(pc, c);
+        pc = add ? pc + c : c > pc ? c : pc;
       }
-      if (pc === Infinity) continue;
+      if (inf) continue;
       const through = pc + 1;
-      for (const add of g.addAtoms) {
-        const k = atomKey(add);
-        const prev = cost.get(k);
-        if (prev === undefined || through < prev) {
-          cost.set(k, through);
+      for (let i = 0; i < addIds.length; i++) {
+        const aid = addIds[i];
+        if (through < cost[aid]) {
+          cost[aid] = through;
           changed = true;
         }
       }
     }
   }
 
+  // combine the (effective) cost of each goal atom
   let h = 0;
-  for (const a of goalAtoms) {
-    const c = atomCost(a);
+  for (let i = 0; i < goals.length; i++) {
+    const g = goals[i];
+    let c: number;
+    if (g.id >= 0) {
+      c = cost[g.id];
+      if (c === Infinity) c = g.fuzzy ? 1 : Infinity;
+    } else {
+      c = s.get(g.slot) === g.value ? 0 : g.fuzzy ? 1 : Infinity;
+    }
     if (c === Infinity) return Infinity;
-    h = mode === "add" ? h + c : Math.max(h, c);
+    h = add ? h + c : c > h ? c : h;
   }
   return h;
+}
+
+/**
+ * Public delete-relaxation heuristic (SPEC §7.3). Builds goal descriptors and a
+ * scratch buffer per call; the Engine uses a faster path that reuses both.
+ */
+export function hAdd(model: Model, s: Snap, goalAtoms: Atom[], mode: "add" | "max" = "add"): number {
+  if (goalAtoms.length === 0) return 0;
+  const cost = new Float64Array(model.relaxAtomCount);
+  return relaxCore(model, s, cost, goalDescs(model, goalAtoms), mode === "add");
 }
 
 // ---------------------------------------------------------------- engine
@@ -291,6 +342,8 @@ export class Engine {
   private scopeIds = 0;
   private readonly pathKeys = new Set<string>();
   private readonly hCache = new Map<number, number>();
+  /** reusable relaxation cost buffer (sized to model.relaxAtomCount) */
+  private costBuf: Float64Array | null = null;
 
   constructor(model: Model, req: PlanRequest) {
     this.model = model;
@@ -591,10 +644,11 @@ export class Engine {
     const weight = this.req.weight;
     const open = new Heap();
     const closed = new Map<number, number>();
-    const seenPairs = new Set<string>();
+    const seenAtoms = new Set<number>();
+    const descs = goalDescs(model, item.atoms);
     let seq = 0;
 
-    const h0 = this.heuristic(start, item.atoms);
+    const h0 = this.heuristic(start, descs);
     if (h0 === Infinity && item.atoms.length > 0) {
       this.reject(item.label, "goal unreachable under relaxation");
       return null;
@@ -637,14 +691,15 @@ export class Engine {
         const known = closed.get(key);
         if (known !== undefined && known <= g2) continue;
         closed.set(key, g2);
-        const h = this.heuristic(child, item.atoms);
+        const h = this.heuristic(child, descs);
         if (h === Infinity) continue;
         let novelty = 1;
         if (this.req.novelty) {
-          for (const a of g.addAtoms) {
-            const k = atomKey(a);
-            if (!seenPairs.has(k)) {
-              seenPairs.add(k);
+          const addIds = g.addIds as Int32Array;
+          for (let i = 0; i < addIds.length; i++) {
+            const aid = addIds[i];
+            if (!seenAtoms.has(aid)) {
+              seenAtoms.add(aid);
               novelty = 0;
             }
           }
@@ -664,13 +719,15 @@ export class Engine {
     return true;
   }
 
-  private heuristic(state: StateView, goalAtoms: Atom[]): number {
-    if (goalAtoms.length === 0 || this.req.heuristic === "none") return 0;
+  private heuristic(state: StateView, descs: GoalAtomDesc[]): number {
+    if (descs.length === 0 || this.req.heuristic === "none") return 0;
     const key = state.key();
     const cached = this.hCache.get(key);
     if (cached !== undefined) return cached;
     this.heuristicEvals++;
-    const h = hAdd(this.model, state, goalAtoms, this.req.heuristic === "hmax" ? "max" : "add");
+    const n = this.model.relaxAtomCount;
+    if (!this.costBuf || this.costBuf.length !== n) this.costBuf = new Float64Array(n);
+    const h = relaxCore(this.model, state, this.costBuf, descs, this.req.heuristic !== "hmax");
     this.hCache.set(key, h);
     return h;
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -246,20 +246,21 @@ function goalDescs(model: Model, goalAtoms: Atom[]): GoalAtomDesc[] {
  * one shared atom like `agentAt` gates nearly every op; the dense round-based
  * sweep wins until domains get large and sparse.)
  */
-function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDesc[], add: boolean): number {
+function relaxCore(model: Model, flat: Float64Array, cost: Float64Array, goals: GoalAtomDesc[], add: boolean): number {
   const n = model.relaxAtomCount;
   const slot = model.relaxAtomSlot;
   const val = model.relaxAtomValue;
   const fuzzy = model.relaxAtomFuzzy;
 
   // seed: an atom that currently holds costs 0, everything else starts unreachable
-  for (let id = 0; id < n; id++) cost[id] = s.get(slot[id]) === val[id] ? 0 : Infinity;
+  // (reads from a flat packed buffer ⇒ O(1) per slot, no delta-chain walk)
+  for (let id = 0; id < n; id++) cost[id] = flat[slot[id]] === val[id] ? 0 : Infinity;
 
   // already satisfied? (mirrors the original missing===0 early-out)
   let allHold = true;
   for (let i = 0; i < goals.length; i++) {
     const g = goals[i];
-    if (!(g.id >= 0 ? cost[g.id] === 0 : s.get(g.slot) === g.value)) {
+    if (!(g.id >= 0 ? cost[g.id] === 0 : flat[g.slot] === g.value)) {
       allHold = false;
       break;
     }
@@ -311,7 +312,7 @@ function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDes
       c = cost[g.id];
       if (c === Infinity) c = g.fuzzy ? 1 : Infinity;
     } else {
-      c = s.get(g.slot) === g.value ? 0 : g.fuzzy ? 1 : Infinity;
+      c = flat[g.slot] === g.value ? 0 : g.fuzzy ? 1 : Infinity;
     }
     if (c === Infinity) return Infinity;
     h = add ? h + c : c > h ? c : h;
@@ -319,13 +320,21 @@ function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDes
   return h;
 }
 
+/** Flatten any Snap into a packed slot buffer for the relaxation reader. */
+function snapToFlat(model: Model, s: Snap): Float64Array {
+  if (s instanceof StateView) return s.materialize();
+  const out = new Float64Array(model.slotCount);
+  for (let i = 0; i < out.length; i++) out[i] = s.get(i);
+  return out;
+}
+
 /**
- * Public delete-relaxation heuristic (SPEC §7.3). Allocates a scratch buffer per
- * call; the Engine uses a faster path that reuses both buffer and goal descriptors.
+ * Public delete-relaxation heuristic (SPEC §7.3). Allocates scratch per call; the
+ * Engine uses a faster path that reuses its buffers and goal descriptors.
  */
 export function hAdd(model: Model, s: Snap, goalAtoms: Atom[], mode: "add" | "max" = "add"): number {
   if (goalAtoms.length === 0) return 0;
-  return relaxCore(model, s, new Float64Array(model.relaxAtomCount), goalDescs(model, goalAtoms), mode === "add");
+  return relaxCore(model, snapToFlat(model, s), new Float64Array(model.relaxAtomCount), goalDescs(model, goalAtoms), mode === "add");
 }
 
 // ---------------------------------------------------------------- engine
@@ -356,6 +365,8 @@ export class Engine {
   private readonly hCache = new Map<number, number>();
   /** reusable relaxation cost buffer (sized to model.relaxAtomCount) */
   private costBuf: Float64Array | null = null;
+  /** reusable flat state buffer for O(1) reads during heuristic evaluation */
+  private flatBuf: Float64Array | null = null;
   /** reusable candidate-op scratch for the indexed successor generator */
   private readonly succScratch: GroundOp[] = [];
 
@@ -705,7 +716,7 @@ export class Engine {
         const list = selTables[k].get(node.state.get(selSlots[k]));
         if (list !== undefined) for (let i = 0; i < list.length; i++) cand.push(list[i]);
       }
-      if (cand.length > 1) cand.sort(byGid); // restore gid order ⇒ identical search
+      if (model.succNeedsSort && cand.length > 1) cand.sort(byGid); // gid order ⇒ identical search
 
       for (let ci = 0; ci < cand.length; ci++) {
         const g = cand[ci];
@@ -765,9 +776,14 @@ export class Engine {
     const cached = this.hCache.get(key);
     if (cached !== undefined) return cached;
     this.heuristicEvals++;
-    const n = this.model.relaxAtomCount;
-    if (!this.costBuf || this.costBuf.length !== n) this.costBuf = new Float64Array(n);
-    const h = relaxCore(this.model, state, this.costBuf, descs, this.req.heuristic !== "hmax");
+    if (!this.costBuf || this.costBuf.length !== this.model.relaxAtomCount) {
+      this.costBuf = new Float64Array(this.model.relaxAtomCount);
+    }
+    if (!this.flatBuf || this.flatBuf.length !== this.model.slotCount) {
+      this.flatBuf = new Float64Array(this.model.slotCount);
+    }
+    state.materializeInto(this.flatBuf);
+    const h = relaxCore(this.model, this.flatBuf, this.costBuf, descs, this.req.heuristic !== "hmax");
     this.hCache.set(key, h);
     return h;
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -55,6 +55,10 @@ export function cons(head: AgendaItem, tail: Agenda): Agenda {
   return { head, tail };
 }
 
+function byGid(a: GroundOp, b: GroundOp): number {
+  return a.gid - b.gid;
+}
+
 export function agendaFrom(items: AgendaItem[], tail: Agenda = null): Agenda {
   let a = tail;
   for (let i = items.length - 1; i >= 0; i--) a = cons(items[i], a);
@@ -158,7 +162,9 @@ class Heap {
     while (i > 0) {
       const p = (i - 1) >> 1;
       if (Heap.less(a[i], a[p])) {
-        [a[i], a[p]] = [a[p], a[i]];
+        const t = a[i];
+        a[i] = a[p];
+        a[p] = t;
         i = p;
       } else break;
     }
@@ -179,7 +185,9 @@ class Heap {
         if (l < a.length && Heap.less(a[l], a[m])) m = l;
         if (r < a.length && Heap.less(a[r], a[m])) m = r;
         if (m === i) break;
-        [a[i], a[m]] = [a[m], a[i]];
+        const t = a[i];
+        a[i] = a[m];
+        a[m] = t;
         i = m;
       }
     }
@@ -232,6 +240,11 @@ function goalDescs(model: Model, goalAtoms: Atom[]): GoalAtomDesc[] {
  * Numeric/external/negative conditions are treated optimistically: a "fuzzy"
  * atom (written non-atomically by some operator) can take any value at cost 1 and
  * is never called unreachable. Semantics match the original Map-based version.
+ *
+ * (A worklist variant — re-enqueue only the ops that read a decreased atom — was
+ * tried and is slower on these small, densely-connected relaxation graphs, where
+ * one shared atom like `agentAt` gates nearly every op; the dense round-based
+ * sweep wins until domains get large and sparse.)
  */
 function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDesc[], add: boolean): number {
   const n = model.relaxAtomCount;
@@ -307,13 +320,12 @@ function relaxCore(model: Model, s: Snap, cost: Float64Array, goals: GoalAtomDes
 }
 
 /**
- * Public delete-relaxation heuristic (SPEC §7.3). Builds goal descriptors and a
- * scratch buffer per call; the Engine uses a faster path that reuses both.
+ * Public delete-relaxation heuristic (SPEC §7.3). Allocates a scratch buffer per
+ * call; the Engine uses a faster path that reuses both buffer and goal descriptors.
  */
 export function hAdd(model: Model, s: Snap, goalAtoms: Atom[], mode: "add" | "max" = "add"): number {
   if (goalAtoms.length === 0) return 0;
-  const cost = new Float64Array(model.relaxAtomCount);
-  return relaxCore(model, s, cost, goalDescs(model, goalAtoms), mode === "add");
+  return relaxCore(model, s, new Float64Array(model.relaxAtomCount), goalDescs(model, goalAtoms), mode === "add");
 }
 
 // ---------------------------------------------------------------- engine
@@ -344,6 +356,8 @@ export class Engine {
   private readonly hCache = new Map<number, number>();
   /** reusable relaxation cost buffer (sized to model.relaxAtomCount) */
   private costBuf: Float64Array | null = null;
+  /** reusable candidate-op scratch for the indexed successor generator */
+  private readonly succScratch: GroundOp[] = [];
 
   constructor(model: Model, req: PlanRequest) {
     this.model = model;
@@ -678,7 +692,33 @@ export class Engine {
         return { state: node.state, steps, cost: node.g };
       }
 
-      for (const g of model.groundOps) {
+      // indexed successor generation: gather only ops whose most-selective
+      // precondition atom holds (plus the always-consider bucket), in gid order
+      // so the search is byte-identical to scanning every ground op.
+      const cand = this.succScratch;
+      cand.length = 0;
+      const always = model.succAlwaysOps;
+      for (let i = 0; i < always.length; i++) cand.push(always[i]);
+      const selSlots = model.succSelSlots;
+      const selTables = model.succSelTables;
+      for (let k = 0; k < selSlots.length; k++) {
+        const list = selTables[k].get(node.state.get(selSlots[k]));
+        if (list !== undefined) for (let i = 0; i < list.length; i++) cand.push(list[i]);
+      }
+      if (cand.length > 1) cand.sort(byGid); // restore gid order ⇒ identical search
+
+      for (let ci = 0; ci < cand.length; ci++) {
+        const g = cand[ci];
+        // fast reject on the cheap atom preconditions before the full closure
+        const pre = g.preAtoms;
+        let preOk = true;
+        for (let i = 0; i < pre.length; i++) {
+          if (node.state.get(pre[i].slot) !== pre[i].value) {
+            preOk = false;
+            break;
+          }
+        }
+        if (!preOk) continue;
         if (g.op.pre && !g.op.pre.fn(node.state, g.b)) continue;
         const child = node.state.child();
         g.op.effects.apply(child, g.b, TIMINGS_PLANNING);

--- a/src/state.ts
+++ b/src/state.ts
@@ -116,17 +116,21 @@ export class StateView implements Snap {
 
   materialize(): Float64Array {
     const flat = this.base.slice();
-    const chain: StateView[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let v: StateView | null = this;
-    while (v !== null) {
-      chain.push(v);
-      v = v.parent;
-    }
-    for (let i = chain.length - 1; i >= 0; i--) {
-      for (const [slot, value] of chain[i].deltas) flat[slot] = value;
-    }
+    this.replayInto(flat);
     return flat;
+  }
+
+  /** Flatten this view into an existing buffer (no allocation). The buffer must
+   *  be at least `base.length` long; used to give hot readers O(1) slot access. */
+  materializeInto(buf: Float64Array): void {
+    buf.set(this.base);
+    this.replayInto(buf);
+  }
+
+  /** Replay the root→this delta chain onto a buffer already holding `base`. */
+  private replayInto(buf: Float64Array): void {
+    if (this.parent !== null) this.parent.replayInto(buf);
+    for (const [slot, value] of this.deltas) buf[slot] = value;
   }
 
   get clock(): number {

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,7 +46,17 @@ export function hashBase(base: Float64Array): number {
 
 // ---------------------------------------------------------------- copy-on-write views
 
-const MAX_CHAIN_DEPTH = 24;
+/**
+ * Adaptive copy-on-write collapse threshold. `get()` walks the delta chain via
+ * Map lookups (tens of ns each); `materialize()` is a flat typed-array copy
+ * (~0.5 ns/element). So collapsing the chain shallowly keeps reads near-O(1) and
+ * wins for small states, while large states tolerate deeper chains because the
+ * full copy would dominate. ≈ slotCount/32, clamped to [2, 32].
+ */
+function collapseDepth(slotCount: number): number {
+  const d = slotCount >> 5;
+  return d < 2 ? 2 : d > 32 ? 32 : d;
+}
 
 /**
  * Immutable-after-build copy-on-write state. Create children with `child()`,
@@ -57,6 +67,7 @@ export class StateView implements Snap {
   private readonly parent: StateView | null;
   private readonly deltas: Map<number, number>;
   private readonly depth: number;
+  private readonly maxDepth: number;
   /** xor-composed hash over all (slot,value≠0) pairs */
   public hash: number;
 
@@ -65,6 +76,7 @@ export class StateView implements Snap {
     this.parent = parent;
     this.deltas = new Map();
     this.depth = depth;
+    this.maxDepth = collapseDepth(base.length);
     this.hash = hash;
   }
 
@@ -74,7 +86,7 @@ export class StateView implements Snap {
 
   /** Create a writable child view. */
   child(): StateView {
-    if (this.depth >= MAX_CHAIN_DEPTH) {
+    if (this.depth >= this.maxDepth) {
       // collapse the chain into a fresh base copy
       const flat = this.materialize();
       return new StateView(flat, null, this.hash, 1);

--- a/tests/blocks.ts
+++ b/tests/blocks.ts
@@ -1,0 +1,154 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { F, Planner, Scheduler, createModel, goal, planOnce, type Plan, type TraceEvent } from "../src/index";
+import { blocksDomain, blocksModel, sussmanSetup, towerSetup } from "../scenarios/blocks";
+
+/**
+ * Tier A "Blocks World+" battle-tests (PLAN-web-demo-and-block-stacking.md §2):
+ * the 4-operator STRIPS blocks world, scaled up and — crucially — driven
+ * through the reactive Planner with executors so plan repair and multi-effector
+ * coordination get exercised. Complements the symbolic 3-op test in puzzles.ts.
+ */
+
+const opNames = (plan: Plan | null | undefined): string[] =>
+  (plan?.steps ?? []).flatMap((s) => (s.k === "op" ? [s.g.op.name] : []));
+
+const runToTerminal = (planner: Planner, step: () => void, budgetMs = 5, maxTicks = 300): void => {
+  for (let i = 0; i < maxTicks; i++) {
+    const st = planner.getStatus();
+    if (st === "succeeded" || st === "failed") return;
+    step();
+    planner.tick({ ms: budgetMs });
+  }
+};
+
+// ---------------------------------------------------------------- Sussman anomaly
+
+test("sussman anomaly: optimal 6-action plan (forces subgoal interleaving)", () => {
+  const model = blocksModel(sussmanSetup());
+  const result = planOnce(model, model.createExecState(), {
+    goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")))],
+    weight: 1,
+    heuristic: "hmax", // admissible → guaranteed-optimal length
+  });
+  assert.equal(result.status, "success");
+  const ops = opNames(result.plan);
+  assert.equal(ops.length, 6, `ground truth: 6 actions, got ${ops.length}: ${ops.join(", ")}`);
+  // the anomaly: C must come off A (unstack) before the A/B/C tower can form
+  assert.is(ops[0], "unstack", `must clear C first, got first op '${ops[0]}'`);
+});
+
+// ---------------------------------------------------------------- scaling: reverse a tower
+
+test("reverse a 4-block tower: optimal length, search stays bounded", () => {
+  // start a-b-c-d (a on top, d on table); goal d-c-b-a (d on top, a on table)
+  const names = ["a", "b", "c", "d"];
+  const model = blocksModel(towerSetup(names));
+  const result = planOnce(model, model.createExecState(), {
+    goals: [goal(F.and(F.lit("on", ["d"], "c"), F.lit("on", ["c"], "b"), F.lit("on", ["b"], "a")))],
+    weight: 1,
+    heuristic: "hmax",
+  });
+  assert.equal(result.status, "success");
+  const ops = opNames(result.plan);
+  // Optimal is 8, not 12: only `a` needs the table (unstack+putdown); every
+  // other block is unstacked and restacked directly onto the growing tower,
+  // skipping redundant put-downs — a non-obvious optimum hmax+A* finds.
+  assert.equal(ops.length, 8, `expected 8-action reversal, got ${ops.length}: ${ops.join(", ")}`);
+});
+
+// ---------------------------------------------------------------- reactive execution + plan repair
+
+test("reactive build with a slipping block: planner repairs and still finishes", () => {
+  // `stack` runs a real executor that drops the block the first time it fires.
+  let slipsLeft = 1;
+  const slipStack = (): "success" | "failure" => {
+    if (slipsLeft > 0) {
+      slipsLeft--;
+      return "failure"; // the block slips out of the gripper once
+    }
+    return "success";
+  };
+  const domain = {
+    ...blocksDomain,
+    operators: (blocksDomain.operators ?? []).map((op) =>
+      op.name === "stack" ? { ...op, executor: "stack" } : op,
+    ),
+  };
+  const model = createModel(
+    domain,
+    { entities: { a: "block", b: "block", c: "block", arm: "hand" } },
+    { executors: { stack: slipStack } },
+  );
+
+  const events: TraceEvent[] = [];
+  let t = 0;
+  const planner = new Planner(model, {
+    goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")))],
+    now: () => t,
+    seed: 7,
+    trace: (e) => events.push(e),
+  });
+
+  runToTerminal(planner, () => {
+    t += 1;
+  });
+
+  assert.equal(planner.getStatus(), "succeeded", "planner must recover from the slip and finish");
+  assert.equal(slipsLeft, 0, "the slip executor must have fired exactly once");
+  assert.ok(events.some((e) => e.t === "step.fail"), "a step must have failed (the slip)");
+  const recovered =
+    events.some((e) => e.t === "repair.attempt" || e.t === "repair.success") ||
+    events.filter((e) => e.t === "plan.new").length >= 2;
+  assert.ok(recovered, "planner must repair or replan after the slip");
+  // model.read decodes entity fluents back to entity names
+  assert.equal(model.read(planner.state, "on", "a"), "b");
+  assert.equal(model.read(planner.state, "on", "b"), "c");
+});
+
+// ---------------------------------------------------------------- multi-effector (two arms)
+
+test("two-arm coordination: builds two towers using a 2-hand domain", () => {
+  // four blocks on the table, two hands; goal a-on-b and c-on-d.
+  const model = blocksModel({ blocks: ["a", "b", "c", "d"], hands: ["left", "right"] });
+  const result = planOnce(model, model.createExecState(), {
+    goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["c"], "d")))],
+    weight: 1,
+    heuristic: "hmax",
+  });
+  assert.equal(result.status, "success");
+  const ops = opNames(result.plan);
+  // optimal: pickup+stack for each of the two towers = 4 actions; the extra
+  // hand must not break optimality (it just widens the grounding).
+  assert.equal(ops.length, 4, `expected 4 actions, got ${ops.length}: ${ops.join(", ")}`);
+  assert.ok(ops.every((n) => n === "pickup" || n === "stack"), `unexpected op in ${ops.join(", ")}`);
+});
+
+// ---------------------------------------------------------------- Scheduler under real planning load
+
+test("scheduler drives two independent block-stackers to completion", () => {
+  let t = 0;
+  const now = () => t;
+  const mk = (): Planner => {
+    const model = blocksModel({ blocks: ["a", "b", "c"] });
+    return new Planner(model, {
+      goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")))],
+      now,
+      seed: 1,
+    });
+  };
+  const p1 = mk();
+  const p2 = mk();
+  const scheduler = new Scheduler();
+  scheduler.add(p1);
+  scheduler.add(p2);
+
+  for (let i = 0; i < 300 && !(p1.getStatus() === "succeeded" && p2.getStatus() === "succeeded"); i++) {
+    t += 1;
+    scheduler.tick(4);
+  }
+  assert.equal(p1.getStatus(), "succeeded");
+  assert.equal(p2.getStatus(), "succeeded");
+});
+
+test.run();

--- a/tests/hints.ts
+++ b/tests/hints.ts
@@ -1,0 +1,88 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { DomainDoc, E, F, type ExtQuery, createModel, goal, planOnce } from "../src/index";
+
+/**
+ * Symbolic relaxation hints (`relax` over-approximations on external/opaque
+ * predicates). A predicate the heuristic can't see through (opaque) or chooses
+ * to (external) is normally invisible to the delete-relaxation — so h can't
+ * account for what it gates. Attaching a *sound necessary condition* lets the
+ * relaxation fold those atoms in, making h informative again, while the real
+ * applicability check still runs unchanged.
+ */
+
+// K independent subgoals: finish(x) needs prepared(x), but that requirement is
+// behind an opaque/external `ready` predicate. `fiddle` is an always-applicable
+// decoy that looks like progress to a blind heuristic.
+function prepDomain(predicate: "opaque" | "external", withHint: boolean): DomainDoc {
+  const hint = F.lit("prepared", ["?x"]);
+  const ready =
+    predicate === "opaque"
+      ? F.opaque("ready", withHint ? hint : undefined)
+      : // reads are the *contract* (ready reads prepared) — independent of the
+        // optional `relax` hint, which only feeds the heuristic
+        F.ext("ready", ["?x"], ["prepared"], withHint ? hint : undefined);
+  return {
+    name: "prep",
+    types: [{ name: "item" }],
+    fluents: [
+      { name: "prepared", params: [{ name: "x", type: "item" }], kind: "boolean", initial: false },
+      { name: "done", params: [{ name: "x", type: "item" }], kind: "boolean", initial: false },
+      { name: "noise", params: [{ name: "x", type: "item" }], kind: "int", initial: 0 },
+    ],
+    operators: [
+      { name: "prepare", params: [{ name: "x", type: "item" }], pre: F.not(F.lit("prepared", ["?x"])), eff: [E.set("prepared", ["?x"], true)] },
+      { name: "finish", params: [{ name: "x", type: "item" }], pre: F.and(F.not(F.lit("done", ["?x"])), ready), eff: [E.set("done", ["?x"], true)] },
+      { name: "fiddle", params: [{ name: "x", type: "item" }], eff: [E.inc("noise", ["?x"], 1)] }, // decoy
+    ],
+    methods: [],
+  };
+}
+
+function solve(predicate: "opaque" | "external", withHint: boolean, k: number) {
+  const ents = Object.fromEntries(Array.from({ length: k }, (_, i) => [`i${i}`, "item"]));
+  const reg = { predicates: { ready: (q: ExtQuery) => q.get("prepared", q.args[0]) === 1 } };
+  const model = createModel(prepDomain(predicate, withHint), { entities: ents }, reg);
+  const goalF = F.and(...Array.from({ length: k }, (_, i) => F.lit("done", [`i${i}`])));
+  return planOnce(model, model.createExecState(), { goals: [goal(goalF)], weight: 1, heuristic: "hadd" });
+}
+
+test("relax hint: an over-approximation makes an opaque-gated heuristic informative", () => {
+  const k = 5;
+  const no = solve("opaque", false, k);
+  const yes = solve("opaque", true, k);
+
+  assert.equal(no.status, "success");
+  assert.equal(yes.status, "success");
+  // identical optimal plan length — the hint only informs h, not the result
+  assert.equal(yes.plan!.steps.length, 2 * k, "prepare+finish per item");
+  assert.equal(no.plan!.steps.length, yes.plan!.steps.length, "same optimal length with or without the hint");
+  // the heuristic is no longer blind to the opaque gate ⇒ far less search
+  assert.ok(no.stats.expansions > 500, `blind search should flail (got ${no.stats.expansions})`);
+  assert.ok(yes.stats.expansions < 100, `hinted search should be tight (got ${yes.stats.expansions})`);
+  assert.ok(yes.stats.expansions * 10 < no.stats.expansions, "hint cuts expansions by >10x");
+});
+
+test("relax hint: works on external predicates too (declared reads + relax)", () => {
+  const k = 5;
+  const no = solve("external", false, k);
+  const yes = solve("external", true, k);
+  assert.equal(yes.status, "success");
+  assert.equal(yes.plan!.steps.length, no.plan!.steps.length);
+  assert.ok(yes.stats.expansions * 10 < no.stats.expansions, `external hint should cut search (got ${yes.stats.expansions} vs ${no.stats.expansions})`);
+});
+
+test("relax hint: stays admissible — hmax + weight 1 still optimal", () => {
+  // a sound necessary condition only raises h toward the true cost, so an
+  // admissible search keeps finding the optimum (just faster).
+  const k = 4;
+  const ents = Object.fromEntries(Array.from({ length: k }, (_, i) => [`i${i}`, "item"]));
+  const reg = { predicates: { ready: (q: ExtQuery) => q.get("prepared", q.args[0]) === 1 } };
+  const model = createModel(prepDomain("opaque", true), { entities: ents }, reg);
+  const goalF = F.and(...Array.from({ length: k }, (_, i) => F.lit("done", [`i${i}`])));
+  const r = planOnce(model, model.createExecState(), { goals: [goal(goalF)], weight: 1, heuristic: "hmax" });
+  assert.equal(r.status, "success");
+  assert.equal(r.plan!.steps.length, 2 * k, "still the optimal prepare+finish-per-item plan");
+});
+
+test.run();

--- a/tests/puzzles.ts
+++ b/tests/puzzles.ts
@@ -213,6 +213,7 @@ test("sokoban corridor: walk + two pushes (relational adjacency, optimal 3 ops)"
           { name: "b", type: "cell" },
         ],
         kind: "boolean",
+        static: true,
       },
       {
         name: "aligned",
@@ -222,6 +223,7 @@ test("sokoban corridor: walk + two pushes (relational adjacency, optimal 3 ops)"
           { name: "c", type: "cell" },
         ],
         kind: "boolean",
+        static: true,
       },
     ],
     operators: [

--- a/tests/spatial.ts
+++ b/tests/spatial.ts
@@ -1,0 +1,124 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { F, Planner, goal, planOnce, simulatePlan, type Model, type Plan, type Snap, type TraceEvent } from "../src/index";
+import {
+  GOAL_HEIGHT,
+  ledgeGoal,
+  ledgeInstance,
+  staircaseGoal,
+  staircaseInstance,
+  staircaseModel,
+} from "../scenarios/staircase";
+
+/**
+ * Tier B "Staircase World" battle-tests (PLAN-web-demo-and-block-stacking.md §2):
+ * the first scenarios where htn-ai's SPATIAL features drive the plan — int
+ * column heights gate both climbing and placing (so the build order is
+ * discovered, not scripted), and N.dist over vec2 positions is the movement
+ * cost. Closes the "vec/dist never drive a plan" gap.
+ */
+
+const opNames = (plan: Plan | null | undefined): string[] =>
+  (plan?.steps ?? []).flatMap((s) => (s.k === "op" ? [s.g.op.name] : []));
+
+const endOf = (model: Model, start: Snap, plan: Plan): Snap => simulatePlan(model, start, plan).end;
+
+// ---------------------------------------------------------------- climb the ledge (GOAP)
+
+test("ledge: must build a support to climb a 2-high wall (geometry gates the plan)", () => {
+  const model = staircaseModel(ledgeInstance(1));
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(ledgeGoal())], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  const ops = opNames(result.plan);
+  // pick a block, place it on `mid` (height 0→1), then climb ground→mid→ledge
+  assert.ok(ops.includes("pick"), `expected a pick, got ${ops.join(", ")}`);
+  assert.ok(ops.includes("place"), `expected a place, got ${ops.join(", ")}`);
+  assert.equal(model.read(endOf(model, start, result.plan!), "agentAt"), "ledge");
+  // a `place` must precede the final climb onto the ledge
+  assert.ok(ops.lastIndexOf("place") < ops.lastIndexOf("goto"), "must build before the final climb");
+});
+
+test("ledge: with no supply, the 2-high wall is provably unreachable", () => {
+  const model = staircaseModel(ledgeInstance(0)); // empty depot
+  const result = planOnce(model, model.createExecState(), {
+    goals: [goal(ledgeGoal())],
+    weight: 1,
+    heuristic: "hmax",
+    maxNodes: 50_000,
+  });
+  assert.equal(result.status, "failure", "no blocks to build with ⇒ can't climb 2 levels");
+});
+
+// ---------------------------------------------------------------- build the staircase (GOAP)
+
+test("staircase: builds the steps from supply and climbs onto the goal", () => {
+  const model = staircaseModel(staircaseInstance());
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(staircaseGoal())], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  const ops = opNames(result.plan);
+  assert.ok(ops.length >= 6, `a real build+climb should take several actions, got ${ops.length}`);
+  const end = endOf(model, start, result.plan!);
+  // goal is position-only (agentAt=goal ∧ agentY=2); the planner DISCOVERED it
+  // must raise the goal column to 2 and build s1 as a support — assert those as
+  // emergent consequences, not as things the goal prescribed.
+  assert.equal(model.read(end, "agentAt"), "goal");
+  assert.equal(model.read(end, "agentY"), GOAL_HEIGHT);
+  assert.ok((model.read(end, "height", "goal") as number) >= GOAL_HEIGHT, "discovered: built the goal column up");
+  assert.ok((model.read(end, "height", "s1") as number) >= 1, "discovered: built s1 as a support to stand on");
+});
+
+// ---------------------------------------------------------------- through the reactive Planner
+
+test("staircase: solved through the reactive Planner (tick loop)", () => {
+  const model = staircaseModel(staircaseInstance());
+  const events: TraceEvent[] = [];
+  let t = 0;
+  const planner = new Planner(model, {
+    goals: [goal(staircaseGoal())],
+    now: () => t,
+    seed: 3,
+    trace: (e) => events.push(e),
+  });
+  for (let i = 0; i < 500 && planner.getStatus() !== "succeeded" && planner.getStatus() !== "failed"; i++) {
+    t += 1;
+    planner.tick({ ms: 5 });
+  }
+  assert.equal(planner.getStatus(), "succeeded");
+  assert.equal(model.read(planner.state, "agentAt"), "goal");
+  assert.ok((model.read(planner.state, "height", "goal") as number) >= GOAL_HEIGHT);
+  assert.ok(events.some((e) => e.t === "plan.new"), "should have produced a plan");
+});
+
+// ---------------------------------------------------------------- geometry drives a choice
+
+test("nearer supply is preferred: N.dist cost steers the plan", () => {
+  // two depots that can each supply the single block needed to climb the ledge;
+  // `near` is one step away, `far` is several — the cheaper plan mines `near`.
+  const model = staircaseModel({
+    cells: [
+      { name: "ground", x: 0, z: 0 },
+      { name: "near", x: 1, z: 0, supply: 1 },
+      { name: "mid", x: 0, z: 1 },
+      { name: "ledge", x: 0, z: 2, height: 2 },
+      { name: "far", x: 0, z: 5, supply: 1 },
+    ],
+    edges: [
+      ["ground", "near"],
+      ["ground", "mid"],
+      ["mid", "ledge"],
+      ["mid", "far"],
+    ],
+    start: "ground",
+  });
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(F.lit("agentAt", [], "ledge"))], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  const end = endOf(model, start, result.plan!);
+  // the cheaper plan mines `near`, so `far` should be untouched (supply intact)
+  assert.equal(model.read(end, "supply", "far"), 1, "should not have walked to the far depot");
+  assert.equal(model.read(end, "supply", "near"), 0, "should have mined the near depot");
+});
+
+test.run();

--- a/tests/spatial.ts
+++ b/tests/spatial.ts
@@ -4,11 +4,14 @@ import { F, Planner, goal, planOnce, simulatePlan, type Model, type Plan, type S
 import {
   GOAL_HEIGHT,
   QUARRY_GOAL_HEIGHT,
+  SCAVENGER_BIG_GOAL_HEIGHT,
   SCAVENGER_GOAL_HEIGHT,
   ledgeGoal,
   ledgeInstance,
   quarryGoal,
   quarryInstance,
+  scavengerBigGoal,
+  scavengerBigInstance,
   scavengerGoal,
   scavengerInstance,
   scavengerModel,
@@ -219,6 +222,24 @@ test("scavenger: a 2-pillar's top block is unreachable from the ground", () => {
   });
   // no loose block to build a step with ⇒ the top block can never be reached
   assert.equal(result.status, "failure", "can't grab a 2-high top block from the ground with nothing to step on");
+});
+
+test("scavenger XL: taller height-3 goal, more blocks, harvests the pillar (greedy weight)", () => {
+  // bigger 4×3 grid, height-3 goal, 5 loose blocks + a 2-pillar. Uses the same
+  // fast settings the web demo runs (hadd, weight 5) — assert it solves, reaches
+  // the goal, and harvests the pillar (loose blocks alone are insufficient).
+  const model = scavengerModel(scavengerBigInstance());
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(scavengerBigGoal())], weight: 5, heuristic: "hadd", maxNodes: 500_000 });
+  assert.equal(result.status, "success");
+  const end = endOf(model, start, result.plan!);
+  assert.equal(model.read(end, "agentAt"), "goal");
+  assert.equal(model.read(end, "agentY"), SCAVENGER_BIG_GOAL_HEIGHT);
+  const towerGid = model.entityId("tower");
+  const harvested = (result.plan!.steps ?? []).some(
+    (s) => s.k === "op" && s.g.op.name === "grab" && s.g.b[s.g.b.length - 1] === towerGid,
+  );
+  assert.ok(harvested, "5 loose blocks can't supply a height-3 goal — the pillar must be harvested");
 });
 
 test("scavenger: solved through the reactive Planner", () => {

--- a/tests/spatial.ts
+++ b/tests/spatial.ts
@@ -13,6 +13,9 @@ import {
   scavengerBigGoal,
   scavengerBigInstance,
   scavengerGoal,
+  scavengerHugeGoal,
+  scavengerHugeGoalCell,
+  scavengerHugeInstance,
   scavengerInstance,
   scavengerModel,
   staircaseGoal,
@@ -254,5 +257,27 @@ test("scavenger: solved through the reactive Planner", () => {
   assert.equal(model.read(planner.state, "agentAt"), "goal");
   assert.equal(model.read(planner.state, "agentY"), SCAVENGER_GOAL_HEIGHT);
 });
+
+// HUGE stress benchmark — ~9s of compute, so it's opt-in (HTN_BENCH=1) to keep
+// the default suite/CI fast. Bounded by maxNodes so it can never run away.
+if (process.env.HTN_BENCH === "1") {
+  test("scavenger HUGE (benchmark): solves a 24-cell height-3 grid (~10× XL compute)", () => {
+    const model = scavengerModel(scavengerHugeInstance());
+    const start = model.createExecState();
+    const t0 = Date.now();
+    const result = planOnce(model, start, {
+      goals: [goal(scavengerHugeGoal())],
+      weight: 6,
+      heuristic: "hadd",
+      maxNodes: 200_000, // safety cap; the greedy search solves in ≈1.7k expansions
+    });
+    // eslint-disable-next-line no-console
+    console.log(`[HUGE] ${result.status} in ${Date.now() - t0}ms, ${result.stats.expansions} expansions`);
+    assert.equal(result.status, "success");
+    const end = endOf(model, start, result.plan!);
+    assert.equal(model.read(end, "agentAt"), scavengerHugeGoalCell);
+    assert.equal(model.read(end, "agentY"), 3);
+  });
+}
 
 test.run();

--- a/tests/spatial.ts
+++ b/tests/spatial.ts
@@ -3,8 +3,11 @@ import * as assert from "uvu/assert";
 import { F, Planner, goal, planOnce, simulatePlan, type Model, type Plan, type Snap, type TraceEvent } from "../src/index";
 import {
   GOAL_HEIGHT,
+  QUARRY_GOAL_HEIGHT,
   ledgeGoal,
   ledgeInstance,
+  quarryGoal,
+  quarryInstance,
   staircaseGoal,
   staircaseInstance,
   staircaseModel,
@@ -119,6 +122,54 @@ test("nearer supply is preferred: N.dist cost steers the plan", () => {
   // the cheaper plan mines `near`, so `far` should be untouched (supply intact)
   assert.equal(model.read(end, "supply", "far"), 1, "should not have walked to the far depot");
   assert.equal(model.read(end, "supply", "near"), 0, "should have mined the near depot");
+});
+
+// ---------------------------------------------------------------- quarry: the advanced grid world
+
+test("quarry: optimal collect/place/build/climb to a height-4 pillar (search stays tiny)", () => {
+  const model = staircaseModel(quarryInstance());
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  const end = endOf(model, start, result.plan!);
+  // reached the 3D position on top of the pillar
+  assert.equal(model.read(end, "agentAt"), "pillar");
+  assert.equal(model.read(end, "agentY"), QUARRY_GOAL_HEIGHT);
+  // discovered the 3-step staircase (heights 1,2,3) — emergent, not prescribed
+  assert.equal(model.read(end, "height", "step1"), 1);
+  assert.equal(model.read(end, "height", "step2"), 2);
+  assert.equal(model.read(end, "height", "step3"), 3);
+  // collected from BOTH scattered depots (6 blocks needed, 3+3 available)
+  assert.equal(model.read(end, "supply", "depotA"), 0);
+  assert.equal(model.read(end, "supply", "depotB"), 0);
+  // the buildable constraint + topology keep optimal search tractable
+  assert.ok(result.stats.expansions < 50_000, `search should stay small, got ${result.stats.expansions} expansions`);
+});
+
+test("quarry: never enters the impassable wall pillar", () => {
+  const model = staircaseModel(quarryInstance());
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(quarryGoal())], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  // no goto step may target the wall (height 6 ≫ the +1 climb limit)
+  const wallGid = model.entityId("wall");
+  const enteredWall = (result.plan!.steps ?? []).some(
+    (s) => s.k === "op" && s.g.op.name === "goto" && s.g.b[s.g.b.length - 1] === wallGid,
+  );
+  assert.not(enteredWall, "the agent must route around the wall, never into it");
+});
+
+test("quarry: solved through the reactive Planner", () => {
+  const model = staircaseModel(quarryInstance());
+  let t = 0;
+  const planner = new Planner(model, { goals: [goal(quarryGoal())], now: () => t, seed: 5 });
+  for (let i = 0; i < 4000 && planner.getStatus() !== "succeeded" && planner.getStatus() !== "failed"; i++) {
+    t += 1;
+    planner.tick({ ms: 20 });
+  }
+  assert.equal(planner.getStatus(), "succeeded");
+  assert.equal(model.read(planner.state, "agentAt"), "pillar");
+  assert.equal(model.read(planner.state, "agentY"), QUARRY_GOAL_HEIGHT);
 });
 
 test.run();

--- a/tests/spatial.ts
+++ b/tests/spatial.ts
@@ -4,10 +4,14 @@ import { F, Planner, goal, planOnce, simulatePlan, type Model, type Plan, type S
 import {
   GOAL_HEIGHT,
   QUARRY_GOAL_HEIGHT,
+  SCAVENGER_GOAL_HEIGHT,
   ledgeGoal,
   ledgeInstance,
   quarryGoal,
   quarryInstance,
+  scavengerGoal,
+  scavengerInstance,
+  scavengerModel,
   staircaseGoal,
   staircaseInstance,
   staircaseModel,
@@ -170,6 +174,64 @@ test("quarry: solved through the reactive Planner", () => {
   assert.equal(planner.getStatus(), "succeeded");
   assert.equal(model.read(planner.state, "agentAt"), "pillar");
   assert.equal(model.read(planner.state, "agentY"), QUARRY_GOAL_HEIGHT);
+});
+
+// ---------------------------------------------------------------- scavenger: collect scattered blocks, top-first
+
+test("scavenger: must build a step to harvest a 2-pillar's top block, then reach the goal", () => {
+  const model = scavengerModel(scavengerInstance());
+  const start = model.createExecState();
+  const result = planOnce(model, start, { goals: [goal(scavengerGoal())], weight: 1, heuristic: "hmax" });
+  assert.equal(result.status, "success");
+  const end = endOf(model, start, result.plan!);
+  // reached the 3D position atop the goal
+  assert.equal(model.read(end, "agentAt"), "goal");
+  assert.equal(model.read(end, "agentY"), SCAVENGER_GOAL_HEIGHT);
+  // only 2 loose blocks exist but 3 are needed, so the 2-pillar MUST be harvested
+  assert.ok((model.read(end, "height", "tower") as number) < 2, "the 2-pillar's top block must be taken");
+
+  // the mechanic: a block had to be PLACED (a step) before the tower's top could be grabbed
+  const towerGid = model.entityId("tower");
+  const ops = (result.plan!.steps ?? []).flatMap((s) => (s.k === "op" ? [{ name: s.g.op.name, at: s.g.b[s.g.b.length - 1] }] : []));
+  const firstPlace = ops.findIndex((o) => o.name === "place");
+  const firstGrabTower = ops.findIndex((o) => o.name === "grab" && o.at === towerGid);
+  assert.ok(firstGrabTower >= 0, "must grab from the tower");
+  assert.ok(firstPlace >= 0 && firstPlace < firstGrabTower, "must build a step before grabbing the tower's top block");
+});
+
+test("scavenger: a 2-pillar's top block is unreachable from the ground", () => {
+  // standing on flat ground (level 0), grabbing the top of a height-2 column is
+  // blocked by the reach rule (0 ≥ 2−1 is false) — proven by making it the only
+  // option: no loose blocks, goal is simply to be holding a block.
+  const model = scavengerModel({
+    cells: [
+      { name: "g", x: 0, z: 0 },
+      { name: "tower", x: 1, z: 0, height: 2 },
+    ],
+    edges: [["g", "tower"]],
+    start: "g",
+  });
+  const result = planOnce(model, model.createExecState(), {
+    goals: [goal(F.lit("holding"))],
+    weight: 1,
+    heuristic: "hmax",
+    maxNodes: 50_000,
+  });
+  // no loose block to build a step with ⇒ the top block can never be reached
+  assert.equal(result.status, "failure", "can't grab a 2-high top block from the ground with nothing to step on");
+});
+
+test("scavenger: solved through the reactive Planner", () => {
+  const model = scavengerModel(scavengerInstance());
+  let t = 0;
+  const planner = new Planner(model, { goals: [goal(scavengerGoal())], now: () => t, seed: 9 });
+  for (let i = 0; i < 2000 && planner.getStatus() !== "succeeded" && planner.getStatus() !== "failed"; i++) {
+    t += 1;
+    planner.tick({ ms: 20 });
+  }
+  assert.equal(planner.getStatus(), "succeeded");
+  assert.equal(model.read(planner.state, "agentAt"), "goal");
+  assert.equal(model.read(planner.state, "agentY"), SCAVENGER_GOAL_HEIGHT);
 });
 
 test.run();

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -6,6 +6,6 @@
     "esModuleInterop": true,
     "rootDir": "."
   },
-  "include": ["tests/**/*.ts", "src/**/*.ts", "tsup.config.ts"],
+  "include": ["tests/**/*.ts", "src/**/*.ts", "scenarios/**/*.ts", "tsup.config.ts"],
   "exclude": []
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "cd examples/web && npm install",
+  "buildCommand": "cd examples/web && npm run build",
+  "outputDirectory": "examples/web/out",
+  "cleanUrls": true
+}


### PR DESCRIPTION
Synthesizes analysis of vibe-city (main + feat/htn-block-stacking) against
htn-ai v2's capabilities and coverage gaps. Proposes:
- Tier A "Blocks World+" symbolic battle-tests (Sussman, scale, reactive
  repair, two-arm multi-agent) and Tier B spatial "Staircase World" where
  build order/reachability are discovered by search.
- A Vite + react-three-fiber web preview under examples/web/ driven by the
  TraceEvent stream (live decomposition graph, world-state diff, plan
  timeline, time-travel scrubber), keeping the core zero-dependency.

Maps both to existing ROADMAP M-2 (demo) and M5 (devtools inspector).