### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a TypeScript library (`htn-ai`, an HTN + GOAP planning/execution runtime) plus a standalone Next.js + Three.js web demo under `examples/web`. There are no databases, Docker, or external services.
+
+### Services / how to run
+
+- **Core library** (`/workspace`): not a long-running service. Develop via the npm scripts in `package.json` — `npm run lint`, `npm run typecheck`, `npm test` (uvu suite), `npm run build` (tsup → `dist/`). Optional benchmarks: `npm run bench`.
+- **Web demo** (`/workspace/examples/web`): the only runnable server. Run `npm run dev` (Next.js on http://localhost:3000). It imports the library directly from `../../src` via a webpack alias, so you do **not** need to `npm run build` the library first; source edits hot-reload in the demo.
+
+### Non-obvious notes
+
+- Dependencies live in **two** separate npm trees: repo root and `examples/web` (independent lockfiles). The update script installs both.
+- `next build` ignores ESLint/TS errors (`next.config.mjs`); use the root `npm run typecheck`/`npm run lint` for real type/lint signal on the library.
+- Known pre-existing bug in the demo: selecting some non-default scenarios (e.g. "Blocks World (Sussman)") in the SCENARIO dropdown throws `TypeError: Cannot read properties of undefined (reading 'heavyMs')` from `examples/web/lib/run.ts`. The default "Staircase" scenario works fine. This is unrelated to environment setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,5 @@ This repo is a TypeScript library (`htn-ai`, an HTN + GOAP planning/execution ru
 ### Non-obvious notes
 
 - Dependencies live in **two** separate npm trees: repo root and `examples/web` (independent lockfiles). The update script installs both.
-- `next build` ignores ESLint/TS errors (`next.config.mjs`); use the root `npm run typecheck`/`npm run lint` for real type/lint signal on the library.
-- Known pre-existing bug in the demo: selecting some non-default scenarios (e.g. "Blocks World (Sussman)") in the SCENARIO dropdown throws `TypeError: Cannot read properties of undefined (reading 'heavyMs')` from `examples/web/lib/run.ts`. The default "Staircase" scenario works fine. This is unrelated to environment setup.
+- `next build` ignores ESLint/TS errors (`next.config.mjs`); use the root `npm run typecheck`/`npm run lint` for real type/lint signal on the library. The web demo (`examples/web`) has its own narrower per-file types — note that `lib/run.ts` `ScenarioId` does not include `"blocks"` (that path lives in `lib/runBlocks.ts`), so any helper consuming a page-level scenario id (which does include `"blocks"`) must guard for ids outside its own `SCENARIOS` map.
+- All 7 demo scenarios (Staircase, Climb the ledge, Quarry, Scavenger, Scavenger XL, Scavenger HUGE, Blocks World) run to "succeeded". "Scavenger HUGE" is a deliberate stress test and takes ~9s to plan before it animates.

--- a/examples/web/lib/run.ts
+++ b/examples/web/lib/run.ts
@@ -88,8 +88,8 @@ const SCENARIOS: Record<ScenarioId, ScenarioCfg> = {
 };
 
 /** Rough heads-up (ms) for scenarios whose planning is slow enough to warn about. */
-export function scenarioHeavyMs(id: ScenarioId): number {
-  return SCENARIOS[id].heavyMs ?? 0;
+export function scenarioHeavyMs(id: string): number {
+  return SCENARIOS[id as ScenarioId]?.heavyMs ?? 0;
 }
 
 export function runScenario(id: ScenarioId): RunResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `htn-ai` library and its Next.js + Three.js web demo, and verifies every demo scenario runs locally.

- Adds `AGENTS.md` with durable Cursor Cloud dev instructions.
- Fixes a pre-existing crash in the web demo: `scenarioHeavyMs()` in `examples/web/lib/run.ts` indexed its `SCENARIOS` map unconditionally, but the page exposes a `"blocks"` scenario (run via `lib/runBlocks.ts`) that isn't in that map — selecting "Blocks World (Sussman)" threw `TypeError: Cannot read properties of undefined (reading 'heavyMs')`. Guarded with optional chaining.

Dependency installation is handled by the configured startup update script (`npm install` at root and in `examples/web`).

## What was verified

**Core library** (`/workspace`):
- `npm run lint` — passes
- `npm run typecheck` — passes
- `npm test` — 84/84 uvu tests pass
- `npm run build` — tsup build succeeds

**Web demo** (`examples/web`):
- `npm run dev` — Next.js dev server on http://localhost:3000
- `npm run build` — static export succeeds
- Verified all **7 scenarios** run to `succeeded` in the browser with live 3D visualization: Staircase, Climb the ledge, Quarry, Scavenger, Scavenger XL, Scavenger HUGE (~9s plan), and Blocks World (Sussman).

## Walkthrough

<a href="https://cursor.com/agents/bc-de1802fd-a108-4be0-b9ac-33dd8192def0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhtn_ai_all_7_scenarios_demo.mp4"><img src="https://cursor.com/artifacts/c/art-dc5e7a72-6962-4f27-a215-3c2983e7ac1a" alt="htn_ai_all_7_scenarios_demo.mp4" /></a>

All 7 planner scenarios cycled through, each reaching `succeeded` (including Blocks World, previously crashing).

![Staircase](https://cursor.com/artifacts/c/art-85dbc414-e76a-44e0-9ebc-8f53d9aa5bf8)
![Climb the ledge](https://cursor.com/artifacts/c/art-c28e506d-cc8a-4bb4-8b62-fab8c1c384a3)
![Quarry](https://cursor.com/artifacts/c/art-cabdf6e2-bae7-4b2f-b1a1-ec00b2cef615)
![Scavenger](https://cursor.com/artifacts/c/art-28e37c80-4710-42b4-bf28-3f9dc685e0d6)
![Scavenger XL](https://cursor.com/artifacts/c/art-1dcd027e-65c3-4d31-9f08-ebe07e829a72)
![Scavenger HUGE](https://cursor.com/artifacts/c/art-3ee02c14-6aa2-4ac6-b3be-407e81d17d39)
![Blocks World (Sussman)](https://cursor.com/artifacts/c/art-10b6ae82-c584-485e-bff5-19419810aee1)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de1802fd-a108-4be0-b9ac-33dd8192def0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de1802fd-a108-4be0-b9ac-33dd8192def0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

