### PR TITLE
Add Dive: a real-time deathmatch shooter scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ test/output
 
 # Local Netlify folder
 .netlify
+
+# External reference repos cloned locally as reading material (not vendored)
+/yuka/
+/dive/

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -8,6 +8,20 @@ app that **visualizes the `htn-ai` planner running in the browser**.
 Scenes selectable from the scenario dropdown, each driving the **real reactive
 `Planner`** in the browser (the app never re-implements planning).
 
+### ★ Deathmatch arena (LIVE — "Dive"-style shooter)
+
+A live 4-bot free-for-all modelled on Mugen87's [Dive](https://github.com/Mugen87/dive)
+demo (originally built on the Yuka game-AI library), here driven entirely by
+`htn-ai` (see [`../../scenarios/dive.ts`](../../scenarios/dive.ts)). Every bot runs
+one reactive `Planner`: its root `Compete` task **arbitrates attack / get-health /
+get-weapon / explore** by method *utility* (Dive's `GoalEvaluator` desirabilities),
+the `Attack` decomposition **engages from sight or hunts the last-seen position**
+(Dive's `CompositeGoal`s), and executors bridge to a continuous world that resolves
+steering, pickups, weapon selection by range, hits, deaths and **respawns**. Click a
+bot for its glass-box plan/step/trace — or **take control** of any slot mid-match
+(WASD/arrows to move, Space/click to fire) and fight the planners yourself; the swap
+hits the running sim with no reset. Rendered with simple primitive shapes.
+
 ### ★ Squad combat (F.E.A.R.-style game AI)
 
 Four scenarios where coordinated NPCs run one reactive `Planner` each over a

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -15,21 +15,24 @@ import {
   type SquadScenarioId,
 } from "../lib/runSquad";
 import { useLiveSquad, type Order } from "../lib/useLiveSquad";
+import { useLiveDive } from "../lib/useLiveDive";
 import type { SquadFrame, SquadInstance } from "@scenarios/squad-combat";
 import type { TraceEvent } from "htn-ai";
 
 const StaircaseScene = dynamic(() => import("../components/StaircaseScene"), { ssr: false });
 const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: false });
 const SquadScene = dynamic(() => import("../components/SquadScene"), { ssr: false });
+const DiveScene = dynamic(() => import("../components/DiveScene"), { ssr: false });
 import SquadDirector from "../components/SquadDirector";
 
 type GridId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge";
