### PR TITLE
Richer combat visuals + "what it's thinking" tactical overlay

### DIFF
--- a/examples/web/app/globals.css
+++ b/examples/web/app/globals.css
@@ -350,6 +350,17 @@ input[type="range"] {
 .hud-legend span { display: flex; align-items: center; gap: 5px; }
 .hud-legend .dot { width: 9px; height: 9px; border-radius: 999px; display: inline-block; }
 .hud-legend .dash { width: 12px; height: 0; border-top: 2px dashed; display: inline-block; }
+.hud-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 3px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+  color: var(--accent);
+  cursor: pointer;
+}
+.hud-toggle input { accent-color: var(--accent); cursor: pointer; }
 
 .hud-narration {
   position: absolute;
@@ -415,4 +426,26 @@ input[type="range"] {
   letter-spacing: 0.8px;
   color: var(--text);
   font-weight: 700;
+}
+
+.risk-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+  font-size: 11px;
+}
+.risk-tag {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+.risk-tag.good {
+  color: var(--good);
+  border-color: rgba(52, 211, 153, 0.4);
 }

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -66,6 +66,7 @@ export default function Page() {
   const [speed, setSpeed] = useState(450);
   const [liveStepMs, setLiveStepMs] = useState(90);
   const [selected, setSelected] = useState<string | null>(null);
+  const [showThinking, setShowThinking] = useState(true);
 
   const isLive = scenario === "companion";
   const live = useLiveSquad(isLive ? "companion" : null, liveStepMs);
@@ -128,7 +129,7 @@ export default function Page() {
 
         {run?.kind === "grid" && <StaircaseScene key="grid" frame={run.data.frames[step]} instance={run.data.instance} target={run.data.target} reached={step === lastStep && status === "succeeded"} />}
         {run?.kind === "blocks" && <BlocksScene key="blocks" frame={run.data.frames[step]} blocks={run.data.blocks} reached={step === lastStep} />}
-        {squad && <SquadScene key="squad" frame={squad.frame} instance={squad.instance} selected={selected} onSelect={(n) => setSelected(n || null)} />}
+        {squad && <SquadScene key="squad" frame={squad.frame} instance={squad.instance} selected={selected} onSelect={(n) => setSelected(n || null)} showThinking={showThinking} />}
 
         {squad && (
           <div className="hud-top">
@@ -147,7 +148,18 @@ export default function Page() {
             <span><i className="dot" style={{ background: "#ef4444" }} />Red team</span>
             <span><i className="dot" style={{ background: "#3b82f6" }} />Blue team</span>
             <span><i className="dash" style={{ background: "#34d399" }} />line of fire</span>
-            <span><i className="dash" style={{ background: "#ef4444" }} />blocked</span>
+            <span><i className="dash" style={{ background: "#ef4444" }} />blocked / incoming</span>
+            <label className="hud-toggle">
+              <input type="checkbox" checked={showThinking} onChange={(e) => setShowThinking(e.target.checked)} />
+              show what it&apos;s thinking
+            </label>
+            {showThinking && (
+              <>
+                <span><i className="dot" style={{ background: "#22c55e" }} />good position</span>
+                <span><i className="dot" style={{ background: "#ef4444" }} />risky position</span>
+                <span><i className="dot" style={{ background: "#7dd3fc" }} />has cover</span>
+              </>
+            )}
           </div>
         )}
         {narration && <div className="hud-narration">{narration}</div>}
@@ -230,7 +242,7 @@ export default function Page() {
           </div>
         )}
 
-        {squad && <SquadDirector frame={squad.frame} units={squad.units} selected={selected} onSelect={(n) => setSelected(n || null)} />}
+        {squad && <SquadDirector frame={squad.frame} instance={squad.instance} units={squad.units} selected={selected} onSelect={(n) => setSelected(n || null)} />}
 
         {run?.kind === "grid" && (
           <div className="card">

--- a/examples/web/components/SquadDirector.tsx
+++ b/examples/web/components/SquadDirector.tsx
@@ -6,7 +6,8 @@
  * a clear "replanning" state), and — when a branch was rejected — the readable
  * "why not X" reasons from collectRejections/explainFailure.
  */
-import type { SquadFrame, UnitFrame } from "@scenarios/squad-combat";
+import type { SquadFrame, SquadInstance, UnitFrame } from "@scenarios/squad-combat";
+import { tacticalRead } from "../lib/tacticalView";
 
 const SIDE_COLOR: Record<string, string> = { enemy: "#ef4444", ally: "#3b82f6", player: "#3b82f6" };
 
@@ -37,16 +38,20 @@ const tacticWord: Record<string, string> = {
 
 export default function SquadDirector({
   frame,
+  instance,
   units,
   selected,
   onSelect,
 }: {
   frame: SquadFrame;
+  instance: SquadInstance;
   units: string[];
   selected: string | null;
   onSelect: (name: string) => void;
 }) {
   const u: UnitFrame | undefined = frame.units.find((x) => x.name === selected);
+  const read = tacticalRead(instance, frame, selected ?? null);
+  const best = read.spots.find((s) => s.best && !s.current);
   return (
     <div className="card">
       <h2>AI director · glass-box</h2>
@@ -81,6 +86,36 @@ export default function SquadDirector({
             <div className="mono" style={{ color: u.posture.includes("cover") || u.posture.includes("shielded") ? "var(--accent)" : "#fca5a5", marginTop: 3, fontSize: 11 }}>
               ◈ reading the room: {u.posture}
             </div>
+          )}
+
+          {u.alive && read.unit && (
+            <>
+              <h3 className="dir-h" style={{ marginTop: 12 }}>
+                POSITION READ <span style={{ color: "var(--muted)", fontWeight: 400 }}>· scoring the map</span>
+              </h3>
+              <div className="risk-row">
+                <span className="risk-tag">here</span>
+                <span className="mono" style={{ color: read.unit.exposure > 0 ? "#fca5a5" : "var(--accent)" }}>
+                  {read.unit.cover > 0 ? `🛡 covered vs ${read.unit.cover}` : read.unit.exposure > 0 ? "exposed" : "no contact"}
+                </span>
+                <span className="mono" style={{ color: "var(--muted)" }}>
+                  {read.unit.exposure} gun{read.unit.exposure === 1 ? "" : "s"} on me{read.unit.range != null ? ` · ${Math.round(read.unit.range)}m` : ""}
+                </span>
+                <span className="pill" style={{ color: read.unit.hasShot ? "var(--good)" : "var(--muted)" }}>{read.unit.hasShot ? "has shot" : "no shot"}</span>
+              </div>
+              {best && (
+                <div className="risk-row">
+                  <span className="risk-tag good">best</span>
+                  <span className="mono" style={{ color: "var(--good)" }}>{best.named ? best.name : "a covered angle"}</span>
+                  <span className="mono" style={{ color: "var(--muted)" }}>
+                    {best.cover > 0 ? `cover vs ${best.cover} · ` : ""}{best.exposure > 0 ? `exposed ${best.exposure}` : "safe"} · {Math.round(best.travel)}m away
+                  </span>
+                </div>
+              )}
+              <div className="mono" style={{ color: "var(--muted)", marginTop: 4, fontSize: 10.5 }}>
+                {read.spots.filter((s) => s.hasLos).length} firing position{read.spots.filter((s) => s.hasLos).length === 1 ? "" : "s"} scored · select on the map to see the heat overlay
+              </div>
+            </>
           )}
 
           <h3 className="dir-h" style={{ marginTop: 12 }}>

--- a/examples/web/components/SquadScene.tsx
+++ b/examples/web/components/SquadScene.tsx
@@ -406,19 +406,19 @@ function ThinkingOverlay({
     <group>
       {/* sight range ring */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[self.x, 0.015, self.z]}>
-        <ringGeometry args={[21.7, 22, 64]} />
-        <meshBasicMaterial color="#38bdf8" transparent opacity={0.35} side={THREE.DoubleSide} />
+        <ringGeometry args={[21.5, 22, 64]} />
+        <meshBasicMaterial color="#38bdf8" transparent opacity={0.5} side={THREE.DoubleSide} />
       </mesh>
 
       {/* scored candidate positions */}
       {spots.map((s) => {
         if (s.current) return null;
         if (!s.hasLos) {
-          // considered, but no line of fire from here → dim grey dot
+          // considered, but no line of fire from here → dim slate dot
           return (
             <mesh key={s.name} rotation={[-Math.PI / 2, 0, 0]} position={[s.x, 0.02, s.z]}>
-              <circleGeometry args={[0.16, 16]} />
-              <meshBasicMaterial color="#475569" transparent opacity={0.3} side={THREE.DoubleSide} />
+              <circleGeometry args={[0.19, 16]} />
+              <meshBasicMaterial color="#64748b" transparent opacity={0.45} side={THREE.DoubleSide} />
             </mesh>
           );
         }

--- a/examples/web/components/SquadScene.tsx
+++ b/examples/web/components/SquadScene.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { GizmoHelper, GizmoViewport, Grid, Html, Line, OrbitControls, PerspectiveCamera } from "@react-three/drei";
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
 import type { SquadFrame, SquadInstance, UnitFrame } from "@scenarios/squad-combat";
+import { buildTacticalWorld, coverIsSoft, readUnit, scoreSpots, type ScoredSpot, type UnitTactical } from "../lib/tacticalView";
 
 const SIDE_COLOR: Record<string, string> = { enemy: "#ef4444", ally: "#3b82f6", player: "#3b82f6" };
-const COVER_COLOR = { free: "#4b463d", flank: "#b45309", high: "#6d28d9", breach: "#7c2d12", rally: "#15803d" };
+const COVER_COLOR = { free: "#6b6051", flank: "#b45309", high: "#6d28d9", breach: "#7c2d12", rally: "#15803d" };
 const CHEST = 0.55;
 const HOSTILE: Record<string, string[]> = { enemy: ["player", "ally"], ally: ["enemy"], player: ["enemy"] };
 
@@ -25,100 +26,230 @@ function actionIcon(action: string): string {
   return "•";
 }
 
+/** Ring colour around a unit's feet, by what it is doing — a quick read of state. */
+function stateColor(action: string): string {
+  if (action.startsWith("firing")) return "#f97316";
+  if (action.startsWith("suppress")) return "#f59e0b";
+  if (action === "flanking" || action.includes("moving") || action.includes("repositioning") || action === "stacking on door") return "#38bdf8";
+  if (action === "reloading") return "#a78bfa";
+  if (action === "falling back") return "#f87171";
+  if (action === "breaching" || action === "taking high ground") return "#fb7185";
+  return "#64748b";
+}
+
 interface SceneProps {
   frame: SquadFrame;
   instance: SquadInstance;
   selected: string | null;
   onSelect: (name: string) => void;
+  showThinking: boolean;
 }
 
 function unitPos(u: UnitFrame): THREE.Vector3 {
   return new THREE.Vector3(u.x, u.elevation * 0.6 + 0.45, u.z);
 }
 
-/** A bright tracer beam from shooter to target, with a round travelling along it. */
+/** A bright tracer beam from shooter to target, with a round travelling along it,
+ *  a pulsing muzzle flash + a flickering muzzle light. */
 function FireBeam({ from, to, kind, color }: { from: THREE.Vector3; to: THREE.Vector3; kind: string; color: string }) {
   const round = useRef<THREE.Mesh>(null);
+  const flash = useRef<THREE.Mesh>(null);
+  const light = useRef<THREE.PointLight>(null);
   const a = useMemo(() => from.clone().setY(from.y + CHEST), [from]);
   const b = useMemo(() => to.clone().setY(to.y + CHEST), [to]);
   useFrame((state) => {
-    const m = round.current;
-    if (!m) return;
     const t = (state.clock.elapsedTime * (kind === "suppress" ? 1.4 : 3)) % 1;
-    m.position.lerpVectors(a, b, t);
+    if (round.current) round.current.position.lerpVectors(a, b, t);
+    // muzzle flash flickers at the firing cadence
+    const f = 0.5 + 0.5 * Math.abs(Math.sin(state.clock.elapsedTime * (kind === "suppress" ? 9 : 22)));
+    if (flash.current) flash.current.scale.setScalar(0.7 + f * 0.9);
+    if (light.current) light.current.intensity = (kind === "suppress" ? 1.2 : 2.6) * f;
   });
   const beamColor = kind === "suppress" ? "#f59e0b" : kind === "breach" ? "#f43f5e" : color;
   return (
     <group>
-      <Line points={[a, b]} color={beamColor} lineWidth={kind === "suppress" ? 3 : 2} transparent opacity={kind === "suppress" ? 0.4 : 0.7} dashed={kind === "suppress"} dashSize={0.3} gapSize={0.2} />
+      <Line points={[a, b]} color={beamColor} lineWidth={kind === "suppress" ? 3 : 2} transparent opacity={kind === "suppress" ? 0.4 : 0.75} dashed={kind === "suppress"} dashSize={0.3} gapSize={0.2} />
       <mesh ref={round}>
         <sphereGeometry args={[0.09, 8, 8]} />
         <meshBasicMaterial color={beamColor} />
       </mesh>
-      {/* muzzle flash */}
-      <mesh position={a}>
-        <sphereGeometry args={[0.16, 8, 8]} />
-        <meshBasicMaterial color={beamColor} transparent opacity={0.5} />
-      </mesh>
+      {/* muzzle flash + a short-range light so it reads as a gunshot */}
+      <group position={a.toArray()}>
+        <mesh ref={flash}>
+          <sphereGeometry args={[0.18, 10, 10]} />
+          <meshBasicMaterial color="#fff7d6" transparent opacity={0.85} />
+        </mesh>
+        <mesh>
+          <sphereGeometry args={[0.13, 8, 8]} />
+          <meshBasicMaterial color={beamColor} transparent opacity={0.6} />
+        </mesh>
+        <pointLight ref={light} color={beamColor} distance={4} decay={2} intensity={2} />
+      </group>
     </group>
   );
 }
 
-/** The selected unit's line of sight to its target — green if it has a shot, red if blocked. */
-function SightLine({ from, to, hasShot }: { from: THREE.Vector3; to: THREE.Vector3; hasShot: boolean }) {
-  const a = from.clone().setY(from.y + CHEST);
-  const b = to.clone().setY(to.y + CHEST);
+/** A transient hit effect: a spray of blood/sparks that pops out and falls away. */
+interface Impact {
+  pos: THREE.Vector3;
+  born: number;
+  lethal: boolean;
+  side: string;
+}
+const PARTICLES = 9;
+function Impacts({ impactsRef }: { impactsRef: React.MutableRefObject<Impact[]> }) {
+  const group = useRef<THREE.Group>(null);
+  const dummy = useMemo(() => new THREE.Object3D(), []);
+  const meshes = useRef<(THREE.InstancedMesh | null)[]>([]);
+  // a small pool of instanced bursts; each burst owns one instanced mesh
+  const POOL = 10;
+  const seeds = useMemo(
+    () =>
+      Array.from({ length: POOL }, () =>
+        Array.from({ length: PARTICLES }, () => ({
+          dir: new THREE.Vector3(Math.random() - 0.5, Math.random() * 0.9 + 0.2, Math.random() - 0.5).normalize(),
+          spd: 1.4 + Math.random() * 2.2,
+        })),
+      ),
+    [],
+  );
+  useFrame((state) => {
+    const now = state.clock.elapsedTime;
+    const live = impactsRef.current;
+    // cull expired
+    while (live.length && now - live[0].born > 0.9) live.shift();
+    if (live.length > POOL) live.splice(0, live.length - POOL);
+    for (let i = 0; i < POOL; i++) {
+      const m = meshes.current[i];
+      if (!m) continue;
+      const imp = live[i];
+      if (!imp) { m.visible = false; continue; }
+      m.visible = true;
+      const age = now - imp.born;
+      const k = Math.min(1, age / 0.9);
+      const mat = m.material as THREE.MeshBasicMaterial;
+      mat.opacity = (1 - k) * 0.95;
+      m.position.copy(imp.pos);
+      const s = seeds[i];
+      for (let p = 0; p < PARTICLES; p++) {
+        const sd = s[p];
+        const r = sd.spd * age;
+        dummy.position.set(sd.dir.x * r, sd.dir.y * r - 2.2 * age * age, sd.dir.z * r);
+        const sc = (imp.lethal ? 0.14 : 0.08) * (1 - k * 0.6);
+        dummy.scale.setScalar(Math.max(0.001, sc));
+        dummy.updateMatrix();
+        m.setMatrixAt(p, dummy.matrix);
+      }
+      m.instanceMatrix.needsUpdate = true;
+    }
+  });
   return (
-    <>
-      <Line points={[a, b]} color={hasShot ? "#34d399" : "#ef4444"} lineWidth={1.5} dashed dashSize={0.25} gapSize={0.18} transparent opacity={0.8} />
-      <Html position={a.clone().lerp(b, 0.5).toArray()} center distanceFactor={16} style={{ pointerEvents: "none" }}>
-        <div style={{ fontSize: 9, color: hasShot ? "#34d399" : "#ef4444", fontFamily: "monospace", background: "rgba(11,14,20,0.7)", padding: "1px 5px", borderRadius: 5, whiteSpace: "nowrap" }}>
-          {hasShot ? "line of fire" : "no line of fire → repositioning"}
-        </div>
-      </Html>
-    </>
+    <group ref={group}>
+      {Array.from({ length: POOL }, (_, i) => (
+        <instancedMesh key={i} ref={(el) => { meshes.current[i] = el; }} args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, PARTICLES]} visible={false}>
+          <sphereGeometry args={[1, 6, 6]} />
+          <meshBasicMaterial color="#b91c1c" transparent opacity={0.9} />
+        </instancedMesh>
+      ))}
+    </group>
   );
 }
 
-function Unit({ u, target, selected, onSelect }: { u: UnitFrame; target: THREE.Vector3 | null; selected: boolean; onSelect: () => void }) {
+function Unit({
+  u,
+  target,
+  read,
+  suppressed,
+  selected,
+  onSelect,
+}: {
+  u: UnitFrame;
+  target: THREE.Vector3 | null;
+  read: UnitTactical | null;
+  suppressed: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) {
   const ref = useRef<THREE.Group>(null);
+  const body = useRef<THREE.Group>(null);
+  const pulse = useRef<THREE.Mesh>(null);
   const dest = useMemo(() => unitPos(u), [u]);
-  useFrame((_, dt) => {
+  const crouch = !!(read?.inCover && u.alive && !/moving|flanking|repositioning|falling|stacking/.test(u.action));
+  useFrame((state, dt) => {
     const g = ref.current;
     if (!g) return;
     g.position.lerp(dest, 1 - Math.pow(0.0015, Math.min(dt, 0.05)));
     if (target) {
-      // face the target/movement
       const dir = Math.atan2(target.x - g.position.x, target.z - g.position.z);
       g.rotation.y += (dir - g.rotation.y) * Math.min(1, dt * 8);
+    }
+    // crouch behind cover (peek), stand otherwise
+    if (body.current) {
+      const ty = crouch ? -0.16 : 0;
+      const ts = crouch ? 0.82 : 1;
+      body.current.position.y += (ty - body.current.position.y) * Math.min(1, dt * 8);
+      body.current.scale.y += (ts - body.current.scale.y) * Math.min(1, dt * 8);
+    }
+    if (pulse.current && suppressed) {
+      const s = 0.7 + 0.25 * Math.abs(Math.sin(state.clock.elapsedTime * 7));
+      pulse.current.scale.setScalar(s);
     }
   });
   const color = SIDE_COLOR[u.side] ?? "#94a3b8";
   const hpFrac = Math.max(0, Math.min(1, u.hp / 100));
   return (
     <group ref={ref} position={dest.toArray()}>
-      <mesh castShadow onClick={(e) => { e.stopPropagation(); onSelect(); }}>
-        <capsuleGeometry args={[0.32, 0.5, 6, 14]} />
-        <meshStandardMaterial color={u.alive ? color : "#3a3f4b"} emissive={u.alive ? color : "#000"} emissiveIntensity={selected ? 0.7 : 0.25} roughness={0.5} transparent opacity={u.alive ? 1 : 0.3} />
-      </mesh>
-      {/* facing / weapon nub */}
+      <group ref={body}>
+        <mesh castShadow onClick={(e) => { e.stopPropagation(); onSelect(); }}>
+          <capsuleGeometry args={[0.32, 0.5, 6, 14]} />
+          <meshStandardMaterial color={u.alive ? color : "#3a3f4b"} emissive={u.alive ? color : "#000"} emissiveIntensity={selected ? 0.7 : 0.25} roughness={0.5} transparent opacity={u.alive ? 1 : 0.3} />
+        </mesh>
+        {/* facing / weapon nub */}
+        {u.alive && (
+          <mesh position={[0, 0.15, 0.42]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.05, 0.05, 0.5, 8]} />
+            <meshStandardMaterial color="#1f2630" />
+          </mesh>
+        )}
+        {/* a small shield arc on the threat-facing side when tucked in cover */}
+        {crouch && (
+          <mesh position={[0, 0.05, 0.46]} rotation={[Math.PI / 2, 0, 0]}>
+            <torusGeometry args={[0.34, 0.05, 8, 16, Math.PI]} />
+            <meshBasicMaterial color="#38bdf8" transparent opacity={0.85} side={THREE.DoubleSide} />
+          </mesh>
+        )}
+      </group>
+      {/* feet ring coloured by what the unit is doing */}
       {u.alive && (
-        <mesh position={[0, 0.15, 0.42]} rotation={[Math.PI / 2, 0, 0]}>
-          <cylinderGeometry args={[0.05, 0.05, 0.5, 8]} />
-          <meshStandardMaterial color="#1f2630" />
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.74, 0]}>
+          <ringGeometry args={[0.42, 0.54, 28]} />
+          <meshBasicMaterial color={stateColor(u.action)} side={THREE.DoubleSide} transparent opacity={0.9} />
+        </mesh>
+      )}
+      {/* pinned-by-suppression pulse */}
+      {u.alive && suppressed && (
+        <mesh ref={pulse} rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.72, 0]}>
+          <ringGeometry args={[0.6, 0.78, 28]} />
+          <meshBasicMaterial color="#f59e0b" side={THREE.DoubleSide} transparent opacity={0.5} />
         </mesh>
       )}
       {selected && (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.78, 0]}>
-          <ringGeometry args={[0.55, 0.72, 32]} />
+          <ringGeometry args={[0.6, 0.78, 32]} />
           <meshBasicMaterial color="#e2e8f0" side={THREE.DoubleSide} />
         </mesh>
       )}
       {u.alive && (
-        <mesh position={[-(1 - hpFrac) * 0.4, 1.0, 0]} scale={[Math.max(0.001, hpFrac), 1, 1]}>
-          <boxGeometry args={[0.8, 0.1, 0.05]} />
-          <meshBasicMaterial color={hpFrac > 0.5 ? "#22c55e" : hpFrac > 0.25 ? "#f59e0b" : "#ef4444"} />
-        </mesh>
+        <group position={[0, 1.0, 0]}>
+          <mesh position={[0, 0, -0.01]}>
+            <boxGeometry args={[0.82, 0.12, 0.04]} />
+            <meshBasicMaterial color="#0b0e14" />
+          </mesh>
+          <mesh position={[-(1 - hpFrac) * 0.4, 0, 0]} scale={[Math.max(0.001, hpFrac), 1, 1]}>
+            <boxGeometry args={[0.8, 0.1, 0.05]} />
+            <meshBasicMaterial color={hpFrac > 0.5 ? "#22c55e" : hpFrac > 0.25 ? "#f59e0b" : "#ef4444"} />
+          </mesh>
+        </group>
       )}
       <Html position={[0, 1.5, 0]} center distanceFactor={13} style={{ pointerEvents: "none", userSelect: "none" }}>
         <div style={{ textAlign: "center", fontFamily: "ui-monospace, monospace", whiteSpace: "nowrap" }}>
@@ -140,26 +271,76 @@ function Unit({ u, target, selected, onSelect }: { u: UnitFrame; target: THREE.V
           >
             {actionIcon(u.action)} {u.action}
           </div>
+          {u.alive && crouch && <div style={{ marginTop: 2, fontSize: 9, color: "#7dd3fc" }}>🛡 in cover</div>}
+          {u.alive && suppressed && <div style={{ marginTop: 2, fontSize: 9, color: "#fbbf24" }}>⚠ pinned</div>}
+          {selected && u.alive && (
+            <div style={{ marginTop: 2, display: "flex", gap: 2, justifyContent: "center" }}>
+              {Array.from({ length: 8 }, (_, i) => (
+                <span key={i} style={{ width: 4, height: 8, borderRadius: 1, background: i < u.ammo ? "#e2e8f0" : "#3a3f4b" }} />
+              ))}
+            </div>
+          )}
         </div>
       </Html>
     </group>
   );
 }
 
-/** Cover is a low sandbag/crate you take position at — no cryptic floating label. */
-function Cover({ x, z, kind, ownerColor }: { x: number; z: number; kind: keyof typeof COVER_COLOR; ownerColor: string | null }) {
+/** A soft-cover crate — a half-height sandbag/crate you fight FROM beside. */
+function CoverCrate({ x, z, color, ownerColor }: { x: number; z: number; color: string; ownerColor: string | null }) {
   return (
     <group position={[x, 0, z]}>
-      <mesh position={[0, 0.13, 0]} castShadow receiveShadow>
-        <boxGeometry args={[0.95, 0.26, 0.5]} />
-        <meshStandardMaterial color={COVER_COLOR[kind]} roughness={0.98} metalness={0.02} />
+      <mesh position={[0, 0.16, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.98, 0.32, 0.56]} />
+        <meshStandardMaterial color={color} roughness={0.96} metalness={0.02} />
+      </mesh>
+      {/* a couple of sandbags on top so it reads as cover, not a floor tile */}
+      <mesh position={[-0.22, 0.4, 0]} rotation={[0, 0, Math.PI / 2]} castShadow>
+        <capsuleGeometry args={[0.12, 0.34, 4, 8]} />
+        <meshStandardMaterial color={color} roughness={1} />
+      </mesh>
+      <mesh position={[0.22, 0.4, 0]} rotation={[0, 0, Math.PI / 2]} castShadow>
+        <capsuleGeometry args={[0.12, 0.34, 4, 8]} />
+        <meshStandardMaterial color={color} roughness={1} />
       </mesh>
       {ownerColor && (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
-          <ringGeometry args={[0.6, 0.74, 24]} />
+          <ringGeometry args={[0.62, 0.76, 24]} />
           <meshBasicMaterial color={ownerColor} side={THREE.DoubleSide} />
         </mesh>
       )}
+    </group>
+  );
+}
+
+/** A maneuver anchor (flank / high / breach / rally) — an open marked spot, NOT a
+ *  fire-blocking crate. Drawn as a flat painted ring + a thin post so it is clearly
+ *  "a position to reach", distinct from a crate that stops bullets. */
+function Anchor({ x, z, kind, color, ownerColor }: { x: number; z: number; kind: string; color: string; ownerColor: string | null }) {
+  const label = kind === "flank" ? "flank" : kind === "high" ? "high ground" : kind === "breach" ? "breach" : "rally";
+  return (
+    <group position={[x, 0, z]}>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+        <ringGeometry args={[0.34, 0.5, 24]} />
+        <meshBasicMaterial color={color} side={THREE.DoubleSide} transparent opacity={0.85} />
+      </mesh>
+      <mesh position={[0, 0.45, 0]}>
+        <cylinderGeometry args={[0.03, 0.03, 0.9, 6]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.4} />
+      </mesh>
+      <mesh position={[0.13, 0.78, 0]}>
+        <boxGeometry args={[0.26, 0.16, 0.02]} />
+        <meshBasicMaterial color={color} side={THREE.DoubleSide} />
+      </mesh>
+      {ownerColor && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
+          <ringGeometry args={[0.54, 0.66, 24]} />
+          <meshBasicMaterial color={ownerColor} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+      <Html position={[0, 1.0, 0]} center distanceFactor={20} style={{ pointerEvents: "none" }}>
+        <div style={{ fontSize: 8, color, fontFamily: "monospace", opacity: 0.85, textTransform: "uppercase", letterSpacing: 0.5 }}>{label}</div>
+      </Html>
     </group>
   );
 }
@@ -169,7 +350,6 @@ function Wall({ x, z, w, d, door, broken }: { x: number; z: number; w: number; d
   const cz = z + d / 2;
   if (door) {
     if (broken) {
-      // breached: low debris on an open threshold
       return (
         <mesh position={[cx, 0.08, cz]} receiveShadow>
           <boxGeometry args={[w, 0.16, d]} />
@@ -197,7 +377,131 @@ function Wall({ x, z, w, d, door, broken }: { x: number; z: number; w: number; d
   );
 }
 
-function Scene({ frame, instance, selected, onSelect }: SceneProps) {
+/** Heat colour for a position's desirability: red (bad) → amber → green (good). */
+function heatColor(d: number): string {
+  const hue = Math.round(d * 120); // 0 = red, 120 = green
+  return `hsl(${hue}, 85%, 55%)`;
+}
+
+/**
+ * The "what the selected unit is thinking" overlay: a sight-range ring, the score/risk
+ * the planner assigns to every candidate position (a heat disc per spot), the best
+ * firing position with the intended move toward it, plus the enemies who currently
+ * have a line of fire ON this unit (incoming threat).
+ */
+function ThinkingOverlay({
+  self,
+  spots,
+  read,
+  incoming,
+}: {
+  self: UnitFrame;
+  spots: ScoredSpot[];
+  read: UnitTactical;
+  incoming: UnitFrame[];
+}) {
+  const here = unitPos(self);
+  const best = spots.find((s) => s.best && !s.current);
+  return (
+    <group>
+      {/* sight range ring */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[self.x, 0.015, self.z]}>
+        <ringGeometry args={[21.7, 22, 64]} />
+        <meshBasicMaterial color="#38bdf8" transparent opacity={0.35} side={THREE.DoubleSide} />
+      </mesh>
+
+      {/* scored candidate positions */}
+      {spots.map((s) => {
+        if (s.current) return null;
+        if (!s.hasLos) {
+          // considered, but no line of fire from here → dim grey dot
+          return (
+            <mesh key={s.name} rotation={[-Math.PI / 2, 0, 0]} position={[s.x, 0.02, s.z]}>
+              <circleGeometry args={[0.16, 16]} />
+              <meshBasicMaterial color="#475569" transparent opacity={0.3} side={THREE.DoubleSide} />
+            </mesh>
+          );
+        }
+        const r = 0.28 + s.desirability * 0.22;
+        return (
+          <group key={s.name}>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} position={[s.x, 0.02, s.z]}>
+              <circleGeometry args={[r, 22]} />
+              <meshBasicMaterial color={heatColor(s.desirability)} transparent opacity={0.32 + s.desirability * 0.33} side={THREE.DoubleSide} />
+            </mesh>
+            {s.cover > 0 && (
+              <mesh rotation={[-Math.PI / 2, 0, 0]} position={[s.x, 0.025, s.z]}>
+                <ringGeometry args={[r, r + 0.06, 22]} />
+                <meshBasicMaterial color="#7dd3fc" transparent opacity={0.7} side={THREE.DoubleSide} />
+              </mesh>
+            )}
+          </group>
+        );
+      })}
+
+      {/* intended move toward the best firing position */}
+      {best && (
+        <>
+          <Line points={[here.clone().setY(0.05), new THREE.Vector3(best.x, 0.05, best.z)]} color="#34d399" lineWidth={2} dashed dashSize={0.3} gapSize={0.18} transparent opacity={0.85} />
+          <mesh rotation={[-Math.PI / 2, 0, 0]} position={[best.x, 0.03, best.z]}>
+            <ringGeometry args={[0.5, 0.62, 28]} />
+            <meshBasicMaterial color="#34d399" side={THREE.DoubleSide} />
+          </mesh>
+          <Html position={[best.x, 0.6, best.z]} center distanceFactor={16} style={{ pointerEvents: "none" }}>
+            <div style={{ fontSize: 9, color: "#34d399", fontFamily: "monospace", background: "rgba(11,14,20,0.75)", padding: "1px 6px", borderRadius: 5, whiteSpace: "nowrap" }}>
+              best angle{best.cover > 0 ? " · in cover" : ""}{best.exposure > 0 ? ` · exposed ${best.exposure}` : " · safe"}
+            </div>
+          </Html>
+        </>
+      )}
+
+      {/* current threat sight line (green = shot / red = blocked) */}
+      {read.threat && (
+        <SightLine from={here} to={unitPos(read.threat)} hasShot={read.hasShot} />
+      )}
+
+      {/* enemies who currently have a line of fire ON this unit */}
+      {incoming.map((e) => (
+        <Line
+          key={`in-${e.name}`}
+          points={[unitPos(e).clone().setY(unitPos(e).y + CHEST), here.clone().setY(here.y + CHEST)]}
+          color="#ef4444"
+          lineWidth={1.5}
+          dashed
+          dashSize={0.15}
+          gapSize={0.12}
+          transparent
+          opacity={0.55}
+        />
+      ))}
+      {incoming.length > 0 && (
+        <Html position={[self.x, 2.2, self.z]} center distanceFactor={16} style={{ pointerEvents: "none" }}>
+          <div style={{ fontSize: 9, color: "#fca5a5", fontFamily: "monospace", background: "rgba(11,14,20,0.75)", padding: "1px 6px", borderRadius: 5, whiteSpace: "nowrap" }}>
+            ⚠ {incoming.length} enemy gun{incoming.length > 1 ? "s" : ""} on me
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+/** The selected unit's line of sight to its target — green if it has a shot, red if blocked. */
+function SightLine({ from, to, hasShot }: { from: THREE.Vector3; to: THREE.Vector3; hasShot: boolean }) {
+  const a = from.clone().setY(from.y + CHEST);
+  const b = to.clone().setY(to.y + CHEST);
+  return (
+    <>
+      <Line points={[a, b]} color={hasShot ? "#34d399" : "#ef4444"} lineWidth={1.5} dashed dashSize={0.25} gapSize={0.18} transparent opacity={0.85} />
+      <Html position={a.clone().lerp(b, 0.5).toArray()} center distanceFactor={16} style={{ pointerEvents: "none" }}>
+        <div style={{ fontSize: 9, color: hasShot ? "#34d399" : "#ef4444", fontFamily: "monospace", background: "rgba(11,14,20,0.7)", padding: "1px 5px", borderRadius: 5, whiteSpace: "nowrap" }}>
+          {hasShot ? "line of fire" : "no line of fire → repositioning"}
+        </div>
+      </Html>
+    </>
+  );
+}
+
+function Scene({ frame, instance, selected, onSelect, showThinking }: SceneProps) {
   const center = useMemo<[number, number, number]>(() => {
     const xs = instance.units.map((u) => u.x).concat(instance.covers.map((c) => c.x));
     const zs = instance.units.map((u) => u.z).concat(instance.covers.map((c) => c.z));
@@ -210,24 +514,49 @@ function Scene({ frame, instance, selected, onSelect }: SceneProps) {
     return m;
   }, [frame]);
 
-  const coverKind = (c: SquadInstance["covers"][number]): keyof typeof COVER_COLOR =>
-    c.breach ? "breach" : c.flank ? "flank" : c.high ? "high" : c.rally ? "rally" : "free";
+  // a SquadWorld snapped to this frame — used to read each unit's cover state and to
+  // score positions for the selected unit (the library's own geometry, no re-impl)
+  const world = useMemo(() => buildTacticalWorld(instance, frame), [instance, frame]);
+  const reads = useMemo(() => {
+    const m = new Map<string, UnitTactical | null>();
+    for (const u of frame.units) m.set(u.name, u.alive ? readUnit(world, frame, u) : null);
+    return m;
+  }, [world, frame]);
 
-  // the selected unit's intended target = its nearest live hostile (regardless of
-  // line of sight) so the sight line can show GREEN (has a shot) or RED (blocked →
-  // it must reposition) — the core lesson of the emergent-flank scenario.
+  // who is being suppressed (an enemy is laying suppressing fire on them this beat)
+  const suppressedSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const u of frame.units) if (u.alive && u.firingKind === "suppress" && u.firingAt) s.add(u.firingAt);
+    return s;
+  }, [frame]);
+
   const sel = selected ? byName.get(selected) : undefined;
-  const selTarget = useMemo(() => {
-    if (!sel || !sel.alive) return undefined;
-    const hostiles = frame.units.filter((u) => u.alive && (HOSTILE[sel.side] ?? []).includes(u.side));
-    let best: UnitFrame | undefined;
-    let bestD = Infinity;
-    for (const h of hostiles) {
-      const d = Math.hypot(h.x - sel.x, h.z - sel.z);
-      if (d < bestD) { bestD = d; best = h; }
+  const selRead = sel ? reads.get(sel.name) ?? null : null;
+  const scored = useMemo(
+    () => (sel && sel.alive ? scoreSpots(world, instance, sel, frame) : []),
+    [world, instance, sel, frame],
+  );
+  // enemies that currently have a line of fire on the selected unit (incoming risk)
+  const incoming = useMemo(() => {
+    if (!sel || !sel.alive) return [];
+    return frame.units.filter(
+      (e) => e.alive && (HOSTILE[sel.side] ?? []).includes(e.side) && Math.hypot(e.x - sel.x, e.z - sel.z) <= 22 && world.losClear(e.x, e.z, sel.x, sel.z),
+    );
+  }, [sel, frame, world]);
+
+  // transient blood/impact effects, fed by per-unit HP drops between frames
+  const impactsRef = useRef<Impact[]>([]);
+  const prevHp = useRef<Map<string, number>>(new Map());
+  const clockRef = useRef(0);
+  useEffect(() => {
+    for (const u of frame.units) {
+      const prev = prevHp.current.get(u.name);
+      if (prev != null && u.hp < prev - 0.5) {
+        impactsRef.current.push({ pos: unitPos(u).clone(), born: clockRef.current, lethal: !u.alive, side: u.side });
+      }
+      prevHp.current.set(u.name, u.hp);
     }
-    return best;
-  }, [sel, frame]);
+  }, [frame]);
 
   return (
     <>
@@ -236,6 +565,7 @@ function Scene({ frame, instance, selected, onSelect }: SceneProps) {
       <ambientLight intensity={0.65} />
       <directionalLight position={[8, 16, 6]} intensity={1.1} castShadow shadow-mapSize={[1024, 1024]} />
       <hemisphereLight args={["#9db7ff", "#0b0e14", 0.4]} />
+      <ClockSync clockRef={clockRef} />
 
       <Grid args={[90, 90]} position={[center[0], 0, center[2]]} cellColor="#1c2436" sectionColor="#283350" fadeDistance={70} infiniteGrid />
 
@@ -251,7 +581,9 @@ function Scene({ frame, instance, selected, onSelect }: SceneProps) {
       {instance.covers.map((c) => {
         const owner = frame.reservations[c.name] ?? null;
         const oc = owner ? SIDE_COLOR[byName.get(owner)?.side ?? ""] ?? "#e2e8f0" : null;
-        return <Cover key={c.name} x={c.x} z={c.z} kind={coverKind(c)} ownerColor={oc} />;
+        if (coverIsSoft(c)) return <CoverCrate key={c.name} x={c.x} z={c.z} color={COVER_COLOR.free} ownerColor={oc} />;
+        const kind = c.breach ? "breach" : c.flank ? "flank" : c.high ? "high" : "rally";
+        return <Anchor key={c.name} x={c.x} z={c.z} kind={kind} color={COVER_COLOR[kind as keyof typeof COVER_COLOR]} ownerColor={oc} />;
       })}
 
       {/* fire beams for every unit currently shooting */}
@@ -262,19 +594,37 @@ function Scene({ frame, instance, selected, onSelect }: SceneProps) {
         return <FireBeam key={`beam-${u.name}`} from={unitPos(u)} to={unitPos(t)} kind={u.firingKind ?? "shot"} color={SIDE_COLOR[u.side] ?? "#fff"} />;
       })}
 
-      {/* selected unit's sight line (teaches LOS / why it repositions) */}
-      {sel && sel.alive && selTarget && <SightLine from={unitPos(sel)} to={unitPos(selTarget)} hasShot={sel.sees === selTarget.name} />}
+      {/* the selected unit's "thinking" overlay */}
+      {showThinking && sel && sel.alive && selRead && <ThinkingOverlay self={sel} spots={scored} read={selRead} incoming={incoming} />}
 
       {frame.units.map((u) => {
         const aimAt = u.firingAt ? byName.get(u.firingAt) : u.sees ? byName.get(u.sees) : null;
-        return <Unit key={u.name} u={u} target={aimAt ? unitPos(aimAt) : null} selected={selected === u.name} onSelect={() => onSelect(u.name)} />;
+        return (
+          <Unit
+            key={u.name}
+            u={u}
+            target={aimAt ? unitPos(aimAt) : null}
+            read={reads.get(u.name) ?? null}
+            suppressed={suppressedSet.has(u.name)}
+            selected={selected === u.name}
+            onSelect={() => onSelect(u.name)}
+          />
+        );
       })}
+
+      <Impacts impactsRef={impactsRef} />
 
       <GizmoHelper alignment="bottom-right" margin={[56, 56]}>
         <GizmoViewport axisColors={["#f87171", "#34d399", "#38bdf8"]} labelColor="#0b0e14" />
       </GizmoHelper>
     </>
   );
+}
+
+/** Keeps a ref in sync with the render clock so frame-driven effects share a timebase. */
+function ClockSync({ clockRef }: { clockRef: React.MutableRefObject<number> }) {
+  useFrame((state) => { clockRef.current = state.clock.elapsedTime; });
+  return null;
 }
 
 export default function SquadScene(props: SceneProps) {

--- a/examples/web/components/SquadScene.tsx
+++ b/examples/web/components/SquadScene.tsx
@@ -426,6 +426,45 @@ function Wall({ x, z, w, d, door, broken }: { x: number; z: number; w: number; d
   );
 }
 
+/** Where the selected unit BELIEVES the enemy is, when that diverges from reality —
+ *  a translucent "ghost" at the last-known position with a dotted leash to the real
+ *  position. Makes stale belief (a unit acting on outdated info, getting flanked)
+ *  visible: the unit plans/scores against the ghost, not the truth. */
+function BeliefGhosts({ believed, actual, color }: { believed: { x: number; z: number }[]; actual: { x: number; z: number }[]; color: string }) {
+  return (
+    <group>
+      {believed.map((b, i) => {
+        let nearest = Infinity;
+        let near: { x: number; z: number } | null = null;
+        for (const a of actual) {
+          const d = Math.hypot(a.x - b.x, a.z - b.z);
+          if (d < nearest) { nearest = d; near = a; }
+        }
+        if (nearest <= 1.4) return null; // belief matches reality → nothing to show
+        const g = new THREE.Vector3(b.x, 0.45, b.z);
+        return (
+          <group key={i}>
+            <mesh position={[b.x, 0.45 + CHEST, b.z]}>
+              <sphereGeometry args={[0.34, 12, 12]} />
+              <meshBasicMaterial color={color} transparent opacity={0.22} />
+            </mesh>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} position={[b.x, 0.02, b.z]}>
+              <ringGeometry args={[0.42, 0.54, 24]} />
+              <meshBasicMaterial color={color} transparent opacity={0.4} side={THREE.DoubleSide} />
+            </mesh>
+            {near && (
+              <Line points={[g.clone().setY(0.05), new THREE.Vector3(near.x, 0.05, near.z)]} color={color} lineWidth={1} dashed dashSize={0.12} gapSize={0.12} transparent opacity={0.4} />
+            )}
+            <Html position={[b.x, 1.1, b.z]} center distanceFactor={18} style={{ pointerEvents: "none" }}>
+              <div style={{ fontSize: 8, color, fontFamily: "monospace", opacity: 0.8, whiteSpace: "nowrap" }}>thinks enemy here</div>
+            </Html>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
 /** The selected unit's line of sight to its target — green if it has a shot, red if blocked. */
 function SightLine({ from, to, hasShot }: { from: THREE.Vector3; to: THREE.Vector3; hasShot: boolean }) {
   const a = from.clone().setY(from.y + CHEST);
@@ -603,6 +642,11 @@ function Scene({ frame, instance, spots = [], heatMode = "belief", showThinking,
             <meshBasicMaterial color="#38bdf8" transparent opacity={0.45} side={THREE.DoubleSide} />
           </mesh>
           {selTarget && <SightLine from={selPos} to={unitPos(selTarget)} hasShot={sel.sees === selTarget.name} />}
+          <BeliefGhosts
+            believed={sel.believedFoes}
+            actual={frame.units.filter((e) => e.alive && (HOSTILE[sel.side] ?? []).includes(e.side)).map((e) => ({ x: e.x, z: e.z }))}
+            color={SIDE_COLOR[(HOSTILE[sel.side] ?? [])[0] ?? ""] ?? "#ef4444"}
+          />
           {incoming.map((e) => (
             <Line
               key={`in-${e.name}`}

--- a/examples/web/lib/tacticalView.ts
+++ b/examples/web/lib/tacticalView.ts
@@ -1,0 +1,218 @@
+"use client";
+/**
+ * Read-only "what is the unit seeing / thinking" layer for the 3D combat view.
+ *
+ * It does NOT re-implement any planning. It rebuilds the SAME geometry the planner
+ * reasons over (a SquadWorld + the auto-generated tactical spot graph) from the
+ * instance, snaps every actor to its position in the current frame, and then asks
+ * the library's own primitives — losClear, inCoverVs, exposureAt, coverCountAt — the
+ * exact questions the planner's costs are built from. That lets the scene overlay,
+ * for a selected unit, the score/risk the planner assigns to each candidate position
+ * (exposure, cover, line of fire, whole-engagement cost) and whether the unit itself
+ * is currently shielded by a crate — i.e. it visualises the planner's spatial reasoning
+ * rather than inventing a parallel one.
+ */
+import {
+  SquadWorld,
+  generateTacticalSpots,
+  isSoftCover,
+  ACC_MIN,
+  BASE_ACCURACY,
+  COVER_HIT_MULT,
+  SHOT_DAMAGE,
+  SIGHT_RANGE,
+  W_EXPOSE,
+  W_MOVE,
+  type CoverSpec,
+  type SquadFrame,
+  type SquadInstance,
+  type UnitFrame,
+} from "@scenarios/squad-combat";
+
+export interface ScoredSpot {
+  name: string;
+  x: number;
+  z: number;
+  /** named, drawn cover crate/anchor vs. an invisible auto-generated grid/edge spot */
+  named: boolean;
+  /** how many living enemies have a clear line of fire on this spot (the risk) */
+  exposure: number;
+  /** how many of those enemies a crate at this spot shields you from (the value) */
+  cover: number;
+  /** does this spot have a line of fire to the unit's current threat? */
+  hasLos: boolean;
+  /** straight-line distance the unit would travel to reach it */
+  travel: number;
+  /** whole-engagement cost the planner would pay to fight from here (lower = better);
+   *  null when the spot has no line of fire (it is not a firing position) */
+  cost: number | null;
+  /** 0..1 desirability among the firing positions (1 = the cheapest place to fight) */
+  desirability: number;
+  /** the unit is standing here right now */
+  current: boolean;
+  /** the cheapest firing position (where the planner wants the unit to be) */
+  best: boolean;
+}
+
+export interface UnitTactical {
+  /** the unit's current believed primary threat (nearest living hostile), if any */
+  threat: UnitFrame | null;
+  /** has a clear line of fire to that threat right now */
+  hasShot: boolean;
+  /** how many enemies can shoot the unit where it stands now */
+  exposure: number;
+  /** how many enemies a crate currently shields the unit from */
+  cover: number;
+  /** the unit is tucked behind soft cover relative to its nearest threat */
+  inCover: boolean;
+  /** range (world units) to the nearest hostile */
+  range: number | null;
+}
+
+export interface TacticalRead {
+  spots: ScoredSpot[];
+  unit: UnitTactical | null;
+}
+
+const HOSTILE: Record<string, string[]> = {
+  enemy: ["player", "ally"],
+  ally: ["enemy"],
+  player: ["enemy"],
+};
+
+function dist(ax: number, az: number, bx: number, bz: number): number {
+  return Math.hypot(ax - bx, az - bz);
+}
+
+/** Hit-chance falloff with range (mirrors the scenario's private rangeFalloff). */
+function rangeFalloff(d: number): number {
+  const t = Math.min(1, Math.max(0, d / SIGHT_RANGE));
+  return BASE_ACCURACY + (ACC_MIN - BASE_ACCURACY) * t;
+}
+
+/** Build a SquadWorld for the instance (incl. the planner's auto tactical spots) and
+ *  snap every actor + the door to the current frame. */
+export function buildTacticalWorld(instance: SquadInstance, frame: SquadFrame): SquadWorld {
+  const augmented: SquadInstance = { ...instance, covers: [...instance.covers, ...generateTacticalSpots(instance)] };
+  const world = new SquadWorld(augmented);
+  for (const u of frame.units) {
+    const a = world.actors.get(u.name);
+    if (!a) continue;
+    a.x = u.x;
+    a.z = u.z;
+    a.hp = u.hp;
+    a.alive = u.alive;
+    a.cover = u.cover;
+    a.elevation = u.elevation;
+  }
+  world.doorBroken = frame.doorBroken;
+  return world;
+}
+
+/** The believed-foe positions a unit reasons about (its living hostiles). */
+function hostilePositions(world: SquadWorld, side: string): { x: number; z: number }[] {
+  return [...world.actors.values()].filter((a) => a.alive && (HOSTILE[side] ?? []).includes(a.side)).map((a) => ({ x: a.x, z: a.z }));
+}
+
+/** The nearest living hostile to a unit (its primary threat), preferring one in sight. */
+function nearestHostileFrame(frame: SquadFrame, self: UnitFrame): UnitFrame | null {
+  const hostiles = frame.units.filter((u) => u.alive && (HOSTILE[self.side] ?? []).includes(u.side));
+  let best: UnitFrame | null = null;
+  let bestD = Infinity;
+  for (const h of hostiles) {
+    const d = dist(self.x, self.z, h.x, h.z);
+    if (d < bestD) { bestD = d; best = h; }
+  }
+  return best;
+}
+
+/** Read a single unit's current tactical posture (cover / exposure / range / shot). */
+export function readUnit(world: SquadWorld, frame: SquadFrame, self: UnitFrame): UnitTactical {
+  const foes = hostilePositions(world, self.side);
+  const threat = nearestHostileFrame(frame, self);
+  const hasShot =
+    !!threat &&
+    dist(self.x, self.z, threat.x, threat.z) <= SIGHT_RANGE &&
+    world.losClear(self.x, self.z, threat.x, threat.z);
+  const inCover = !!threat && world.inCoverVs(self.x, self.z, threat.x, threat.z);
+  return {
+    threat,
+    hasShot,
+    exposure: world.exposureAt(self.x, self.z, foes),
+    cover: world.coverCountAt(self.x, self.z, foes),
+    inCover,
+    range: threat ? dist(self.x, self.z, threat.x, threat.z) : null,
+  };
+}
+
+/**
+ * Score every candidate position the planner could relocate to, from the selected
+ * unit's point of view: its exposure (risk), the cover it grants, whether it has a
+ * line of fire, and the whole-engagement cost of fighting from there. Mirrors the
+ * scenario's spot-graph terminal cost so the overlay shows the planner's own ranking.
+ */
+export function scoreSpots(world: SquadWorld, instance: SquadInstance, self: UnitFrame, frame: SquadFrame): ScoredSpot[] {
+  const foes = hostilePositions(world, self.side);
+  const threat = nearestHostileFrame(frame, self);
+  const namedNames = new Set(instance.covers.map((c) => c.name));
+  const candidates: CoverSpec[] = world.covers.filter((c) => {
+    const owner = world.coverOwner.get(c.name);
+    return !owner || owner === self.name;
+  });
+
+  const out: ScoredSpot[] = candidates.map((c) => {
+    const hasLos = !!threat && dist(c.x, c.z, threat.x, threat.z) <= SIGHT_RANGE && world.losClear(c.x, c.z, threat.x, threat.z);
+    const exposure = world.exposureAt(c.x, c.z, foes);
+    const cover = world.coverCountAt(c.x, c.z, foes);
+    const travel = dist(self.x, self.z, c.x, c.z);
+    let cost: number | null = null;
+    if (hasLos && threat) {
+      let hit = rangeFalloff(dist(c.x, c.z, threat.x, threat.z));
+      if (world.inCoverVs(threat.x, threat.z, c.x, c.z)) hit *= COVER_HIT_MULT;
+      const dmg = SHOT_DAMAGE * Math.max(0.12, hit);
+      const shots = Math.max(1, Math.ceil(Math.max(1, threat.hp) / dmg));
+      cost = W_MOVE * travel + shots * (1 + W_EXPOSE * exposure);
+    }
+    const here = c.x === self.x && c.z === self.z;
+    return {
+      name: c.name,
+      x: c.x,
+      z: c.z,
+      named: namedNames.has(c.name),
+      exposure,
+      cover,
+      hasLos,
+      travel,
+      cost,
+      desirability: 0,
+      current: here || c.name === self.cover,
+      best: false,
+    };
+  });
+
+  // normalise desirability across the firing positions (cheapest = 1) and flag the best
+  const firing = out.filter((s) => s.cost != null);
+  if (firing.length) {
+    const costs = firing.map((s) => s.cost as number);
+    const lo = Math.min(...costs);
+    const hi = Math.max(...costs);
+    for (const s of firing) s.desirability = hi > lo ? 1 - ((s.cost as number) - lo) / (hi - lo) : 1;
+    let bestSpot = firing[0];
+    for (const s of firing) if ((s.cost as number) < (bestSpot.cost as number)) bestSpot = s;
+    bestSpot.best = true;
+  }
+  return out;
+}
+
+export function tacticalRead(instance: SquadInstance | null, frame: SquadFrame | null, selected: string | null): TacticalRead {
+  if (!instance || !frame) return { spots: [], unit: null };
+  const self = selected ? frame.units.find((u) => u.name === selected) : undefined;
+  const world = buildTacticalWorld(instance, frame);
+  if (!self || !self.alive) return { spots: [], unit: null };
+  return { spots: scoreSpots(world, instance, self, frame), unit: readUnit(world, frame, self) };
+}
+
+/** Identify soft cover (a crate that blocks fire) vs. an open maneuver anchor. */
+export function coverIsSoft(c: CoverSpec): boolean {
+  return isSoftCover(c);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

<a href="https://cursor.com/agents/bc-1f79a55d-54f2-4684-b51c-3267e1f93409/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsquad_combat_merged_overlay_demo-2.mp4"><img src="https://cursor.com/artifacts/c/art-0cce6e27-fddb-4a1f-8f8e-af1293a4fc13" alt="squad_combat_merged_overlay_demo-2.mp4" /></a>

Selecting a unit overlays the planner's risk/reward heat field over its candidate positions, the cyan move it chose, its sight-range ring and line of fire; the bottom-left toggle re-scores the field against the unit's belief vs. ground truth. Combat shows muzzle flashes, tracers, blood on hits, and cover crouching.

![Unified overlay during combat](https://cursor.com/artifacts/c/art-d382a33d-a0c7-4aeb-8116-f76456d0f14b)
![Overlay following a red unit](https://cursor.com/artifacts/c/art-ec26e512-d97f-4ab1-96a7-57a37d403a20)
![POSITION READ section in the director](https://cursor.com/artifacts/c/art-3f2ec3b9-0a48-4ad6-8ea5-a25912e9e946)

## Why

The squad-combat web scenarios looked simplistic, and it was hard to read *what* was happening or *why* a unit moved. This makes the combat both more legible and more faithful to the planner's spatial reasoning.

## What changed

All visual changes are in the web demo (`examples/web`). This branch was merged with `claude/clever-wozniak-niqpdy`, which independently added a candidate-spot heatmap, a belief/ground-truth toggle, GOAP positioning, and exposed `evaluateSpot`/`SpotEval`/`believedThreat`/`believedFoes`/`sim.spots` from the scenario. The two overlays were **unified** into one coherent "what it's thinking" layer that reuses the library's own geometry/cost primitives rather than re-implementing planning.

### Unified tactical overlay (click a unit)
- **Risk/reward heat field** over the planner's real candidate spots (`sim.spots`), tinted via the library's `evaluateSpot` (green = cheap & safe → red = exposed; grey = no line of fire).
- **Belief vs. ground-truth** scoring toggle (uses the unit's `believedThreat`/`believedFoes`), wired to the same `heatMode`.
- The **cyan chosen-move** dot + line (the move the GOAP search committed to this beat).
- **Sight-range ring**, **line of fire** (green = shot / red = blocked), and **incoming threat lines** with a `⚠ N enemy guns on me` tag.
- **Stale-belief ghosts**: when a unit's belief diverges from reality, a translucent "thinks enemy here" marker with a leash to the real position — visualising it acting on outdated info.
- A master **`show what it's thinking`** toggle in the legend.

### Combat fidelity (`components/SquadScene.tsx`)
- Cover crouch + shield arc + `🛡 in cover` tag (via `inCoverVs`); brighter muzzle flash with a flickering light; blood/impact particle bursts on HP drops; action-coloured feet rings; `⚠ pinned` pulse under suppression; ammo pips; soft-cover crates vs. open maneuver anchors.

### Director panel (`components/SquadDirector.tsx` + `lib/tacticalView.ts`)
- **POSITION READ** section mirroring the overlay (current exposure/cover/range/has-shot + the cheapest firing spot with its cost), computed through the library's `evaluateSpot` so the text matches the 3D field.

## Testing
- ✅ `npm run typecheck`, `npm run lint`, `npm test` (113/113, incl. 29 squad tests) after the merge.
- ✅ `npx tsc --noEmit` in `examples/web`.
- ✅ Manual GUI verification + demo video of the merged overlay: heat field + cyan chosen move + sight ring + line of fire render together, belief/truth toggle recolors the field, overlay follows selection across teams, master toggle hides/shows it, and combat effects appear (verified via the video above and an independent video review).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f79a55d-54f2-4684-b51c-3267e1f93409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f79a55d-54f2-4684-b51c-3267e1f93409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