-type ScenarioId = GridId | "blocks" | SquadScenarioId;
-type Kind = "grid" | "blocks" | "squad";
+type ScenarioId = GridId | "blocks" | SquadScenarioId | "dive";
+type Kind = "grid" | "blocks" | "squad" | "dive";
 
 type Run = { kind: "grid"; data: RunResult } | { kind: "blocks"; data: BlocksRun } | { kind: "squad"; data: SquadRun };
 
 const SCENARIOS: Record<ScenarioId, { name: string; blurb: string; kind: Kind }> = {
+  dive: { name: "★ Deathmatch arena (LIVE)", kind: "dive", blurb: "A LIVE 4-bot free-for-all à la the 'Dive' shooter — but every bot is an htn-ai planner. Each arbitrates attack / get-health / get-weapon / explore from its own belief, hunts your last-seen position, picks weapons by range and respawns. Take over a bot (WASD + Space/click to fire) and fight them yourself." },
   skirmish: { name: "★ Skirmish: Red vs Blue", kind: "squad", blurb: "Two AI squads fight autonomously. Each unit plans from its OWN belief (no shared memory across teams) and reactively readjusts as it discovers the other's moves." },
   blockedFlank: { name: "★ Emergent flank: Red vs Blue", kind: "squad", blurb: "A barricade blocks every direct shot. No flank is scripted — each squad DISCOVERS it must reach a cover that can see the enemy, and they contest the same flanks." },
   breach: { name: "★ Timed breach: Red vs Blue", kind: "squad", blurb: "A Red fire-team breaches a door a Blue team holds — stacking and breaching in sync inside a deadline window enforced inside the planner's search." },
@@ -70,11 +73,13 @@ export default function Page() {
   const [heatMode, setHeatMode] = useState<"belief" | "truth">("belief");
 
   const isLive = scenario === "companion";
+  const isDive = scenario === "dive";
   const live = useLiveSquad(isLive ? "companion" : null, liveStepMs);
+  const dive = useLiveDive(isDive, liveStepMs);
 
-  // build the deterministic replay for everything EXCEPT the live companion battle
+  // build the deterministic replay for everything EXCEPT the live battles (dive + companion)
   useEffect(() => {
-    if (isLive) { setRun(null); setComputing(false); return; }
+    if (isLive || isDive) { setRun(null); setComputing(false); return; }
     setComputing(true);
     setRun(null);
     setStep(0);
@@ -118,7 +123,19 @@ export default function Page() {
 
   const narration = squad ? squadNarration(squad.frame) : "";
   const watch = SCENARIOS[scenario].kind === "squad" ? whatToWatch(scenario as SquadScenarioId) : [];
-  const status = run?.kind === "grid" ? run.data.status : squad ? outcome(squad.frame) : "—";
+  const status = run?.kind === "grid" ? run.data.status : squad ? outcome(squad.frame) : isDive && dive.frame ? diveStatus(dive.frame) : "—";
+
+  // a unified "live" controller so the playback card drives the squad OR dive sim
+  const liveCtl = isDive
+    ? { playing: dive.playing, setPlaying: dive.setPlaying, stepOnce: dive.stepOnce, reset: dive.reset }
+    : isLive
+      ? { playing: live.playing, setPlaying: live.setPlaying, stepOnce: live.stepOnce, reset: live.reset }
+      : null;
+
+  // default the inspector to the first combatant in the live deathmatch
+  useEffect(() => {
+    if (isDive && dive.frame && !selected) setSelected(dive.frame.bots[0]?.name ?? null);
+  }, [isDive, dive.frame, selected]);
 
   return (
     <div className="app">
@@ -131,6 +148,32 @@ export default function Page() {
         {run?.kind === "grid" && <StaircaseScene key="grid" frame={run.data.frames[step]} instance={run.data.instance} target={run.data.target} reached={step === lastStep && status === "succeeded"} />}
         {run?.kind === "blocks" && <BlocksScene key="blocks" frame={run.data.frames[step]} blocks={run.data.blocks} reached={step === lastStep} />}
         {squad && <SquadScene key="squad" frame={squad.frame} instance={squad.instance} spots={squad.spots} heatMode={heatMode} selected={selected} onSelect={(n) => setSelected(n || null)} />}
+        {isDive && dive.frame && (
+          <DiveScene
+            key="dive"
+            frame={dive.frame}
+            halfWidth={dive.frame.halfWidth}
+            halfDepth={dive.frame.halfDepth}
+            selected={selected}
+            onSelect={(n) => setSelected(n || null)}
+            humanName={dive.humanName}
+            onInput={dive.setInput}
+          />
+        )}
+        {isDive && dive.frame && (
+          <div className="hud-top">
+            {dive.frame.scoreboard.map((s) => (
+              <span key={s.name} className="team-chip">
+                <i className="dot" style={{ background: s.color }} />
+                <b style={{ color: s.color }}>{s.name}</b>
+                <span className="mono">{s.frags} frags · {s.deaths} deaths{dive.humanName === s.name ? " · YOU" : ""}</span>
+              </span>
+            ))}
+          </div>
+        )}
+        {isDive && dive.humanName && (
+          <div className="hud-narration">You are <b>{dive.humanName}</b> — WASD / arrows to move · Space or click to fire</div>
+        )}
 
         {squad && (
           <div className="hud-top">
@@ -183,11 +226,11 @@ export default function Page() {
           <h2>Scenario</h2>
           <div className="row spread">
             <select value={scenario} onChange={(e) => { setScenario(e.target.value as ScenarioId); setSelected(null); }}>
-              <optgroup label="Squad combat (game AI)">
-                {(Object.keys(SCENARIOS) as ScenarioId[]).filter((id) => SCENARIOS[id].kind === "squad").map((id) => <option key={id} value={id}>{SCENARIOS[id].name}</option>)}
+              <optgroup label="Game AI">
+                {(Object.keys(SCENARIOS) as ScenarioId[]).filter((id) => SCENARIOS[id].kind === "squad" || SCENARIOS[id].kind === "dive").map((id) => <option key={id} value={id}>{SCENARIOS[id].name}</option>)}
               </optgroup>
               <optgroup label="Spatial planning">
-                {(Object.keys(SCENARIOS) as ScenarioId[]).filter((id) => SCENARIOS[id].kind !== "squad").map((id) => <option key={id} value={id}>{SCENARIOS[id].name}</option>)}
+                {(Object.keys(SCENARIOS) as ScenarioId[]).filter((id) => SCENARIOS[id].kind !== "squad" && SCENARIOS[id].kind !== "dive").map((id) => <option key={id} value={id}>{SCENARIOS[id].name}</option>)}
               </optgroup>
             </select>
             <span className={`pill ${/eliminated|succeeded/.test(status) ? "good" : status === "failed" ? "bad" : "busy"}`}>{status}</span>
@@ -214,16 +257,54 @@ export default function Page() {
           </div>
         )}
 
-        <div className="card">
-          <h2>{isLive ? "Live battle" : "Playback · deterministic replay"}</h2>
-          <div className="row">
-            <button className="primary" onClick={() => (isLive ? live.setPlaying(!live.playing) : setPlaying((p) => !p))} disabled={!isLive && !run}>
-              {(isLive ? live.playing : playing) ? "⏸ Pause" : "▶ Play"}
-            </button>
-            <button onClick={() => (isLive ? live.stepOnce() : setStep((s) => Math.min(s + 1, lastStep)))} disabled={isLive ? false : !run || step >= lastStep}>Step ⟩</button>
-            <button onClick={() => (isLive ? live.reset() : (setStep(0), setPlaying(true)))} disabled={!isLive && !run}>⟲ {isLive ? "Restart" : "Reset"}</button>
+        {isDive && dive.frame && (
+          <div className="card">
+            <h2>Take control — live</h2>
+            <div className="mono" style={{ color: "var(--muted)", marginBottom: 8 }}>
+              swap a bot between the <span style={{ color: "var(--accent-2)" }}>htn-ai planner</span> and <span style={{ color: "var(--accent-2)" }}>you</span> on the running sim — no reset. WASD/arrows move · Space/click fires.
+            </div>
+            <div className="row" style={{ flexWrap: "wrap", gap: 6 }}>
+              {dive.frame.bots.map((b) => (
+                <button
+                  key={b.name}
+                  onClick={() => { setSelected(b.name); dive.takeOver(dive.humanName === b.name ? null : b.name); }}
+                  style={{ border: "1px solid " + (dive.humanName === b.name ? "#fde047" : "#2a3650"), color: dive.humanName === b.name ? "#fde047" : b.color, fontWeight: 700 }}
+                >
+                  {dive.humanName === b.name ? `🎮 ${b.name} (release)` : `take ${b.name}`}
+                </button>
+              ))}
+            </div>
           </div>
-          {!isLive && (
+        )}
+
+        {isDive && dive.frame && selected && (() => {
+          const b = dive.frame.bots.find((x) => x.name === selected);
+          if (!b) return null;
+          return (
+            <div className="card">
+              <h2>Bot · <span style={{ color: b.color }}>{b.name}</span> {b.control === "human" ? "(you)" : "· glass-box"}</h2>
+              <div className="mono" style={{ color: "var(--muted)" }}>{b.goalText}</div>
+              <div className="mono" style={{ marginTop: 4 }}>action: <span style={{ color: "var(--accent-2)" }}>{b.action}</span> · {b.hp} hp · {b.weapon}{b.ammo >= 0 ? ` (${b.ammo})` : ""}</div>
+              {b.control === "ai" && b.plan.length > 0 && (
+                <div className="mono" style={{ marginTop: 6, color: "var(--muted)" }}>plan: {b.plan.join(" → ")}</div>
+              )}
+              {b.control === "ai" && (
+                <div className="legend" style={{ marginTop: 6 }}>{b.events.map((e, i) => <span key={i} className="mono">{e}</span>)}</div>
+              )}
+            </div>
+          );
+        })()}
+
+        <div className="card">
+          <h2>{liveCtl ? "Live battle" : "Playback · deterministic replay"}</h2>
+          <div className="row">
+            <button className="primary" onClick={() => (liveCtl ? liveCtl.setPlaying(!liveCtl.playing) : setPlaying((p) => !p))} disabled={!liveCtl && !run}>
+              {(liveCtl ? liveCtl.playing : playing) ? "⏸ Pause" : "▶ Play"}
+            </button>
+            <button onClick={() => (liveCtl ? liveCtl.stepOnce() : setStep((s) => Math.min(s + 1, lastStep)))} disabled={liveCtl ? false : !run || step >= lastStep}>Step ⟩</button>
+            <button onClick={() => (liveCtl ? liveCtl.reset() : (setStep(0), setPlaying(true)))} disabled={!liveCtl && !run}>⟲ {liveCtl ? "Restart" : "Reset"}</button>
+          </div>
+          {!liveCtl && (
             <div className="row" style={{ marginTop: 10 }}>
               <span className="mono" style={{ color: "var(--muted)" }}>t</span>
               <input type="range" min={0} max={lastStep} step={1} value={Math.min(step, lastStep)} onChange={(e) => { setPlaying(false); setStep(Number(e.target.value)); }} style={{ flex: 1 }} />
@@ -232,7 +313,7 @@ export default function Page() {
           )}
           <div className="row" style={{ marginTop: 8 }}>
             <span className="mono" style={{ color: "var(--muted)" }}>speed</span>
-            {isLive ? (
+            {liveCtl ? (
               <input type="range" min={40} max={260} step={10} value={300 - liveStepMs} onChange={(e) => setLiveStepMs(300 - Number(e.target.value))} style={{ flex: 1 }} />
             ) : (
               <input type="range" min={120} max={1400} step={20} value={1520 - speed} onChange={(e) => setSpeed(1520 - Number(e.target.value))} style={{ flex: 1 }} />
@@ -274,4 +355,9 @@ function outcome(f: SquadFrame): string {
   const dead = f.teams.filter((t) => t.alive === 0);
   if (dead.length) return `${teamName(dead[0].side)} eliminated`;
   return "engaging";
+}
+
+function diveStatus(f: import("@scenarios/dive").DiveFrame): string {
+  const leader = f.scoreboard[0];
+  return leader && leader.frags > 0 ? `${leader.name} leads ${leader.frags}` : "deathmatch";
 }

--- a/examples/web/components/DiveScene.tsx
+++ b/examples/web/components/DiveScene.tsx
@@ -1,0 +1,228 @@
+"use client";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { GizmoHelper, GizmoViewport, Grid, Html, Line, OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { BotFrame, DiveFrame, ItemFrame, BoxSpec } from "@scenarios/dive";
+import type { PlayerInput } from "../lib/useLiveDive";
+
+const CHEST = 0.55;
+
+function actionIcon(action: string): string {
+  if (action.startsWith("firing")) return "🎯";
+  if (action.startsWith("hunting")) return "👁";
+  if (action.startsWith("fetching")) return "✦";
+  if (action.startsWith("exploring")) return "→";
+  if (action === "respawning") return "✖";
+  if (action === "thinking…") return "…";
+  if (action === "you") return "🎮";
+  return "•";
+}
+
+function weaponLabel(w: string): string {
+  return w === "shotgun" ? "SG" : w === "rifle" ? "RF" : "BL";
+}
+
+interface SceneProps {
+  frame: DiveFrame;
+  halfWidth: number;
+  halfDepth: number;
+  selected: string | null;
+  onSelect: (name: string) => void;
+  humanName: string | null;
+  onInput: (input: PlayerInput) => void;
+}
+
+function botPos(b: BotFrame): THREE.Vector3 {
+  return new THREE.Vector3(b.x, 0.45, b.z);
+}
+
+/** A short tracer beam for a shot fired this tick. */
+function Tracer({ from, to, color, hit }: { from: THREE.Vector3; to: THREE.Vector3; color: string; hit: boolean }) {
+  const a = from.clone().setY(CHEST);
+  const b = to.clone().setY(CHEST);
+  return (
+    <>
+      <Line points={[a, b]} color={hit ? color : "#94a3b8"} lineWidth={hit ? 2.5 : 1.2} transparent opacity={hit ? 0.85 : 0.4} />
+      <mesh position={a}>
+        <sphereGeometry args={[0.15, 8, 8]} />
+        <meshBasicMaterial color={color} transparent opacity={0.6} />
+      </mesh>
+    </>
+  );
+}
+
+function Bot({ b, selected, isHuman, onSelect }: { b: BotFrame; selected: boolean; isHuman: boolean; onSelect: () => void }) {
+  const ref = useRef<THREE.Group>(null);
+  const dest = useMemo(() => botPos(b), [b]);
+  useFrame((_, dt) => {
+    const g = ref.current;
+    if (!g) return;
+    g.position.lerp(dest, 1 - Math.pow(0.002, Math.min(dt, 0.05)));
+    g.rotation.y += (b.heading - g.rotation.y) * Math.min(1, dt * 10);
+  });
+  const hpFrac = Math.max(0, Math.min(1, b.hp / 100));
+  return (
+    <group ref={ref} position={dest.toArray()} rotation={[0, b.heading, 0]}>
+      <mesh castShadow onClick={(e) => { e.stopPropagation(); onSelect(); }}>
+        <capsuleGeometry args={[0.32, 0.5, 6, 14]} />
+        <meshStandardMaterial color={b.alive ? b.color : "#3a3f4b"} emissive={b.alive ? b.color : "#000"} emissiveIntensity={selected || isHuman ? 0.75 : 0.25} roughness={0.5} transparent opacity={b.alive ? 1 : 0.25} />
+      </mesh>
+      {/* gun nub (points along heading +z local) */}
+      {b.alive && (
+        <mesh position={[0, 0.15, 0.42]} rotation={[Math.PI / 2, 0, 0]}>
+          <cylinderGeometry args={[0.05, 0.05, 0.5, 8]} />
+          <meshStandardMaterial color="#1f2630" />
+        </mesh>
+      )}
+      {(selected || isHuman) && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.78, 0]}>
+          <ringGeometry args={[0.55, 0.72, 32]} />
+          <meshBasicMaterial color={isHuman ? "#fde047" : "#e2e8f0"} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+      {b.alive && (
+        <mesh position={[-(1 - hpFrac) * 0.4, 1.0, 0]} scale={[Math.max(0.001, hpFrac), 1, 1]} rotation={[0, -b.heading, 0]}>
+          <boxGeometry args={[0.8, 0.1, 0.05]} />
+          <meshBasicMaterial color={hpFrac > 0.5 ? "#22c55e" : hpFrac > 0.25 ? "#f59e0b" : "#ef4444"} />
+        </mesh>
+      )}
+      <Html position={[0, 1.5, 0]} center distanceFactor={14} style={{ pointerEvents: "none", userSelect: "none" }}>
+        <div style={{ textAlign: "center", fontFamily: "ui-monospace, monospace", whiteSpace: "nowrap" }}>
+          <div style={{ fontSize: 11, color: b.color, fontWeight: 700 }}>
+            {b.name}
+            <span style={{ color: "#9aa4b8", fontWeight: 400 }}> · {weaponLabel(b.weapon)}{b.ammo >= 0 ? ` ${b.ammo}` : ""}</span>
+          </div>
+          <div style={{ marginTop: 2, fontSize: 10, color: "#0b0e14", background: b.alive ? b.color : "#3a3f4b", borderRadius: 6, padding: "1px 7px", display: "inline-block", fontWeight: 600 }}>
+            {actionIcon(b.action)} {b.action}
+          </div>
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+function Wall({ x, z, w, d }: BoxSpec) {
+  return (
+    <mesh position={[x + w / 2, 0.9, z + d / 2]} castShadow receiveShadow>
+      <boxGeometry args={[w, 1.8, d]} />
+      <meshStandardMaterial color="#161c28" roughness={0.95} />
+    </mesh>
+  );
+}
+
+function Item({ it }: { it: ItemFrame }) {
+  const ref = useRef<THREE.Group>(null);
+  useFrame((state) => {
+    const g = ref.current;
+    if (!g) return;
+    g.rotation.y = state.clock.elapsedTime * 1.5;
+    g.position.y = 0.6 + Math.sin(state.clock.elapsedTime * 2) * 0.12;
+  });
+  const color = it.kind === "health" ? "#22c55e" : it.weapon === "shotgun" ? "#f97316" : "#a855f7";
+  return (
+    <group position={[it.x, 0.6, it.z]} visible={it.active}>
+      <group ref={ref}>
+        {it.kind === "health" ? (
+          <group>
+            <mesh><boxGeometry args={[0.5, 0.16, 0.16]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.5} /></mesh>
+            <mesh><boxGeometry args={[0.16, 0.16, 0.5]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.5} /></mesh>
+          </group>
+        ) : (
+          <mesh><boxGeometry args={[0.5, 0.22, 0.22]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.5} metalness={0.4} /></mesh>
+        )}
+      </group>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.58, 0]}>
+        <ringGeometry args={[0.5, 0.62, 24]} />
+        <meshBasicMaterial color={color} transparent opacity={0.5} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+
+/** Captures WASD movement + space/click to fire for the human-controlled bot, and
+ *  feeds it into the live sim every frame. No-op when nobody is under human control. */
+function HumanControls({ active, onInput }: { active: boolean; onInput: (i: PlayerInput) => void }) {
+  const keys = useRef<Record<string, boolean>>({});
+  const shoot = useRef(false);
+  useEffect(() => {
+    if (!active) return;
+    const down = (e: KeyboardEvent) => {
+      keys.current[e.key.toLowerCase()] = true;
+      if (e.key === " ") shoot.current = true;
+    };
+    const up = (e: KeyboardEvent) => {
+      keys.current[e.key.toLowerCase()] = false;
+      if (e.key === " ") shoot.current = false;
+    };
+    const md = () => (shoot.current = true);
+    const mu = () => (shoot.current = false);
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    window.addEventListener("mousedown", md);
+    window.addEventListener("mouseup", mu);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+      window.removeEventListener("mousedown", md);
+      window.removeEventListener("mouseup", mu);
+      onInput({ moveX: 0, moveZ: 0, shoot: false });
+    };
+  }, [active, onInput]);
+  useFrame(() => {
+    if (!active) return;
+    const k = keys.current;
+    // screen-up (w) = -z; world axes match the top-down camera
+    const mx = (k["d"] || k["arrowright"] ? 1 : 0) - (k["a"] || k["arrowleft"] ? 1 : 0);
+    const mz = (k["s"] || k["arrowdown"] ? 1 : 0) - (k["w"] || k["arrowup"] ? 1 : 0);
+    onInput({ moveX: mx, moveZ: mz, shoot: shoot.current });
+  });
+  return null;
+}
+
+function Scene({ frame, halfWidth, halfDepth, selected, onSelect, humanName, onInput }: SceneProps) {
+  return (
+    <>
+      <PerspectiveCamera makeDefault position={[0, Math.max(halfWidth, halfDepth) * 1.5, halfDepth * 1.4]} fov={42} />
+      <OrbitControls target={[0, 0, 0]} enablePan minDistance={10} maxDistance={90} maxPolarAngle={Math.PI / 2.1} />
+      <ambientLight intensity={0.65} />
+      <directionalLight position={[10, 20, 8]} intensity={1.1} castShadow shadow-mapSize={[1024, 1024]} />
+      <hemisphereLight args={["#9db7ff", "#0b0e14", 0.4]} />
+
+      <Grid args={[halfWidth * 2, halfDepth * 2]} cellColor="#1c2436" sectionColor="#283350" fadeDistance={120} infiniteGrid />
+
+      {/* arena floor (click to deselect) */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.02, 0]} receiveShadow onClick={() => onSelect("")}>
+        <planeGeometry args={[halfWidth * 2, halfDepth * 2]} />
+        <meshStandardMaterial color="#0e1422" roughness={1} />
+      </mesh>
+      {/* arena border */}
+      <Line points={[[-halfWidth, 0.02, -halfDepth], [halfWidth, 0.02, -halfDepth], [halfWidth, 0.02, halfDepth], [-halfWidth, 0.02, halfDepth], [-halfWidth, 0.02, -halfDepth]]} color="#2a3650" lineWidth={2} />
+
+      {frame.obstacles.map((o, i) => <Wall key={i} {...o} />)}
+      {frame.items.map((it) => <Item key={it.name} it={it} />)}
+
+      {frame.shots.map((s, i) => (
+        <Tracer key={i} from={new THREE.Vector3(s.from.x, 0, s.from.z)} to={new THREE.Vector3(s.to.x, 0, s.to.z)} color={frame.bots.find((b) => b.name === s.by)?.color ?? "#fff"} hit={s.hit} />
+      ))}
+
+      {frame.bots.map((b) => (
+        <Bot key={b.name} b={b} selected={selected === b.name} isHuman={humanName === b.name} onSelect={() => onSelect(b.name)} />
+      ))}
+
+      <HumanControls active={!!humanName} onInput={onInput} />
+
+      <GizmoHelper alignment="bottom-right" margin={[56, 56]}>
+        <GizmoViewport axisColors={["#f87171", "#34d399", "#38bdf8"]} labelColor="#0b0e14" />
+      </GizmoHelper>
+    </>
+  );
+}
+
+export default function DiveScene(props: SceneProps) {
+  return (
+    <Canvas shadows dpr={[1, 2]} gl={{ antialias: true }} style={{ background: "linear-gradient(180deg,#0d1320,#0b0e14)" }}>
+      <Scene {...props} />
+    </Canvas>
+  );
+}

--- a/examples/web/lib/useLiveDive.ts
+++ b/examples/web/lib/useLiveDive.ts
@@ -1,0 +1,108 @@
+"use client";
+/**
+ * Live, interactive deathmatch sim for the Dive scenario. Drives a real-time
+ * DiveSim (4-bot free-for-all) on a wall-clock interval, and lets one slot be
+ * handed between the htn-ai planner and a human player — the swap hits the RUNNING
+ * sim (`setControl`), so taking over (or handing back) happens mid-match with no
+ * reset. Human movement/fire is fed in via `setInput` each tick.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { DiveSim, arenaInstance, type DiveFrame } from "@scenarios/dive";
+
+export interface PlayerInput {
+  moveX: number;
+  moveZ: number;
+  shoot: boolean;
+}
+
+export interface LiveDive {
+  frame: DiveFrame | null;
+  playing: boolean;
+  setPlaying: (p: boolean) => void;
+  reset: () => void;
+  stepOnce: () => void;
+  /** the bot currently under human control (null = all AI) */
+  humanName: string | null;
+  /** take over a bot (or hand control back to the AI with null) */
+  takeOver: (name: string | null) => void;
+  /** feed the human-controlled bot's input for the coming ticks */
+  setInput: (input: PlayerInput) => void;
+  names: string[];
+}
+
+/** Drives a live DiveSim. `stepMs` = wall-clock ms per sim tick (null = inactive). */
+export function useLiveDive(active: boolean, stepMs: number): LiveDive {
+  const simRef = useRef<DiveSim | null>(null);
+  const [frame, setFrame] = useState<DiveFrame | null>(null);
+  const [playing, setPlaying] = useState(true);
+  const [humanName, setHumanName] = useState<string | null>(null);
+  const [, bump] = useState(0);
+
+  const reset = useCallback(() => {
+    if (!active) {
+      simRef.current = null;
+      setFrame(null);
+      return;
+    }
+    const sim = new DiveSim(arenaInstance(), { seed: 1, dt: 0.1 });
+    simRef.current = sim;
+    setHumanName(null);
+    setFrame(sim.snapshot());
+    setPlaying(true);
+  }, [active]);
+
+  useEffect(() => {
+    reset();
+  }, [reset]);
+
+  useEffect(() => {
+    if (!active || !playing) return;
+    const id = setInterval(() => {
+      const sim = simRef.current;
+      if (!sim) return;
+      sim.step();
+      setFrame(sim.snapshot());
+      bump((n) => (n + 1) % 1_000_000);
+    }, Math.max(40, stepMs));
+    return () => clearInterval(id);
+  }, [active, playing, stepMs]);
+
+  const stepOnce = useCallback(() => {
+    const sim = simRef.current;
+    if (!sim) return;
+    sim.step();
+    setFrame(sim.snapshot());
+    bump((n) => (n + 1) % 1_000_000);
+  }, []);
+
+  const takeOver = useCallback(
+    (name: string | null) => {
+      const sim = simRef.current;
+      if (!sim) return;
+      if (humanName && humanName !== name) sim.setControl(humanName, "ai"); // hand the old one back
+      if (name) sim.setControl(name, "human");
+      setHumanName(name);
+    },
+    [humanName],
+  );
+
+  const setInput = useCallback(
+    (input: PlayerInput) => {
+      const sim = simRef.current;
+      if (sim && humanName) sim.setInput(humanName, input);
+    },
+    [humanName],
+  );
+
+  return {
+    frame,
+    playing,
+    setPlaying,
+    reset,
+    stepOnce,
+    humanName,
+    takeOver,
+    setInput,
+    names: simRef.current ? [...simRef.current.world.actors.keys()] : [],
+  };
+}

--- a/scenarios/dive.ts
+++ b/scenarios/dive.ts
@@ -1,0 +1,1170 @@
+/**
+ * Dive — a real-time deathmatch-shooter AI, modelled on Mugen87's "Dive" demo
+ * (built on the Yuka game-AI library) but driven entirely by **htn-ai**.
+ *
+ * Where Dive wires together Yuka's `Think` goal-evaluators, `CompositeGoal`
+ * trees, steering, navmesh and perception, this scenario keeps the SAME bot brain
+ * — attack / get-health / get-weapon / explore arbitration, hunt-the-last-seen,
+ * fight-from-sight, item pickups, weapon selection, death + respawn — but the
+ * *decision layer is our planner*:
+ *
+ *   • One Model + reactive Planner per AI combatant (free-for-all). Each planner's
+ *     ExecState IS that bot's belief / working memory (perception mirrors truth
+ *     into it, gated by line-of-sight + memory decay).
+ *   • Dive's GoalEvaluator desirabilities (attack/health/weapon/explore) become
+ *     the *utilities* on the root `Compete` task's methods — the planner's
+ *     utility-ordered method selection IS the arbitration. The HTN decomposition
+ *     (Attack → engage-from-sight | hunt-last-seen) mirrors Dive's CompositeGoals.
+ *   • Executors are the thin bridge down to the continuous world (a stand-in for
+ *     Dive's steering + weapon controller): they command motion/fire and report
+ *     running / success / failure; the world integrates kinematics and resolves
+ *     pickups, hits, deaths and respawns. Steering, navmesh and physics stay OUT
+ *     of the planner — exactly the planner/controller/world split Dive blurs.
+ *
+ * Shared by tests/dive.ts (ground-truth assertions) and the web preview.
+ */
+import {
+  type DomainDoc,
+  type ExecutorApi,
+  type Model,
+  type Planner as PlannerT,
+  type TaskStatus,
+  type TraceEvent,
+  E,
+  F,
+  N,
+  Planner,
+  createModel,
+  planSummary,
+} from "../src/index";
+
+// ---------------------------------------------------------------- tunables
+
+export const MAX_HEALTH = 100;
+export const MOVE_SPEED = 4.0; // world units / second
+export const SIGHT_RANGE = 24;
+export const MEMORY_SECONDS = 4; // how long a lost target is hunted before it's forgotten
+export const PICKUP_RADIUS = 1.1; // touch an item to collect it
+export const ITEM_RESPAWN = 8; // seconds an item takes to come back after pickup
+export const RESPAWN_DELAY = 3; // seconds a dead bot waits before respawning
+export const HEALTH_PACK_AMOUNT = 40;
+export const WANT_HEALTH_BELOW = 0.9; // seek health once below this fraction
+export const UNIT_RADIUS = 0.5;
+
+/** Weapon stats. The blaster is the always-available fallback (infinite ammo). */
+export type WeaponType = "blaster" | "shotgun" | "rifle";
+export interface WeaponStats {
+  damage: number;
+  fireTime: number; // seconds between shots
+  maxAmmo: number; // Infinity for the blaster
+  idealRange: number; // distance of peak effectiveness (drives weapon selection)
+  accuracyClose: number;
+  accuracyFar: number;
+}
+export const WEAPONS: Record<WeaponType, WeaponStats> = {
+  blaster: { damage: 12, fireTime: 0.5, maxAmmo: Infinity, idealRange: 10, accuracyClose: 0.9, accuracyFar: 0.4 },
+  shotgun: { damage: 34, fireTime: 0.8, maxAmmo: 12, idealRange: 4, accuracyClose: 0.95, accuracyFar: 0.12 },
+  rifle: { damage: 20, fireTime: 0.25, maxAmmo: 30, idealRange: 16, accuracyClose: 0.8, accuracyFar: 0.7 },
+};
+export const ALL_WEAPONS: WeaponType[] = ["blaster", "shotgun", "rifle"];
+
+// ---------------------------------------------------------------- instance shapes
+
+export interface Vec2 {
+  x: number;
+  z: number;
+}
+
+/** Axis-aligned obstacle that blocks line-of-sight AND movement. */
+export interface BoxSpec {
+  x: number;
+  z: number;
+  w: number;
+  d: number;
+}
+
+export interface ItemSpec {
+  name: string;
+  x: number;
+  z: number;
+  kind: "health" | "weapon";
+  /** the weapon a "weapon" item grants (and refills ammo for) */
+  weapon?: WeaponType;
+}
+
+export interface BotSpec {
+  name: string;
+  x: number;
+  z: number;
+  /** display colour for the view */
+  color?: string;
+}
+
+export interface DiveInstance {
+  /** the arena bounds: play area is [-halfW, halfW] × [-halfD, halfD] */
+  halfWidth: number;
+  halfDepth: number;
+  bots: BotSpec[];
+  items: ItemSpec[];
+  obstacles: BoxSpec[];
+  /** explicit spawn points; bots respawn at the one furthest from danger */
+  spawns: Vec2[];
+}
+
+// ---------------------------------------------------------------- ground-truth world
+
+interface Combatant {
+  name: string;
+  color: string;
+  x: number;
+  z: number;
+  /** facing (for the view + human aim) */
+  heading: number;
+  hp: number;
+  alive: boolean;
+  respawnAt: number;
+  /** ammo per weapon; blaster is Infinity */
+  ammo: Map<WeaponType, number>;
+  weapon: WeaponType;
+  frags: number;
+  deaths: number;
+  control: "ai" | "human";
+  /** the believed last-seen position of this bot's current quarry (set by perception);
+   *  the hunt executor walks to it (kept on the actor so the executor needn't read a vec belief) */
+  huntTarget: Vec2 | null;
+  /** human input intent (when control === "human") */
+  input: { moveX: number; moveZ: number; aim: number; shoot: boolean };
+}
+
+interface ItemState extends ItemSpec {
+  active: boolean;
+  respawnAt: number;
+}
+
+/** A fired shot this tick — for tracer rendering. */
+export interface Shot {
+  from: Vec2;
+  to: Vec2;
+  by: string;
+  hit: boolean;
+  kind: WeaponType;
+}
+
+function dist2(ax: number, az: number, bx: number, bz: number): number {
+  return Math.hypot(ax - bx, az - bz);
+}
+
+/** Segment (a→b) vs axis-aligned box intersection — line-of-sight test (slab method). */
+function segHitsBox(ax: number, az: number, bx: number, bz: number, b: BoxSpec): boolean {
+  const dx = bx - ax;
+  const dz = bz - az;
+  let t0 = 0;
+  let t1 = 1;
+  for (const [p, q] of [
+    [-dx, ax - b.x],
+    [dx, b.x + b.w - ax],
+    [-dz, az - b.z],
+    [dz, b.z + b.d - az],
+  ] as [number, number][]) {
+    if (p === 0) {
+      if (q < 0) return false;
+    } else {
+      const t = q / p;
+      if (p < 0) {
+        if (t > t1) return false;
+        if (t > t0) t0 = t;
+      } else {
+        if (t < t0) return false;
+        if (t < t1) t1 = t;
+      }
+    }
+  }
+  return t0 <= t1;
+}
+
+/** The four padded corners of a box, as candidate path waypoints. */
+function boxCorners(b: BoxSpec, pad: number): Vec2[] {
+  return [
+    { x: b.x - pad, z: b.z - pad },
+    { x: b.x + b.w + pad, z: b.z - pad },
+    { x: b.x - pad, z: b.z + b.d + pad },
+    { x: b.x + b.w + pad, z: b.z + b.d + pad },
+  ];
+}
+
+/** Position reached by walking `dist` along a polyline; `done` once past the end. */
+function walkPolyline(path: Vec2[], dist: number): { x: number; z: number; done: boolean } {
+  let rem = dist;
+  for (let i = 0; i < path.length - 1; i++) {
+    const seg = dist2(path[i].x, path[i].z, path[i + 1].x, path[i + 1].z);
+    if (rem <= seg) {
+      const t = seg > 0 ? rem / seg : 1;
+      return { x: lerp(path[i].x, path[i + 1].x, t), z: lerp(path[i].z, path[i + 1].z, t), done: false };
+    }
+    rem -= seg;
+  }
+  const last = path[path.length - 1];
+  return { x: last.x, z: last.z, done: true };
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.min(1, Math.max(0, t));
+}
+
+/**
+ * The shared deathmatch world: ground-truth combatant kinematics + vitals, item
+ * states, the static arena geometry, and this tick's fired shots. Belief lives in
+ * each planner's ExecState; this is truth. A stand-in for Dive's three.js world +
+ * Yuka EntityManager (steering, navmesh, weapon system, spawning).
+ */
+export class DiveWorld {
+  public clock = 0;
+  public readonly actors = new Map<string, Combatant>();
+  public readonly items: ItemState[];
+  public readonly obstacles: BoxSpec[];
+  public readonly spawns: Vec2[];
+  public readonly halfWidth: number;
+  public readonly halfDepth: number;
+  /** shots fired during the most recent step (rendered as tracers) */
+  public shots: Shot[] = [];
+
+  constructor(inst: DiveInstance) {
+    this.halfWidth = inst.halfWidth;
+    this.halfDepth = inst.halfDepth;
+    this.obstacles = inst.obstacles;
+    this.spawns = inst.spawns;
+    this.items = inst.items.map((it) => ({ ...it, active: true, respawnAt: 0 }));
+    for (const b of inst.bots) {
+      this.actors.set(b.name, this.freshActor(b.name, b.color ?? "#38bdf8", b.x, b.z));
+    }
+  }
+
+  private freshActor(name: string, color: string, x: number, z: number): Combatant {
+    const ammo = new Map<WeaponType, number>();
+    for (const w of ALL_WEAPONS) ammo.set(w, w === "blaster" ? Infinity : 0);
+    return {
+      name,
+      color,
+      x,
+      z,
+      heading: 0,
+      hp: MAX_HEALTH,
+      alive: true,
+      respawnAt: 0,
+      ammo,
+      weapon: "blaster",
+      frags: 0,
+      deaths: 0,
+      control: "ai",
+      huntTarget: null,
+      input: { moveX: 0, moveZ: 0, aim: 0, shoot: false },
+    };
+  }
+
+  /** clamp a point to the arena and out of any obstacle (cheap push-out). */
+  clampToArena(x: number, z: number): Vec2 {
+    let cx = Math.max(-this.halfWidth, Math.min(this.halfWidth, x));
+    let cz = Math.max(-this.halfDepth, Math.min(this.halfDepth, z));
+    for (const o of this.obstacles) {
+      if (cx > o.x - UNIT_RADIUS && cx < o.x + o.w + UNIT_RADIUS && cz > o.z - UNIT_RADIUS && cz < o.z + o.d + UNIT_RADIUS) {
+        // push to the nearest edge
+        const toLeft = cx - (o.x - UNIT_RADIUS);
+        const toRight = o.x + o.w + UNIT_RADIUS - cx;
+        const toTop = cz - (o.z - UNIT_RADIUS);
+        const toBottom = o.z + o.d + UNIT_RADIUS - cz;
+        const m = Math.min(toLeft, toRight, toTop, toBottom);
+        if (m === toLeft) cx = o.x - UNIT_RADIUS;
+        else if (m === toRight) cx = o.x + o.w + UNIT_RADIUS;
+        else if (m === toTop) cz = o.z - UNIT_RADIUS;
+        else cz = o.z + o.d + UNIT_RADIUS;
+      }
+    }
+    return { x: cx, z: cz };
+  }
+
+  losClear(ax: number, az: number, bx: number, bz: number): boolean {
+    for (const o of this.obstacles) if (segHitsBox(ax, az, bx, bz, o)) return false;
+    return true;
+  }
+
+  /** every other living combatant (free-for-all — everyone is hostile to everyone). */
+  enemiesOf(self: string): Combatant[] {
+    return [...this.actors.values()].filter((a) => a.alive && a.name !== self);
+  }
+
+  /** nearest living enemy, optionally requiring an unobstructed line of sight in range. */
+  nearestEnemy(self: string, requireLos: boolean): Combatant | null {
+    const me = this.actors.get(self);
+    if (!me) return null;
+    let best: Combatant | null = null;
+    let bestD = Infinity;
+    for (const other of this.enemiesOf(self)) {
+      const d = dist2(me.x, me.z, other.x, other.z);
+      if (d > SIGHT_RANGE) continue;
+      if (requireLos && !this.losClear(me.x, me.z, other.x, other.z)) continue;
+      if (d < bestD) {
+        bestD = d;
+        best = other;
+      }
+    }
+    return best;
+  }
+
+  /** Probability a shot from `shooter` (using its current weapon) lands on `target`. */
+  hitChance(shooter: Combatant, target: Combatant): number {
+    const w = WEAPONS[shooter.weapon];
+    const d = dist2(shooter.x, shooter.z, target.x, target.z);
+    const t = Math.min(1, d / SIGHT_RANGE);
+    return Math.max(0.02, w.accuracyClose + (w.accuracyFar - w.accuracyClose) * t);
+  }
+
+  /** ammo fraction the bot holds for a weapon (1 for the blaster — always topped up). */
+  ammoFraction(a: Combatant, w: WeaponType): number {
+    const max = WEAPONS[w].maxAmmo;
+    if (!isFinite(max)) return 1;
+    return Math.min(1, (a.ammo.get(w) ?? 0) / max);
+  }
+
+  /** average weapon strength across the arsenal — drives the attack desirability. */
+  weaponStrength(a: Combatant): number {
+    let s = 0;
+    for (const w of ALL_WEAPONS) s += this.ammoFraction(a, w);
+    return s / ALL_WEAPONS.length;
+  }
+
+  /** Shortest walkable path from (ax,az) to (bx,bz) around obstacles (visibility
+   *  graph over padded box corners + Dijkstra). Returns waypoints incl. the goal. */
+  findPath(ax: number, az: number, bx: number, bz: number): Vec2[] {
+    if (this.losClear(ax, az, bx, bz)) return [{ x: bx, z: bz }];
+    const pad = UNIT_RADIUS + 0.4;
+    const inside = (p: Vec2) => this.obstacles.some((o) => p.x > o.x - 0.01 && p.x < o.x + o.w + 0.01 && p.z > o.z - 0.01 && p.z < o.z + o.d + 0.01);
+    const nodes: Vec2[] = [{ x: ax, z: az }, ...this.obstacles.flatMap((o) => boxCorners(o, pad)).filter((c) => !inside(c)), { x: bx, z: bz }];
+    const n = nodes.length;
+    const clear = (i: number, j: number) => this.losClear(nodes[i].x, nodes[i].z, nodes[j].x, nodes[j].z);
+    const adj: number[][] = nodes.map(() => []);
+    for (let i = 0; i < n; i++) for (let j = i + 1; j < n; j++) if (clear(i, j)) { adj[i].push(j); adj[j].push(i); }
+    const dist = new Array(n).fill(Infinity);
+    const prev = new Array(n).fill(-1);
+    const done = new Array(n).fill(false);
+    dist[0] = 0;
+    for (let it = 0; it < n; it++) {
+      let u = -1;
+      let best = Infinity;
+      for (let k = 0; k < n; k++) if (!done[k] && dist[k] < best) { best = dist[k]; u = k; }
+      if (u < 0) break;
+      done[u] = true;
+      for (const v of adj[u]) {
+        const d = dist[u] + dist2(nodes[u].x, nodes[u].z, nodes[v].x, nodes[v].z);
+        if (d < dist[v]) { dist[v] = d; prev[v] = u; }
+      }
+    }
+    if (dist[n - 1] === Infinity) return [{ x: bx, z: bz }];
+    const path: Vec2[] = [];
+    for (let cur = n - 1; cur > 0; cur = prev[cur]) path.unshift({ x: nodes[cur].x, z: nodes[cur].z });
+    return path;
+  }
+
+  /** fire `shooter`'s current weapon at `target`; rolls the seeded RNG, applies damage,
+   *  records a tracer, and handles the kill (frags / death / respawn timer). */
+  fire(shooter: Combatant, target: Combatant, rng: () => number): boolean {
+    const w = WEAPONS[shooter.weapon];
+    if (isFinite(w.maxAmmo)) shooter.ammo.set(shooter.weapon, Math.max(0, (shooter.ammo.get(shooter.weapon) ?? 0) - 1));
+    const hit = rng() < this.hitChance(shooter, target);
+    this.shots.push({ from: { x: shooter.x, z: shooter.z }, to: { x: target.x, z: target.z }, by: shooter.name, hit, kind: shooter.weapon });
+    if (hit) {
+      target.hp = Math.max(0, target.hp - w.damage);
+      if (target.hp <= 0 && target.alive) this.kill(shooter, target);
+    }
+    return hit;
+  }
+
+  private kill(killer: Combatant, victim: Combatant): void {
+    victim.alive = false;
+    victim.respawnAt = this.clock + RESPAWN_DELAY;
+    victim.deaths += 1;
+    if (killer.name !== victim.name) killer.frags += 1;
+  }
+
+  /** the spawn point furthest from the nearest living enemy (avoid spawning into a fight). */
+  bestSpawn(self: string): Vec2 {
+    let best = this.spawns[0];
+    let bestScore = -Infinity;
+    for (const s of this.spawns) {
+      let nearestFoe = Infinity;
+      for (const a of this.actors.values()) if (a.alive && a.name !== self) nearestFoe = Math.min(nearestFoe, dist2(s.x, s.z, a.x, a.z));
+      if (nearestFoe > bestScore) {
+        bestScore = nearestFoe;
+        best = s;
+      }
+    }
+    return best;
+  }
+
+  /** respawn a fallen combatant at a safe point with a fresh blaster loadout. */
+  respawn(a: Combatant): void {
+    const s = this.bestSpawn(a.name);
+    a.x = s.x;
+    a.z = s.z;
+    a.hp = MAX_HEALTH;
+    a.alive = true;
+    a.respawnAt = 0;
+    a.weapon = "blaster";
+    a.huntTarget = null;
+    for (const w of ALL_WEAPONS) a.ammo.set(w, w === "blaster" ? Infinity : 0);
+  }
+}
+
+// ---------------------------------------------------------------- the domain (one POV)
+
+/**
+ * The deathmatch bot brain, authored from one combatant's point of view. Every AI
+ * bot runs this same domain; only its identity (perception, executors) differs.
+ *
+ * The root task `Compete` is the goal arbitration: its four methods are Dive's
+ * four GoalEvaluators, and their `utility` expressions are the desirabilities
+ * (computed by perception, the "Feature" layer). Utility-ordered method selection
+ * picks the most desirable goal each beat — exactly `Think.arbitrate()`.
+ */
+export const diveDomain: DomainDoc = {
+  name: "dive",
+  types: [{ name: "item" }, { name: "spot" }],
+  fluents: [
+    // --- self (belief; perception mirrors truth) ---
+    { name: "myPos", kind: "vec2" },
+    { name: "myHp", kind: "float", initial: MAX_HEALTH },
+    { name: "weaponStrength", kind: "float", initial: 1 },
+    // --- threat (belief; gated by line-of-sight + memory decay) ---
+    { name: "hasTarget", kind: "boolean", initial: false }, // a position fix (sight or recent memory)
+    { name: "targetVisible", kind: "boolean", initial: false }, // a current line of sight
+    { name: "targetPos", kind: "vec2" },
+    { name: "targetHp", kind: "float", initial: MAX_HEALTH },
+    // desirability of attacking right now (weaponStrength × health) — Dive's AttackEvaluator
+    { name: "attackDesire", kind: "float", initial: 0 },
+    // the explore waypoint chosen for this beat (perception picks one; isExplore binds it)
+    { name: "exploreSpot", kind: "entity", entityType: "spot" },
+    // --- items (static descriptors + dynamic desirability, set by perception) ---
+    { name: "itemPos", params: [{ name: "i", type: "item" }], kind: "vec2" },
+    { name: "itemActive", params: [{ name: "i", type: "item" }], kind: "boolean", initial: false },
+    { name: "itemWanted", params: [{ name: "i", type: "item" }], kind: "boolean", initial: false },
+    // desirability of fetching this item — Dive's GetHealth/GetWeapon evaluators
+    { name: "itemDesire", params: [{ name: "i", type: "item" }], kind: "float", initial: 0 },
+    // --- spots (static walkable waypoints) ---
+    { name: "spotPos", params: [{ name: "s", type: "spot" }], kind: "vec2" },
+  ],
+  compounds: [{ name: "Compete" }, { name: "Attack" }, { name: "Explore" }],
+  operators: [
+    {
+      // walk to an item and collect it (the world grants it on contact). Reactively
+      // aborts if someone else grabs it first (itemActive drops → repair).
+      name: "pickup",
+      params: [{ name: "i", type: "item" }],
+      pre: F.lit("itemActive", ["?i"]),
+      verify: F.lit("itemActive", ["?i"]),
+      eff: [E.setVec("myPos", [], N.ext("itemX", ["?i"], ["itemPos"]), N.ext("itemZ", ["?i"], ["itemPos"]), undefined, "planOnly")],
+      cost: N.add(N.dist("myPos", [], "itemPos", ["?i"]), N.c(0.1)),
+      duration: N.div(N.add(N.dist("myPos", [], "itemPos", ["?i"]), N.c(0.1)), N.c(MOVE_SPEED)),
+      executor: "pickup",
+    },
+    {
+      // fire on the visible target; chips its (believed) HP. Reactively aborts the
+      // instant line-of-sight is lost (verify targetVisible) → Attack falls to hunt.
+      name: "fight",
+      pre: F.and(F.lit("hasTarget"), F.lit("targetVisible"), F.gt(N.fl("targetHp"), N.c(0))),
+      verify: F.lit("targetVisible"),
+      eff: [E.dec("targetHp", [], N.ext("shotDamage", [], ["myPos", "targetPos"]), "planOnly")],
+      cost: 1,
+      duration: N.c(0.3),
+      executor: "fight",
+    },
+    {
+      // hunt the last-seen position when the target is no longer visible (in memory
+      // but out of sight) — the F.E.A.R./Dive "search the last-known position" beat
+      name: "huntTo",
+      pre: F.and(F.lit("hasTarget"), F.not(F.lit("targetVisible"))),
+      eff: [E.setVec("myPos", [], N.ext("targetX", [], ["targetPos"]), N.ext("targetZ", [], ["targetPos"]), undefined, "planOnly")],
+      cost: N.add(N.dist("myPos", [], "targetPos", []), N.c(0.1)),
+      duration: N.div(N.add(N.dist("myPos", [], "targetPos", []), N.c(0.1)), N.c(MOVE_SPEED)),
+      executor: "hunt",
+    },
+    {
+      // roam to a tactical waypoint to look for opponents and items
+      name: "roamTo",
+      params: [{ name: "s", type: "spot" }],
+      pre: F.ext("isExplore", ["?s"], ["exploreSpot"]),
+      verify: F.ext("isExplore", ["?s"], ["exploreSpot"]),
+      eff: [E.setVec("myPos", [], N.ext("spotX", ["?s"], ["spotPos"]), N.ext("spotZ", ["?s"], ["spotPos"]), undefined, "planOnly")],
+      cost: N.add(N.dist("myPos", [], "spotPos", ["?s"]), N.c(0.1)),
+      duration: N.div(N.add(N.dist("myPos", [], "spotPos", ["?s"]), N.c(0.1)), N.c(MOVE_SPEED)),
+      executor: "roam",
+    },
+  ],
+  methods: [
+    // ---- root arbitration: Dive's four GoalEvaluators, ordered by desirability ----
+    {
+      // GET ITEM (health or weapon) — fires when an item is wanted; desirability is
+      // (need × nearness), computed by perception. Covers GetHealth + GetWeapon.
+      name: "getItem",
+      task: "Compete",
+      params: [{ name: "i", type: "item" }],
+      pre: F.and(F.lit("itemActive", ["?i"]), F.lit("itemWanted", ["?i"])),
+      utility: N.fl("itemDesire", "?i"),
+      subtasks: [{ do: "pickup", args: ["?i"] }],
+    },
+    {
+      // ATTACK — fight the current target; desirability is weaponStrength × health
+      name: "attack",
+      task: "Compete",
+      pre: F.lit("hasTarget"),
+      utility: N.fl("attackDesire"),
+      subtasks: [{ do: "Attack" }],
+    },
+    {
+      // EXPLORE — the low, constant-desirability default (always applicable)
+      name: "explore",
+      task: "Compete",
+      utility: N.c(0.1),
+      subtasks: [{ do: "Explore" }],
+    },
+    // ---- Attack: engage from sight, else hunt the last-seen position ----
+    {
+      name: "engage",
+      task: "Attack",
+      pre: F.and(F.lit("hasTarget"), F.lit("targetVisible")),
+      // keep firing WHILE we have a line of sight; losing it violates the scope and
+      // the planner re-decides (→ hunt) on the next beat
+      subtasks: [{ scope: { maintain: F.lit("targetVisible"), label: "in-sight" }, subtasks: [{ do: "fight" }] }],
+    },
+    {
+      name: "hunt",
+      task: "Attack",
+      pre: F.lit("hasTarget"),
+      subtasks: [{ do: "huntTo" }],
+    },
+    {
+      // there's a target fix but no actionable move right now → hold a short beat
+      name: "holdAttack",
+      task: "Attack",
+      pre: F.lit("hasTarget"),
+      subtasks: [{ hold: 0.3 }],
+    },
+    // ---- Explore: roam to the chosen waypoint, else idle briefly ----
+    {
+      name: "roam",
+      task: "Explore",
+      params: [{ name: "s", type: "spot" }],
+      pre: F.ext("isExplore", ["?s"], ["exploreSpot"]),
+      subtasks: [{ do: "roamTo", args: ["?s"] }],
+    },
+    {
+      name: "idle",
+      task: "Explore",
+      subtasks: [{ hold: 0.4 }],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------- registry / model per unit
+
+function buildBotModel(self: string, world: DiveWorld, items: ItemSpec[], spots: Vec2[]): Model {
+  const entities: Record<string, string> = {};
+  for (const it of items) entities[it.name] = "item";
+  const spotNames = spots.map((_, i) => `spot${i}`);
+  for (const s of spotNames) entities[s] = "spot";
+  return createModel(
+    diveDomain,
+    {
+      entities,
+      init: (w) => {
+        for (const it of items) {
+          w.set("itemPos", [it.name], [it.x, it.z]);
+          w.set("itemActive", [it.name], true);
+        }
+        for (let i = 0; i < spots.length; i++) w.set("spotPos", [spotNames[i]], [spots[i].x, spots[i].z]);
+        const me = world.actors.get(self);
+        if (me) {
+          w.set("myPos", [], [me.x, me.z]);
+          w.set("myHp", [], me.hp);
+        }
+      },
+    },
+    {
+      predicates: {
+        // is `s` the explore waypoint perception chose this beat? (entities encode gid+1)
+        isExplore: (q) => Math.round(q.get("exploreSpot")) === q.args[0] + 1,
+      },
+      numerics: {
+        itemX: (q) => q.vec("itemPos", q.args[0])[0],
+        itemZ: (q) => q.vec("itemPos", q.args[0])[1],
+        spotX: (q) => q.vec("spotPos", q.args[0])[0],
+        spotZ: (q) => q.vec("spotPos", q.args[0])[1],
+        targetX: (q) => q.vec("targetPos")[0],
+        targetZ: (q) => q.vec("targetPos")[1],
+        // expected damage of a shot at the target from my position (range falloff ×
+        // current weapon) — drives the planner toward closing for accuracy
+        shotDamage: (q) => {
+          const me = world.actors.get(self);
+          if (!me) return WEAPONS.blaster.damage;
+          const m = q.vec("myPos");
+          const t = q.vec("targetPos");
+          const w = WEAPONS[me.weapon];
+          const tf = Math.min(1, dist2(m[0], m[1], t[0], t[1]) / SIGHT_RANGE);
+          return w.damage * Math.max(0.12, w.accuracyClose + (w.accuracyFar - w.accuracyClose) * tf);
+        },
+      },
+      executors: {
+        pickup: moveExecutor(self, world, (api) => {
+          const it = world.items.find((x) => x.name === api.model.entityName(api.args[0]));
+          return it && it.active ? { x: it.x, z: it.z } : null;
+        }),
+        hunt: moveExecutor(self, world, () => world.actors.get(self)?.huntTarget ?? null),
+        roam: moveExecutor(self, world, (api) => {
+          const name = api.model.entityName(api.args[0]);
+          const i = Number(name.replace("spot", ""));
+          return spots[i] ?? null;
+        }),
+        fight: fightExecutor(self, world),
+      },
+    },
+  );
+}
+
+// ---------------------------------------------------------------- executors (enact on the world)
+
+/** A generic "walk to a point" executor. `resolve` yields the live destination (or
+ *  null → failure/repair). Motion is clock-based and pathfinds around obstacles. */
+function moveExecutor(self: string, world: DiveWorld, resolve: (api: ExecutorApi) => Vec2 | null): (api: ExecutorApi) => TaskStatus {
+  return (api) => {
+    const a = world.actors.get(self);
+    if (!a || !a.alive) return "failure";
+    const dst = resolve(api);
+    if (!dst) return "failure";
+    const mem = api.remember(() => ({ path: [{ x: a.x, z: a.z }, ...world.findPath(a.x, a.z, dst.x, dst.z)], t0: api.clock() })) as { path: Vec2[]; t0: number };
+    const traveled = (api.clock() - mem.t0) * MOVE_SPEED;
+    const at = walkPolyline(mem.path, traveled);
+    if (at.x !== a.x || at.z !== a.z) a.heading = Math.atan2(at.x - a.x, at.z - a.z);
+    a.x = at.x;
+    a.z = at.z;
+    if (at.done || dist2(a.x, a.z, dst.x, dst.z) <= PICKUP_RADIUS) return "success";
+    return "continue";
+  };
+}
+
+/** Fire the current weapon at the nearest visible enemy at the weapon's fire rate;
+ *  success on a kill, failure when the line of sight is lost (→ hunt). Mirrors Dive's
+ *  weapon-system "shoot" loop; weapon SELECTION happens in perception. */
+function fightExecutor(self: string, world: DiveWorld): (api: ExecutorApi) => TaskStatus {
+  return (api) => {
+    const a = world.actors.get(self);
+    if (!a || !a.alive) return "failure";
+    const target = world.nearestEnemy(self, true);
+    if (!target) return "failure"; // lost the shot → repair / hunt
+    a.heading = Math.atan2(target.x - a.x, target.z - a.z);
+    const mem = api.remember(() => ({ next: 0 })) as { next: number };
+    const el = api.elapsedInStep();
+    const fireTime = WEAPONS[a.weapon].fireTime;
+    // out of ammo on the selected weapon → drop to the blaster (always loaded)
+    if (a.weapon !== "blaster" && (a.ammo.get(a.weapon) ?? 0) <= 0) a.weapon = "blaster";
+    if (el >= mem.next) {
+      mem.next = el + fireTime;
+      world.fire(a, target, () => api.rng.next());
+      if (!target.alive) return "success"; // target down
+    }
+    return "continue";
+  };
+}
+
+// ---------------------------------------------------------------- belief write helpers
+
+function setBelief(p: BotPlanner, fluent: string, args: (string | number)[], value: number | string | boolean): void {
+  const gids = args.map((x) => (typeof x === "string" ? p.model.entityId(x) : x));
+  p.planner.state.set(p.model.slotOf(fluent, ...gids), p.model.encodeValue(fluent, value));
+}
+
+function setBeliefVec(p: BotPlanner, fluent: string, args: (string | number)[], x: number, z: number): void {
+  const gids = args.map((a) => (typeof a === "string" ? p.model.entityId(a) : a));
+  const slot = p.model.slotOf(fluent, ...gids);
+  p.planner.state.set(slot, x);
+  p.planner.state.set(slot + 1, z);
+}
+
+// ---------------------------------------------------------------- per-bot planner wrapper
+
+export interface BotPlanner {
+  name: string;
+  model: Model;
+  planner: PlannerT;
+  /** per-enemy memory: last-seen position / time / current visibility */
+  memory: Map<string, { x: number; z: number; lastSeen: number; visible: boolean; hp: number }>;
+  /** the explore waypoint currently being walked to (held stable until reached) */
+  exploreIdx: number | null;
+  trace: TraceEvent[];
+}
+
+// ---------------------------------------------------------------- frames (snapshot for the view)
+
+export interface BotFrame {
+  name: string;
+  color: string;
+  x: number;
+  z: number;
+  heading: number;
+  hp: number;
+  alive: boolean;
+  weapon: WeaponType;
+  ammo: number; // ammo of the current weapon (Infinity → -1)
+  frags: number;
+  deaths: number;
+  control: "ai" | "human";
+  /** label of the step currently executing */
+  step: string;
+  /** human-readable verb for what the bot is doing */
+  action: string;
+  /** the enemy it currently sees / is firing on */
+  sees: string | null;
+  goalText: string;
+  plan: string[];
+  events: string[];
+  replanning: boolean;
+}
+
+export interface ItemFrame {
+  name: string;
+  x: number;
+  z: number;
+  kind: "health" | "weapon";
+  weapon?: WeaponType;
+  active: boolean;
+}
+
+export interface DiveFrame {
+  clock: number;
+  halfWidth: number;
+  halfDepth: number;
+  bots: BotFrame[];
+  items: ItemFrame[];
+  obstacles: BoxSpec[];
+  spots: Vec2[];
+  shots: Shot[];
+  scoreboard: { name: string; color: string; frags: number; deaths: number }[];
+}
+
+export interface DiveSimOptions {
+  seed?: number;
+  /** fixed sim timestep in seconds */
+  dt?: number;
+  /** per-bot planning node budget per tick */
+  nodes?: number;
+  /** frag count that ends the match (offline rollout) */
+  fragLimit?: number;
+}
+
+/**
+ * Headless, deterministic deathmatch simulation: one reactive Planner per AI bot
+ * over a shared world, with a perception step between ticks. One bot can be handed
+ * to a human (control = "human") — its planner is dropped and its motion/fire come
+ * from `setInput`. Used verbatim by tests and the web preview.
+ */
+export class DiveSim {
+  public readonly world: DiveWorld;
+  public readonly bots = new Map<string, BotPlanner>();
+  public readonly trace: { unit: string; e: TraceEvent }[] = [];
+  public readonly spots: Vec2[];
+  private readonly items: ItemSpec[];
+  private readonly dt: number;
+  private readonly nodes: number;
+  private readonly fragLimit: number;
+  private readonly seed: number;
+  private seedBump = 0;
+  /** seeded RNG for explore-waypoint choice (kept separate from planner RNGs) */
+  private exploreRng: () => number;
+
+  constructor(inst: DiveInstance, opts: DiveSimOptions = {}) {
+    this.dt = opts.dt ?? 0.1;
+    this.nodes = opts.nodes ?? 20_000;
+    this.fragLimit = opts.fragLimit ?? Infinity;
+    this.seed = opts.seed ?? 1;
+    this.items = inst.items;
+    this.world = new DiveWorld(inst);
+    this.spots = generateSpots(inst);
+    this.exploreRng = mulberry32(this.seed * 7919 + 17);
+    for (const b of inst.bots) this.bots.set(b.name, this.buildPlanner(b.name));
+  }
+
+  private buildPlanner(name: string): BotPlanner {
+    const model = buildBotModel(name, this.world, this.items, this.spots);
+    const trace: TraceEvent[] = [];
+    const entry: BotPlanner = { name, model, planner: undefined as unknown as PlannerT, memory: new Map(), exploreIdx: null, trace };
+    entry.planner = new Planner(model, {
+      goals: [{ kind: "task", name: "Compete" }],
+      now: () => this.world.clock,
+      seed: this.seed + this.seedBump++,
+      weight: 1.4,
+      collectRejections: true,
+      trace: (e) => {
+        trace.push(e);
+        this.trace.push({ unit: name, e });
+      },
+    });
+    return entry;
+  }
+
+  /** hand a bot to a human (drops its planner) or back to the AI (rebuilds it). */
+  setControl(name: string, control: "ai" | "human"): void {
+    const a = this.world.actors.get(name);
+    if (!a || a.control === control) return;
+    a.control = control;
+    a.input = { moveX: 0, moveZ: 0, aim: a.heading, shoot: false };
+    if (control === "ai") {
+      this.bots.set(name, this.buildPlanner(name));
+    } else {
+      this.bots.delete(name);
+    }
+  }
+
+  /** set a human-controlled bot's input intent for the coming ticks. */
+  setInput(name: string, input: Partial<Combatant["input"]>): void {
+    const a = this.world.actors.get(name);
+    if (!a || a.control !== "human") return;
+    a.input = { ...a.input, ...input };
+  }
+
+  /** select the best weapon for the current target distance (Dive's fuzzy weapon
+   *  selection, here a simple rule table over ideal ranges among weapons with ammo). */
+  private selectWeapon(a: Combatant): void {
+    const target = this.world.nearestEnemy(a.name, true);
+    const d = target ? dist2(a.x, a.z, target.x, target.z) : Infinity;
+    let best: WeaponType = "blaster";
+    let bestScore = -Infinity;
+    for (const w of ALL_WEAPONS) {
+      if (w !== "blaster" && (a.ammo.get(w) ?? 0) <= 0) continue;
+      // prefer the weapon whose ideal range is closest to the engagement distance;
+      // a stronger weapon wins ties (more damage potential)
+      const score = -Math.abs(WEAPONS[w].idealRange - (isFinite(d) ? d : WEAPONS[w].idealRange)) + WEAPONS[w].damage * 0.1;
+      if (score > bestScore) {
+        bestScore = score;
+        best = w;
+      }
+    }
+    a.weapon = best;
+  }
+
+  // ---- perception: world (truth) → each bot's ExecState (belief) ----
+  private perceive(p: BotPlanner): void {
+    const a = this.world.actors.get(p.name);
+    if (!a) return;
+    setBeliefVec(p, "myPos", [], a.x, a.z);
+    setBelief(p, "myHp", [], a.hp);
+    setBelief(p, "weaponStrength", [], this.world.weaponStrength(a));
+
+    // weapon selection (the controller's job — runs before we reason about attacking)
+    this.selectWeapon(a);
+
+    // sight + memory: update the per-enemy record, then pick the target like Dive's
+    // TargetSystem — the closest visible foe, else the most-recently-seen within memory.
+    for (const e of this.world.enemiesOf(p.name)) {
+      const los = dist2(a.x, a.z, e.x, e.z) <= SIGHT_RANGE && this.world.losClear(a.x, a.z, e.x, e.z);
+      const rec = p.memory.get(e.name) ?? { x: e.x, z: e.z, lastSeen: -Infinity, visible: false, hp: MAX_HEALTH };
+      if (los) {
+        rec.x = e.x;
+        rec.z = e.z;
+        rec.lastSeen = this.world.clock;
+        rec.visible = true;
+        rec.hp = e.hp;
+      } else {
+        rec.visible = false;
+      }
+      p.memory.set(e.name, rec);
+    }
+    // drop stale / dead memories
+    for (const [name, rec] of p.memory) {
+      const e = this.world.actors.get(name);
+      if (!e || !e.alive || this.world.clock - rec.lastSeen > MEMORY_SECONDS) p.memory.delete(name);
+    }
+    // pick the target
+    let target: { name: string; rec: { x: number; z: number; visible: boolean; lastSeen: number; hp: number } } | null = null;
+    for (const [name, rec] of p.memory) {
+      if (rec.visible) {
+        if (!target || !target.rec.visible || dist2(a.x, a.z, rec.x, rec.z) < dist2(a.x, a.z, target.rec.x, target.rec.z)) target = { name, rec };
+      } else if (!target || (!target.rec.visible && rec.lastSeen > target.rec.lastSeen)) {
+        if (!target) target = { name, rec };
+      }
+    }
+    if (target) {
+      setBelief(p, "hasTarget", [], true);
+      setBelief(p, "targetVisible", [], target.rec.visible);
+      setBeliefVec(p, "targetPos", [], target.rec.x, target.rec.z);
+      setBelief(p, "targetHp", [], target.rec.hp);
+      a.huntTarget = { x: target.rec.x, z: target.rec.z };
+    } else {
+      setBelief(p, "hasTarget", [], false);
+      setBelief(p, "targetVisible", [], false);
+      a.huntTarget = null;
+    }
+
+    // attack desirability — Dive's AttackEvaluator: weaponStrength × health fraction
+    setBelief(p, "attackDesire", [], target ? this.world.weaponStrength(a) * (a.hp / MAX_HEALTH) : 0);
+
+    // items: desirability + "wanted" gate (GetHealth / GetWeapon evaluators)
+    const diag = Math.hypot(this.world.halfWidth * 2, this.world.halfDepth * 2);
+    for (const it of this.world.items) {
+      setBelief(p, "itemActive", [it.name], it.active);
+      const nearness = 1 - Math.min(1, dist2(a.x, a.z, it.x, it.z) / diag);
+      let wanted = false;
+      let desire = 0;
+      if (it.kind === "health") {
+        const deficit = 1 - a.hp / MAX_HEALTH;
+        wanted = it.active && a.hp < MAX_HEALTH * WANT_HEALTH_BELOW;
+        desire = deficit * nearness * 1.2;
+      } else if (it.weapon) {
+        const haveFrac = this.world.ammoFraction(a, it.weapon);
+        wanted = it.active && haveFrac < 0.999;
+        desire = (1 - haveFrac) * nearness * 0.8;
+      }
+      setBelief(p, "itemWanted", [it.name], wanted);
+      setBelief(p, "itemDesire", [it.name], desire);
+    }
+
+    // explore waypoint: keep the current one until reached, then pick a fresh random one
+    if (p.exploreIdx === null || dist2(a.x, a.z, this.spots[p.exploreIdx].x, this.spots[p.exploreIdx].z) <= PICKUP_RADIUS * 2) {
+      p.exploreIdx = Math.floor(this.exploreRng() * this.spots.length) % this.spots.length;
+    }
+    setBelief(p, "exploreSpot", [], `spot${p.exploreIdx}`);
+  }
+
+  /** drive a human-controlled bot from its input intent (no planner). */
+  private driveHuman(a: Combatant): void {
+    const inp = a.input;
+    const len = Math.hypot(inp.moveX, inp.moveZ);
+    if (len > 0.001) {
+      const nx = a.x + (inp.moveX / len) * MOVE_SPEED * this.dt;
+      const nz = a.z + (inp.moveZ / len) * MOVE_SPEED * this.dt;
+      const c = this.world.clampToArena(nx, nz);
+      a.x = c.x;
+      a.z = c.z;
+      a.heading = Math.atan2(inp.moveX, inp.moveZ);
+    }
+    this.selectWeapon(a);
+    if (inp.shoot) {
+      const target = this.world.nearestEnemy(a.name, true);
+      if (target) {
+        // gate fire rate via a lightweight per-actor clock stored on heading-free state
+        const w = WEAPONS[a.weapon];
+        const last = (a as unknown as { _lastShot?: number })._lastShot ?? -Infinity;
+        if (this.world.clock - last >= w.fireTime) {
+          (a as unknown as { _lastShot?: number })._lastShot = this.world.clock;
+          a.heading = Math.atan2(target.x - a.x, target.z - a.z);
+          this.world.fire(a, target, this.playerRng);
+        }
+      }
+    }
+  }
+  private playerRng = mulberry32(0xc0ffee);
+
+  /** advance the world one fixed step and return a snapshot. */
+  step(): DiveFrame {
+    this.world.clock += this.dt;
+    this.world.shots = [];
+
+    // respawns
+    for (const a of this.world.actors.values()) {
+      if (!a.alive && this.world.clock >= a.respawnAt) this.world.respawn(a);
+    }
+
+    // AI bots: perceive + plan; human bots: apply input
+    for (const a of this.world.actors.values()) {
+      if (!a.alive) continue;
+      if (a.control === "human") {
+        this.driveHuman(a);
+      } else {
+        const p = this.bots.get(a.name);
+        if (!p) continue;
+        this.perceive(p);
+        p.planner.tick({ nodes: this.nodes });
+      }
+    }
+
+    // item pickups (proximity) + respawns
+    for (const it of this.world.items) {
+      if (!it.active) {
+        if (this.world.clock >= it.respawnAt) it.active = true;
+        continue;
+      }
+      for (const a of this.world.actors.values()) {
+        if (a.alive && dist2(a.x, a.z, it.x, it.z) <= PICKUP_RADIUS) {
+          this.grant(a, it);
+          it.active = false;
+          it.respawnAt = this.world.clock + ITEM_RESPAWN;
+          break;
+        }
+      }
+    }
+
+    return this.snapshot();
+  }
+
+  private grant(a: Combatant, it: ItemState): void {
+    if (it.kind === "health") {
+      a.hp = Math.min(MAX_HEALTH, a.hp + HEALTH_PACK_AMOUNT);
+    } else if (it.weapon) {
+      a.ammo.set(it.weapon, WEAPONS[it.weapon].maxAmmo);
+    }
+  }
+
+  snapshot(): DiveFrame {
+    const bots: BotFrame[] = [];
+    for (const a of this.world.actors.values()) {
+      const p = this.bots.get(a.name);
+      const step = p?.planner.currentStep();
+      const stepLabel = step && step.k === "op" ? p!.model.describeGroundOp(step.g) : step ? step.k : "—";
+      const plan = p?.planner.getPlan();
+      const status = p?.planner.getStatus() ?? "—";
+      const sees = a.alive ? this.world.nearestEnemy(a.name, true)?.name ?? null : null;
+      bots.push({
+        name: a.name,
+        color: a.color,
+        x: round(a.x),
+        z: round(a.z),
+        heading: round(a.heading),
+        hp: round(a.hp),
+        alive: a.alive,
+        weapon: a.weapon,
+        ammo: isFinite(a.ammo.get(a.weapon) ?? Infinity) ? (a.ammo.get(a.weapon) as number) : -1,
+        frags: a.frags,
+        deaths: a.deaths,
+        control: a.control,
+        step: stepLabel,
+        action: a.control === "human" ? "you" : describeAction(stepLabel, status, a.alive, sees),
+        sees,
+        goalText: a.control === "human" ? "human player" : goalFor(stepLabel),
+        plan: p && plan ? planSummary(p.model, plan) : [],
+        events: p ? p.trace.slice(-6).map((e) => e.t) : [],
+        replanning: p ? p.trace.slice(-3).some((e) => e.t === "replan.dirty" || e.t === "repair.attempt") || status === "planning" : false,
+      });
+    }
+    return {
+      clock: round(this.world.clock),
+      halfWidth: this.world.halfWidth,
+      halfDepth: this.world.halfDepth,
+      bots,
+      items: this.world.items.map((it) => ({ name: it.name, x: it.x, z: it.z, kind: it.kind, weapon: it.weapon, active: it.active })),
+      obstacles: this.world.obstacles,
+      spots: this.spots,
+      shots: this.world.shots,
+      scoreboard: [...this.world.actors.values()]
+        .map((a) => ({ name: a.name, color: a.color, frags: a.frags, deaths: a.deaths }))
+        .sort((x, y) => y.frags - x.frags),
+    };
+  }
+
+  /** run the match to the frag limit or a step cap (offline rollout for tests). */
+  run(maxSteps = 2000): DiveFrame[] {
+    const frames: DiveFrame[] = [this.snapshot()];
+    for (let i = 0; i < maxSteps; i++) {
+      frames.push(this.step());
+      if (this.matchOver()) break;
+    }
+    return frames;
+  }
+
+  matchOver(): boolean {
+    return [...this.world.actors.values()].some((a) => a.frags >= this.fragLimit);
+  }
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** small deterministic PRNG (mulberry32) for explore-waypoint / player-fire rolls. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------- tactical waypoints
+
+/** Generate a coarse grid of walkable explore waypoints over the arena (skipping
+ *  cells inside obstacles) — the discrete positions the explore goal roams between. */
+export function generateSpots(inst: DiveInstance): Vec2[] {
+  const step = 6;
+  const pts: Vec2[] = [];
+  const insideObstacle = (x: number, z: number) => inst.obstacles.some((o) => x > o.x - 0.6 && x < o.x + o.w + 0.6 && z > o.z - 0.6 && z < o.z + o.d + 0.6);
+  for (let x = -inst.halfWidth + 2; x <= inst.halfWidth - 2; x += step) {
+    for (let z = -inst.halfDepth + 2; z <= inst.halfDepth - 2; z += step) {
+      if (!insideObstacle(x, z)) pts.push({ x: round(x), z: round(z) });
+    }
+  }
+  return pts;
+}
+
+// ---------------------------------------------------------------- view labels
+
+function describeAction(step: string, status: string, alive: boolean, sees: string | null): string {
+  if (!alive) return "respawning";
+  if (step.startsWith("fight")) return sees ? `firing on ${sees}` : "firing";
+  if (step.startsWith("huntTo")) return "hunting last-seen";
+  if (step.startsWith("pickup")) return "fetching item";
+  if (step.startsWith("roamTo")) return "exploring";
+  if (step === "hold" || step === "wait") return "holding";
+  if (status === "planning") return "thinking…";
+  return "exploring";
+}
+
+function goalFor(step: string): string {
+  if (step.startsWith("fight") || step.startsWith("huntTo")) return "Attack — neutralize the target";
+  if (step.startsWith("pickup")) return "Get item — health / weapon";
+  if (step.startsWith("roamTo")) return "Explore — roam the arena";
+  return "Compete";
+}
+
+// ---------------------------------------------------------------- instances
+
+/** The default arena: a square map with a central block, four corner cover boxes,
+ *  health in the middle, and the two special weapons on opposite flanks. 4 bots. */
+export function arenaInstance(): DiveInstance {
+  const colors = ["#ef4444", "#3b82f6", "#22c55e", "#eab308"];
+  return {
+    halfWidth: 18,
+    halfDepth: 18,
+    bots: [
+      { name: "Vela", x: -14, z: -14, color: colors[0] },
+      { name: "Orion", x: 14, z: 14, color: colors[1] },
+      { name: "Lyra", x: -14, z: 14, color: colors[2] },
+      { name: "Mira", x: 14, z: -14, color: colors[3] },
+    ],
+    items: [
+      { name: "health-c", x: 0, z: 0, kind: "health" },
+      { name: "health-n", x: 0, z: -13, kind: "health" },
+      { name: "health-s", x: 0, z: 13, kind: "health" },
+      { name: "shotgun-w", x: -13, z: 0, kind: "weapon", weapon: "shotgun" },
+      { name: "rifle-e", x: 13, z: 0, kind: "weapon", weapon: "rifle" },
+    ],
+    obstacles: [
+      { x: -3, z: -3, w: 6, d: 6 }, // central block
+      { x: -15, z: -1, w: 4, d: 2 }, // west nook
+      { x: 11, z: -1, w: 4, d: 2 }, // east nook
+      { x: -1, z: -15, w: 2, d: 4 }, // north nook
+      { x: -1, z: 11, w: 2, d: 4 }, // south nook
+    ],
+    spawns: [
+      { x: -15, z: -15 },
+      { x: 15, z: 15 },
+      { x: -15, z: 15 },
+      { x: 15, z: -15 },
+      { x: 0, z: -15 },
+      { x: 0, z: 15 },
+    ],
+  };
+}
+
+/** exposed for focused unit tests that build a single planner directly. */
+export function diveModel(inst: DiveInstance, self: string): Model {
+  const world = new DiveWorld(inst);
+  return buildBotModel(self, world, inst.items, generateSpots(inst));
+}

--- a/scenarios/index.ts
+++ b/scenarios/index.ts
@@ -6,3 +6,5 @@
 export * from "./blocks";
 export * from "./staircase";
 export * from "./squad-combat";
+// `dive` is imported via its subpath (../scenarios/dive) to avoid barrel name
+// collisions with squad-combat's shared constants (MOVE_SPEED, SIGHT_RANGE, …).

--- a/tests/dive.ts
+++ b/tests/dive.ts
@@ -1,0 +1,220 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import {
+  type DiveInstance,
+  DiveSim,
+  DiveWorld,
+  MAX_HEALTH,
+  WEAPONS,
+  arenaInstance,
+  diveModel,
+} from "../scenarios/dive";
+
+/**
+ * Dive — ground-truth assertions for the htn-ai deathmatch bot brain. These pin the
+ * behaviours the demo shows off, all driven by the real reactive Planner per bot:
+ * goal arbitration (attack / get-health / get-weapon / explore via method utility),
+ * fight-from-sight, hunt-the-last-seen, item pickups, weapon selection, death +
+ * respawn, and deterministic (seed + fixed timestep) replay.
+ */
+
+// the bot's executed step labels, in order
+function stepStarts(sim: DiveSim, unit: string): string[] {
+  return sim.trace.filter((t) => t.unit === unit && t.e.t === "step.start").map((t) => (t.e as { label: string }).label);
+}
+function ran(labels: string[], op: string): boolean {
+  return labels.some((l) => l.startsWith(op));
+}
+
+// ---------------------------------------------------------------- domain validity
+
+test("dive: the deathmatch domain compiles, grounds and binds", () => {
+  const inst: DiveInstance = {
+    halfWidth: 8,
+    halfDepth: 8,
+    bots: [{ name: "A", x: 0, z: 0 }],
+    items: [{ name: "h", x: 2, z: 2, kind: "health" }],
+    obstacles: [],
+    spawns: [{ x: 0, z: 0 }],
+  };
+  const model = diveModel(inst, "A");
+  assert.ok(model.operators.length >= 4, "operators compiled");
+  assert.ok(model.methodsByTask.has("Compete"), "root Compete task has methods");
+  assert.ok(model.methodsByTask.has("Attack"), "Attack compound has methods");
+});
+
+// ---------------------------------------------------------------- A: attack with line of sight
+
+test("dive: a bot with a visible enemy arbitrates to ATTACK and fires", () => {
+  // two bots in an empty arena with clear sight → both should pick the attack goal
+  const inst: DiveInstance = {
+    halfWidth: 10,
+    halfDepth: 10,
+    bots: [
+      { name: "A", x: -5, z: 0 },
+      { name: "B", x: 5, z: 0 },
+    ],
+    items: [],
+    obstacles: [],
+    spawns: [{ x: -9, z: -9 }, { x: 9, z: 9 }],
+  };
+  const sim = new DiveSim(inst, { seed: 3 });
+  for (let i = 0; i < 40; i++) sim.step();
+  assert.ok(ran(stepStarts(sim, "A"), "fight"), "A fired on the enemy it can see");
+});
+
+// ---------------------------------------------------------------- B: hunt the last-seen position
+
+test("dive: losing sight of a target makes the bot HUNT the last-seen position", () => {
+  // A sees B, then B is around a wall — A should switch from fight to hunt
+  const inst: DiveInstance = {
+    halfWidth: 12,
+    halfDepth: 12,
+    bots: [
+      { name: "A", x: -8, z: 0 },
+      { name: "B", x: 8, z: 0 },
+    ],
+    items: [],
+    obstacles: [{ x: -1, z: 1, w: 2, d: 8 }], // wall B can duck behind
+    spawns: [{ x: -10, z: -10 }, { x: 10, z: 10 }],
+  };
+  const sim = new DiveSim(inst, { seed: 5 });
+  // freeze B (a stationary dummy) so A's reaction is isolated and deterministic
+  sim.setControl("B", "human");
+  // let A acquire B in the open first (clear sight along z=0, below the wall)
+  for (let i = 0; i < 8; i++) sim.step();
+  // now move B behind the wall (out of A's sight) and keep stepping
+  const B = sim.world.actors.get("B")!;
+  B.x = 8;
+  B.z = 8;
+  for (let i = 0; i < 25; i++) sim.step();
+  assert.ok(ran(stepStarts(sim, "A"), "huntTo"), "A hunted B's last-seen position after losing sight");
+});
+
+// ---------------------------------------------------------------- C: get-health arbitration
+
+test("dive: a hurt bot near a health pack arbitrates to GET-HEALTH over explore", () => {
+  const inst: DiveInstance = {
+    halfWidth: 10,
+    halfDepth: 10,
+    bots: [{ name: "A", x: -4, z: 0 }],
+    items: [{ name: "med", x: 0, z: 0, kind: "health" }],
+    obstacles: [],
+    spawns: [{ x: -9, z: -9 }],
+  };
+  const sim = new DiveSim(inst, { seed: 1 });
+  sim.world.actors.get("A")!.hp = 30; // hurt → health desirability beats explore
+  for (let i = 0; i < 40; i++) sim.step();
+  assert.ok(ran(stepStarts(sim, "A"), "pickup"), "A went to fetch the health pack");
+  assert.ok(sim.world.actors.get("A")!.hp > 30, "A's health increased after pickup");
+});
+
+// ---------------------------------------------------------------- D: weapon pickup
+
+test("dive: a bot collects a weapon and refills its ammo (GET-WEAPON)", () => {
+  const inst: DiveInstance = {
+    halfWidth: 10,
+    halfDepth: 10,
+    bots: [{ name: "A", x: -3, z: 0 }],
+    items: [{ name: "sg", x: 0, z: 0, kind: "weapon", weapon: "shotgun" }],
+    obstacles: [],
+    spawns: [{ x: -9, z: -9 }],
+  };
+  const sim = new DiveSim(inst, { seed: 1 });
+  assert.is(sim.world.actors.get("A")!.ammo.get("shotgun"), 0, "starts with no shotgun ammo");
+  for (let i = 0; i < 40; i++) sim.step();
+  assert.is(sim.world.actors.get("A")!.ammo.get("shotgun"), WEAPONS.shotgun.maxAmmo, "shotgun ammo refilled by pickup");
+});
+
+// ---------------------------------------------------------------- E: explore when nothing else
+
+test("dive: an idle, healthy, weapon-full bot with no enemy EXPLORES", () => {
+  const inst: DiveInstance = {
+    halfWidth: 10,
+    halfDepth: 10,
+    bots: [{ name: "A", x: 0, z: 0 }],
+    items: [], // no items wanted → explore is the only positive goal
+    obstacles: [],
+    spawns: [{ x: -9, z: -9 }],
+  };
+  const sim = new DiveSim(inst, { seed: 1 });
+  for (let i = 0; i < 20; i++) sim.step();
+  assert.ok(ran(stepStarts(sim, "A"), "roamTo"), "A roamed the arena");
+});
+
+// ---------------------------------------------------------------- F: death + respawn
+
+test("dive: a killed bot respawns at full health after the respawn delay", () => {
+  const inst = arenaInstance();
+  const sim = new DiveSim(inst, { seed: 2, dt: 0.1 });
+  const victim = sim.world.actors.get("Vela")!;
+  const killer = sim.world.actors.get("Orion")!;
+  victim.hp = 1;
+  // force a kill through the world so the death/respawn machinery runs
+  killer.x = victim.x + 1;
+  killer.z = victim.z;
+  sim.world.fire(killer, victim, () => 0); // guaranteed hit
+  assert.is(victim.alive, false, "victim died");
+  assert.is(killer.frags, 1, "killer scored a frag");
+  for (let i = 0; i < 40; i++) sim.step(); // > RESPAWN_DELAY
+  assert.is(victim.alive, true, "victim respawned");
+  assert.is(victim.hp, MAX_HEALTH, "respawned at full health");
+});
+
+// ---------------------------------------------------------------- G: determinism
+
+test("dive: identical seed + fixed timestep ⇒ byte-identical rollouts", () => {
+  const run = () => {
+    const sim = new DiveSim(arenaInstance(), { seed: 9, dt: 0.1 });
+    const tail: string[] = [];
+    for (let i = 0; i < 120; i++) {
+      const f = sim.step();
+      tail.push(f.bots.map((b) => `${b.name}:${b.x},${b.z},${b.hp},${b.frags}`).join("|"));
+    }
+    return tail.join("\n");
+  };
+  assert.is(run(), run(), "two rollouts with the same seed match exactly");
+});
+
+// ---------------------------------------------------------------- H: a full 4-bot match runs
+
+test("dive: a 4-bot free-for-all runs and produces frags", () => {
+  const sim = new DiveSim(arenaInstance(), { seed: 4, dt: 0.1, fragLimit: 3 });
+  const frames = sim.run(3000);
+  const totalFrags = [...sim.world.actors.values()].reduce((s, a) => s + a.frags, 0);
+  assert.ok(frames.length > 1, "the match produced frames");
+  assert.ok(totalFrags > 0, "bots actually killed each other in the deathmatch");
+});
+
+// ---------------------------------------------------------------- I: human control swap
+
+test("dive: a bot can be swapped to human control and driven by input", () => {
+  const sim = new DiveSim(arenaInstance(), { seed: 1 });
+  sim.setControl("Vela", "human");
+  assert.is(sim.world.actors.get("Vela")!.control, "human");
+  assert.is(sim.bots.has("Vela"), false, "human bot has no planner");
+  const before = { ...sim.world.actors.get("Vela")! };
+  sim.setInput("Vela", { moveX: 1, moveZ: 0 });
+  for (let i = 0; i < 5; i++) sim.step();
+  assert.ok(sim.world.actors.get("Vela")!.x > before.x, "human input moved the bot");
+  // swap back to AI → planner rebuilt
+  sim.setControl("Vela", "ai");
+  assert.is(sim.bots.has("Vela"), true, "AI control rebuilt the planner");
+});
+
+// ---------------------------------------------------------------- J: world line-of-sight
+
+test("dive: obstacles block line of sight", () => {
+  const world = new DiveWorld({
+    halfWidth: 10,
+    halfDepth: 10,
+    bots: [],
+    items: [],
+    obstacles: [{ x: -1, z: -1, w: 2, d: 2 }],
+    spawns: [],
+  });
+  assert.is(world.losClear(-5, 0, 5, 0), false, "a wall on the line blocks sight");
+  assert.is(world.losClear(-5, 5, 5, 5), true, "an offset line is clear");
+});
+
+test.run();


### PR DESCRIPTION
## Summary

Introduces **Dive**, a real-time 4-bot free-for-all deathmatch arena scenario where every combatant is driven by an `htn-ai` reactive planner. The scenario mirrors the architecture of Mugen87's "Dive" demo (built on Yuka) but replaces its goal-evaluator trees with HTN task decomposition and utility-ordered method selection for arbitration.

## Key Changes

- **New scenario: `scenarios/dive.ts`** (~1170 lines)
  - Complete deathmatch simulation with ground-truth world state (`DiveWorld`), combatant kinematics, item pickups, weapon selection, death/respawn mechanics
  - HTN domain (`diveDomain`) with root `Compete` task whose methods encode Dive's four goal-evaluators (attack/get-health/get-weapon/explore) as utilities
  - Reactive planner per bot (`BotPlanner`) with perception layer that mirrors truth into belief (gated by line-of-sight and memory decay)
  - Executors bridge planning to continuous world: `moveExecutor` (pathfinding + kinematics), `fightExecutor` (weapon fire + hit resolution)
  - Deterministic, seeded simulation (`DiveSim`) with fixed timestep for reproducible replay
  - Weapon system (blaster/shotgun/rifle) with ammo, range-based accuracy, and damage falloff
  - Arena geometry: obstacles (axis-aligned boxes), spawn points, item respawn timers

- **Web preview: `examples/web/components/DiveScene.tsx`** (~228 lines)
  - Three.js/React Three Fiber 3D visualization of the arena, bots, items, and tracer shots
  - Real-time bot state display (health bar, weapon, action label, plan trace)
  - Interactive bot selection and human takeover (WASD + Space/click to fire)

- **Live sim hook: `examples/web/lib/useLiveDive.ts`** (~108 lines)
  - React hook driving a live `DiveSim` on a wall-clock interval
  - Supports mid-match human takeover/handoff without reset
  - Feeds human input (movement, aim, fire) into the running simulation

- **Tests: `tests/dive.ts`** (~220 lines)
  - Ground-truth assertions pinning bot behaviors: attack with line-of-sight, hunt last-seen position, health/weapon arbitration, explore, death/respawn
  - Deterministic replay validation via trace inspection

- **Integration**
  - Updated `examples/web/app/page.tsx` to register Dive scenario and wire up live sim hook
  - Updated `examples/web/README.md` with Dive scenario description
  - Updated `.gitignore` to exclude external reference repos (yuka/, dive/)
  - Updated `scenarios/index.ts` to note Dive's subpath import (avoids barrel name collisions)

## Notable Implementation Details

- **Belief/truth split**: Each planner's `ExecState` is the bot's working memory; perception gates updates by line-of-sight and decays memory over time (MEMORY_SECONDS)
- **Utility-ordered arbitration**: Root `Compete` task's four methods (getItem, attack, explore) are selected by utility expressions computed from belief (weaponStrength, attackDesire, itemDesire)
- **Reactive repair**: Executors report running/success/failure; lost line-of-sight or item pickup by another bot triggers re-planning on the next beat
- **Pathfinding**: Visibility graph over padded box corners + Dijkstra for obstacle avoidance
- **Deterministic**: Seeded RNG, fixed timestep, and trace logging enable reproducible replay and testing
- **Human integration**: One bot can be swapped to human control mid-match; planner is dropped, motion/fire come from keyboard/mouse input

https://claude.ai/code/session_01MGxRxs6iZhWmG6s1RiN54w