### PR TITLE
Protected goal-agenda serialization (sound subgoal commitment)

### DIFF
--- a/docs/goal-serialization.md
+++ b/docs/goal-serialization.md
@@ -57,6 +57,29 @@ interact.
 This is the soundness core of **agenda-driven / ordered-landmark planning**
 (cf. Koehler & Hoffmann, *On Reasonable and Forced Goal Orderings*, JAIR 2000).
 
+### `landmarks` — threshold landmarks for interfering build-up goals
+
+Protection keeps serialization *sound*, but per-cell serialization can still
+*fail* when the subgoals genuinely **interfere**. The worked example is the hard
+wall (`wallInstanceHard`): under realistic physics a ring cell can only be topped
+from a neighbour that's already been raised, so a lone 2-tall pillar is
+unbuildable and committing cell-by-cell strands cells the agent can't reach.
+
+The fix is **ordered landmarks**. A goal `f ≥ k` over a unit-step integer fluent
+(changed only by ±1) can only be reached by passing through `f ≥ 1, …, f ≥ k-1`
+— each lower threshold is a **landmark** (a fact every solution must establish
+first). With `landmarks: true` the agenda is expanded into these threshold
+landmarks and **ordered by level**: every cell's `≥ 1` before any cell's `≥ 2`.
+For the wall that means *the whole base course is laid before any top course*, so
+every upper course has a neighbour to stand on. The same hard instance that fails
+10/12 under plain serialization finishes 12/12 in tens of milliseconds.
+
+This is the agenda analogue of ordered landmarks in classical planning
+(Hoffmann/Porteous/Sebastia, *Ordered Landmarks in Planning*, JAIR 2004). The
+threshold landmarks (per fluent) are sound; the cross-variable *level* ordering is
+a "build the lower courses first" heuristic that matches the support structure of
+stacking domains.
+
 ## Soundness vs completeness — what we guarantee
 
 - **Sound:** with protection on (the default), the planner never reports success
@@ -65,16 +88,19 @@ This is the soundness core of **agenda-driven / ordered-landmark planning**
 - **Serializable-under-protection:** protected serialization solves any goal where
   some order lets each prefix be (re-)achieved while protecting the rest — which
   includes the classic non-serializable puzzles like Sussman.
+- **Interfering build-up goals:** `landmarks: true` decomposes numeric `f ≥ k`
+  goals into level-ordered threshold landmarks (base course before top course),
+  which solves the hard, interdependent wall that plain per-cell serialization
+  strands.
 - **Not a completeness guarantee in general.** In a *reactive* executor, commitment
   means *executed* actions, which can't be un-executed; a pathologically bad static
-  order could strand the planner (it then fails soundly). Two standard extensions
-  close the remaining gap and are good future work:
+  order could still strand the planner (it then fails soundly). Two further
+  extensions would close the remaining gap:
   - **Reasonable goal orderings** (Koehler-Hoffmann): derive an order so prefixes
-    stay achievable (for Sussman, order `on(b,c)` before `on(a,b)`), so even blind
-    serialization succeeds and protected serialization needs no re-work.
-  - **Landmark heuristics** (Hoffmann/Porteous/Sebastia 2004; LAMA): extract
-    intermediate landmarks and an LM-count/LM-cut heuristic to guide search and
-    derive orderings automatically.
+    stay achievable (for Sussman, order `on(b,c)` before `on(a,b)`) automatically,
+    rather than relying on the agenda's input order.
+  - **Landmark heuristics** (LAMA; LM-cut): use landmark counting/cost as a search
+    heuristic, and extract richer intermediate landmarks beyond numeric thresholds.
 
 ## When to reach for what
 
@@ -82,6 +108,7 @@ This is the soundness core of **agenda-driven / ordered-landmark planning**
 |---|---|
 | You can encode independence into the domain | Model it away first (e.g. the wall's source-gated `grab` + reach-one-up `place`) |
 | Subgoals serializable; speed > optimality | `goalAgenda` serialization (protection on) |
+| Build-up subgoals INTERFERE (top needs base) | `goalAgenda` + `landmarks` (threshold landmarks, base course first) |
 | Lots of interchangeable objects; need completeness/optimality | Symmetry breaking (orbit pruning) |
 | General goals; want a principled heuristic + ordering | Landmarks / factored planning |
 | You have reliable expert know-how on *how* | HTN control knowledge |

--- a/docs/goal-serialization.md
+++ b/docs/goal-serialization.md
@@ -1,0 +1,90 @@
+# Goal serialization & protection (combinatorial blow-up of conjunctive goals)
+
+A common, deceptively hard situation in planning: the goal is a **conjunction**
+`g₁ ∧ g₂ ∧ … ∧ gₙ` whose conjuncts are *individually easy* but, handed to one
+search, **blow up combinatorially**. The wall demo (`scenarios/wall.ts`) is the
+worked example — "every cell of this ring ends up two blocks tall" — but the
+shape is generic. This note explains why it blows up and what htn-ai does about
+it.
+
+## Why one joint search blows up
+
+Two independent causes compound (different techniques attack different ones):
+
+- **Depth.** The combined plan is long (the 12-cell, 2-tall wall is ≈ 96 steps).
+  Search cost is exponential in depth for any imperfect heuristic.
+- **Symmetry.** Blocks are interchangeable and target cells are interchangeable,
+  so every *ordering* of the n subgoals and every *block↔slot assignment* is a
+  distinct search path (~n! of them) that all collapse to the same essential
+  plan. A better heuristic sharpens the gradient but removes neither cause —
+  empirically, even very greedy weighted-A\* still dies on the flat 12-cell goal.
+
+The fix is **decomposition**, not a cleverer heuristic.
+
+## The technique: goal-agenda serialization (with protection)
+
+htn-ai's reactive `Planner` takes two related options:
+
+### `goalAgenda: true` — serialize the conjunction
+
+Treat the goal set as an ordered agenda and solve it **one subgoal at a time,
+committing** to each before the next (replanning from the reached state). A single
+*declarative* conjunctive goal `goal(a ∧ b ∧ …)` is **auto-split into its
+conjuncts** (`buildAgenda`, purely structural — the subgoals come from the goal's
+own form, nothing is prescribed). This turns one n!-symmetric, depth-96 search
+into n tiny depth-~7 searches: cost becomes **linear in cells** (the wall drops
+from ~56 s / intractable to ~0.2 s).
+
+### `protectAchieved` — keep it sound (default ON with `goalAgenda`)
+
+Plain serialization with commitment is **unsound** on *non-serializable* goals:
+it can report success after the last subgoal while an earlier one has been
+clobbered. The canonical case is the **Sussman anomaly** (`on(a,b)` and
+`on(b,c)`): achieving `on(b,c)` requires clearing `b`, which destroys `on(a,b)`.
+Blind serialization happily returns `on(b,c)` true and `on(a,b)` *false* —
+"succeeded" but wrong (see `tests/exec.ts`).
+
+Protection fixes this: when a subgoal is committed, every *later* subgoal's search
+goal becomes the **cumulative conjunction** of all subgoals achieved so far plus
+the current one. A later subgoal may pass *through* states that break an earlier
+one, but the committed result never violates it — the planner temporarily undoes
+and restores as correctness demands (for Sussman: unstack `a`, stack `b` on `c`,
+re-stack `a` on `b`). Because each step still starts from a state where the
+protected prefix already holds, protection is **nearly free when subgoals are
+independent** (it's never disturbed) and pays only for the local re-work when they
+interact.
+
+This is the soundness core of **agenda-driven / ordered-landmark planning**
+(cf. Koehler & Hoffmann, *On Reasonable and Forced Goal Orderings*, JAIR 2000).
+
+## Soundness vs completeness — what we guarantee
+
+- **Sound:** with protection on (the default), the planner never reports success
+  with the conjunction violated. If a subgoal genuinely can't be added from the
+  committed state, it reports `failed` — never a wrong result.
+- **Serializable-under-protection:** protected serialization solves any goal where
+  some order lets each prefix be (re-)achieved while protecting the rest — which
+  includes the classic non-serializable puzzles like Sussman.
+- **Not a completeness guarantee in general.** In a *reactive* executor, commitment
+  means *executed* actions, which can't be un-executed; a pathologically bad static
+  order could strand the planner (it then fails soundly). Two standard extensions
+  close the remaining gap and are good future work:
+  - **Reasonable goal orderings** (Koehler-Hoffmann): derive an order so prefixes
+    stay achievable (for Sussman, order `on(b,c)` before `on(a,b)`), so even blind
+    serialization succeeds and protected serialization needs no re-work.
+  - **Landmark heuristics** (Hoffmann/Porteous/Sebastia 2004; LAMA): extract
+    intermediate landmarks and an LM-count/LM-cut heuristic to guide search and
+    derive orderings automatically.
+
+## When to reach for what
+
+| Situation | Approach |
+|---|---|
+| You can encode independence into the domain | Model it away first (e.g. the wall's source-gated `grab` + reach-one-up `place`) |
+| Subgoals serializable; speed > optimality | `goalAgenda` serialization (protection on) |
+| Lots of interchangeable objects; need completeness/optimality | Symmetry breaking (orbit pruning) |
+| General goals; want a principled heuristic + ordering | Landmarks / factored planning |
+| You have reliable expert know-how on *how* | HTN control knowledge |
+
+The wall demo combines the first two: domain rules make the subgoals independent,
+and `goalAgenda` (with protection, free here) exploits it.

--- a/docs/goal-serialization.md
+++ b/docs/goal-serialization.md
@@ -80,6 +80,42 @@ threshold landmarks (per fluent) are sound; the cross-variable *level* ordering 
 a "build the lower courses first" heuristic that matches the support structure of
 stacking domains.
 
+### `heuristic: "lmcut"` — admissible landmark heuristic for *optimal* joint planning
+
+Serialization buys tractability by **sacrificing optimality**: committing to one
+subgoal at a time can force re-work that an all-at-once plan avoids. The Sussman
+anomaly is the clean measurement — serialized (and protected, so *sound*) it costs
+**10 actions; the optimal plan is 6**. Crucially this gap is *structural to
+serializing*, not an artifact we can tune away: neither reordering the two
+subgoals nor solving each subgoal optimally (weight 1) changes the 10 — both
+orders still commit `b`-on-`c` while `c` is on `a` and must tear it down. Only a
+**joint** search that sees the whole goal at once clears `a` first and finds the 6.
+
+So when you want optimality, you want the joint search — but the joint search is
+exactly what blows up (that's why we serialize). The bridge is a stronger
+**admissible** heuristic. The engine's default admissible heuristic is `h_max`,
+which is weak; `heuristic: "lmcut"` adds **LM-cut** (Helmert & Domshlak 2009),
+which repeatedly extracts *disjunctive action landmarks* (the cheapest action
+across each cut between the goal zone and the rest) and sums their costs. It
+**dominates `h_max`** while staying admissible, so weight-1 A\* still returns the
+optimal plan but expands a tiny fraction of the nodes. Measured on reversing an
+`N`-tower (optimal joint planning, weight 1):
+
+| instance | optimal cost | `h_max` expansions | `lmcut` expansions |
+|---|---|---|---|
+| Sussman | 6 | 12 | 10 |
+| reverse-7 | 14 | 107 | 15 |
+| reverse-8 | 16 | 347 | 17 |
+| reverse-9 | 18 | 1253 | **19** |
+
+LM-cut's expansions track the plan length (the heuristic is nearly perfect here)
+while `h_max` blows up — a 66× cut on reverse-9. That is what makes the optimal
+joint plan **affordable**: where you'd otherwise serialize and accept the
+suboptimal-but-sound result, an admissible landmark heuristic lets you take the
+optimal one for as long as the joint search stays in budget. It's an admissible
+search heuristic (`planOnce(..., { weight: 1, heuristic: "lmcut" })`), independent
+of and complementary to the agenda machinery above.
+
 ## Soundness vs completeness — what we guarantee
 
 - **Sound:** with protection on (the default), the planner never reports success
@@ -97,10 +133,13 @@ stacking domains.
   order could still strand the planner (it then fails soundly). Two further
   extensions would close the remaining gap:
   - **Reasonable goal orderings** (Koehler-Hoffmann): derive an order so prefixes
-    stay achievable (for Sussman, order `on(b,c)` before `on(a,b)`) automatically,
-    rather than relying on the agenda's input order.
-  - **Landmark heuristics** (LAMA; LM-cut): use landmark counting/cost as a search
-    heuristic, and extract richer intermediate landmarks beyond numeric thresholds.
+    stay achievable rather than relying on the agenda's input order. Note this does
+    *not* help the Sussman optimality gap — both orders cost 10 (above); it is a
+    *completeness/soundness-of-order* tool, not an optimality one.
+  - **Optimality via admissible search** — *implemented*: `heuristic: "lmcut"`
+    (above) makes optimal joint planning tractable, recovering the optimal plan
+    that serialization gives up. The open extension is using these discovered
+    landmarks to drive the *agenda* (cost-based ordering), not just the search.
 
 ## When to reach for what
 
@@ -108,6 +147,7 @@ stacking domains.
 |---|---|
 | You can encode independence into the domain | Model it away first (e.g. the wall's source-gated `grab` + reach-one-up `place`) |
 | Subgoals serializable; speed > optimality | `goalAgenda` serialization (protection on) |
+| Need the **optimal** plan; problem moderate-sized | joint search + `heuristic: "lmcut"` (weight 1) |
 | Build-up subgoals INTERFERE (top needs base) | `goalAgenda` + `landmarks` (threshold landmarks, base course first) |
 | Lots of interchangeable objects; need completeness/optimality | Symmetry breaking (orbit pruning) |
 | General goals; want a principled heuristic + ordering | Landmarks / factored planning |

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -26,7 +26,7 @@ const SquadScene = dynamic(() => import("../components/SquadScene"), { ssr: fals
 import SquadDirector from "../components/SquadDirector";
 
 type GridId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge";
-type ScenarioId = GridId | "blocks" | "wall" | SquadScenarioId;
+type ScenarioId = GridId | "blocks" | "wall" | "wallHard" | SquadScenarioId;
 type Kind = "grid" | "blocks" | "wall" | "squad";
 
 type Run =
@@ -48,12 +48,13 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string; kind: Kind }>
   scavengerHuge: { name: "Scavenger HUGE (~9s)", kind: "grid", blurb: "A 6×4 grid (24 cells) — a deliberate stress test (~9s to plan). Search is hard-capped so it can't run away." },
   blocks: { name: "Blocks World (Sussman)", kind: "blocks", blurb: "The classic Sussman anomaly: goal A-on-B-on-C. The naive order deadlocks, so the planner interleaves subgoals." },
   wall: { name: "Build a wall (structure goal)", kind: "wall", blurb: "The goal isn't a position to stand at — and it isn't a recipe either. It's one DECLARATIVE end-state: 'every cell of this octagonal ring ends up two blocks tall.' The domain has only goto / grab / place; nothing tells the agent to pick up or place anything. The planner DISCOVERS pickup-and-place by search. A single search over all 12 cells blows up, so the planner runs in goal-agenda mode: it splits the conjunction into per-cell subgoals and commits to them one at a time. Blocks come only from the scattered pile, so a laid block is never cannibalised — which is what makes serialising sound." },
+  wallHard: { name: "Build a wall — realistic physics (needs landmarks)", kind: "wall", blurb: "The SAME wall, same declarative goal — but realistic physics: the agent can't place a block above its own reach. Now a cell can only be topped from a neighbour that's already raised, so the cells INTERFERE: a lone 2-tall pillar is unbuildable, and per-cell serialization strands cells it can't reach. The fix is landmark layering — the planner derives that every cell's height-2 goal passes through height-1 first (a sound threshold landmark) and lays the WHOLE base course before any top course, so every upper course has a neighbour to stand on. This is the Sussman-like 'subgoals interfere, order matters' case made tractable." },
 };
 
 function buildRun(id: ScenarioId): Run {
   const kind = SCENARIOS[id].kind;
   if (kind === "blocks") return { kind: "blocks", data: runBlocks() };
-  if (kind === "wall") return { kind: "wall", data: runWall() };
+  if (kind === "wall") return { kind: "wall", data: runWall(id === "wallHard") };
   if (kind === "squad") return { kind: "squad", data: runSquad(id as SquadScenarioId) };
   return { kind: "grid", data: runScenario(id as GridId) };
 }
@@ -286,6 +287,11 @@ export default function Page() {
                 <div className="mono" style={{ color: "var(--muted)", marginTop: 8, fontSize: 11 }}>
                   <b style={{ color: "var(--accent-2)" }}>goalAgenda</b>: splits the conjunction into {run.data.targets.length} per-cell subgoals and commits to them one at a time. A flat search over all of them blows up; this stays linear.
                 </div>
+                {run.data.hard && (
+                  <div className="mono" style={{ color: "#fbbf24", marginTop: 8, fontSize: 11 }}>
+                    <b>landmarks</b>: realistic physics makes the cells interfere — a cell can only be topped from a raised neighbour. The planner derives that <span style={{ color: "var(--accent-2)" }}>height ≥ 2</span> passes through <span style={{ color: "var(--accent-2)" }}>height ≥ 1</span> (a threshold landmark) and lays the whole <b>base course before any top course</b>. Without it, per-cell serialization strands cells.
+                  </div>
+                )}
                 <div style={{ marginTop: 10, padding: "8px 10px", borderRadius: 8, background: "rgba(56,189,248,0.08)", border: "1px solid rgba(56,189,248,0.18)" }}>
                   <div className="mono" style={{ fontSize: 11, color: "var(--muted)" }}>now · subgoal {activeSlot}/{run.data.targets.length} (height(cell) ≥ {want})</div>
                   <div className="mono" style={{ marginTop: 2 }}><span style={{ color: phase.color }}>{phase.icon} {phase.text}</span></div>

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -24,6 +24,7 @@ const BlocksScene = dynamic(() => import("../components/BlocksScene"), { ssr: fa
 const WallScene = dynamic(() => import("../components/WallScene"), { ssr: false });
 const SquadScene = dynamic(() => import("../components/SquadScene"), { ssr: false });
 import SquadDirector from "../components/SquadDirector";
+import WallPanel from "../components/WallPanel";
 
 type GridId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge";
 type ScenarioId = GridId | "blocks" | "wall" | "wallHard" | SquadScenarioId;
@@ -137,7 +138,7 @@ export default function Page() {
 
         {run?.kind === "grid" && <StaircaseScene key="grid" frame={run.data.frames[step]} instance={run.data.instance} target={run.data.target} reached={step === lastStep && status === "succeeded"} />}
         {run?.kind === "blocks" && <BlocksScene key="blocks" frame={run.data.frames[step]} blocks={run.data.blocks} reached={step === lastStep} />}
-        {run?.kind === "wall" && <WallScene key="wall" frame={run.data.frames[step]} cells={run.data.cells} targets={run.data.targets} sources={run.data.sources} core={run.data.core} wantHeight={run.data.wantHeight} reached={step === lastStep && status === "succeeded"} />}
+        {run?.kind === "wall" && <WallScene key="wall" frame={run.data.frames[step]} cells={run.data.cells} targets={run.data.targets} sources={run.data.sources} core={run.data.core} wantHeight={run.data.wantHeight} reached={step === lastStep && status === "succeeded"} activeCell={run.data.subgoals[run.data.frames[Math.min(step, lastStep)]?.goalIndex ?? 0]?.cell ?? null} />}
         {squad && <SquadScene key="squad" frame={squad.frame} instance={squad.instance} selected={selected} onSelect={(n) => setSelected(n || null)} />}
 
         {squad && (
@@ -249,58 +250,7 @@ export default function Page() {
           </div>
         )}
 
-        {run?.kind === "wall" && (() => {
-          const f = run.data.frames[Math.min(step, lastStep)];
-          const want = run.data.wantHeight;
-          const totalBlocks = run.data.targets.length * want;
-          const blocksLaid = run.data.targets.reduce((n, c) => n + Math.min(f?.heights[c] ?? 0, want), 0);
-          const activeSlot = Math.min((f?.placed ?? 0) + 1, run.data.targets.length);
-          const phase = wallPhase(f?.action ?? "start", f?.holding ?? false);
-          return (
-            <>
-              <div className="card watch">
-                <h2>Goal · a structure, not a position</h2>
-                <div className="mono">{run.data.goalText}</div>
-                <ol style={{ marginTop: 8 }}>
-                  <li><b style={{ color: "#fbbf24" }}>amber wireframe</b> = a goal slot, {want} blocks tall, still to build</li>
-                  <li><b style={{ color: "#34d399" }}>green blocks</b> = wall laid · <b style={{ color: "#f59e0b" }}>orange</b> = scattered pile · <b style={{ color: "#a78bfa" }}>◆</b> = courtyard core</li>
-                </ol>
-                <div className="row" style={{ marginTop: 8, gap: 8 }}>
-                  <span className="mono" style={{ color: "var(--muted)", minWidth: 70 }}>blocks laid</span>
-                  <input type="range" min={0} max={totalBlocks} step={1} value={blocksLaid} readOnly style={{ flex: 1, accentColor: "#34d399" }} />
-                  <span className="mono" style={{ color: "#34d399" }}>{blocksLaid}/{totalBlocks}</span>
-                </div>
-                <div className="row" style={{ marginTop: 6, gap: 8 }}>
-                  <span className="mono" style={{ color: "var(--muted)", minWidth: 70 }}>slots done</span>
-                  <input type="range" min={0} max={run.data.targets.length} step={1} value={f?.placed ?? 0} readOnly style={{ flex: 1, accentColor: "#34d399" }} />
-                  <span className="mono" style={{ color: "#34d399" }}>{f?.placed ?? 0}/{run.data.targets.length}</span>
-                </div>
-              </div>
-
-              <div className="card">
-                <h2>How the planner solves it</h2>
-                <div className="mono" style={{ fontSize: 11, lineHeight: 1.7 }}>
-                  <div><span style={{ color: "var(--muted)" }}>goal (declarative):</span> <span style={{ color: "var(--accent-2)" }}>∧ height(cell) ≥ {want}</span> over {run.data.targets.length} cells</div>
-                  <div><span style={{ color: "var(--muted)" }}>domain ops:</span> <span style={{ color: "var(--accent)" }}>goto · grab · place</span> &nbsp;<span style={{ color: "var(--muted)" }}>// no &quot;build&quot; task</span></div>
-                  <div style={{ marginTop: 2 }}>planner <b style={{ color: "var(--accent-2)" }}>discovers</b> grab→carry→place per cell</div>
-                </div>
-                <div className="mono" style={{ color: "var(--muted)", marginTop: 8, fontSize: 11 }}>
-                  <b style={{ color: "var(--accent-2)" }}>goalAgenda</b>: splits the conjunction into {run.data.targets.length} per-cell subgoals and commits to them one at a time. A flat search over all of them blows up; this stays linear.
-                </div>
-                {run.data.hard && (
-                  <div className="mono" style={{ color: "#fbbf24", marginTop: 8, fontSize: 11 }}>
-                    <b>landmarks</b>: realistic physics makes the cells interfere — a cell can only be topped from a raised neighbour. The planner derives that <span style={{ color: "var(--accent-2)" }}>height ≥ 2</span> passes through <span style={{ color: "var(--accent-2)" }}>height ≥ 1</span> (a threshold landmark) and lays the whole <b>base course before any top course</b>. Without it, per-cell serialization strands cells.
-                  </div>
-                )}
-                <div style={{ marginTop: 10, padding: "8px 10px", borderRadius: 8, background: "rgba(56,189,248,0.08)", border: "1px solid rgba(56,189,248,0.18)" }}>
-                  <div className="mono" style={{ fontSize: 11, color: "var(--muted)" }}>now · subgoal {activeSlot}/{run.data.targets.length} (height(cell) ≥ {want})</div>
-                  <div className="mono" style={{ marginTop: 2 }}><span style={{ color: phase.color }}>{phase.icon} {phase.text}</span></div>
-                  <div className="mono" style={{ fontSize: 11, color: "var(--muted)", marginTop: 2 }}>{f?.action ?? "start"}</div>
-                </div>
-              </div>
-            </>
-          );
-        })()}
+        {run?.kind === "wall" && <WallPanel run={run.data} step={Math.min(step, lastStep)} />}
 
         <div className="card">
           <h2>Trace events {squad ? "· glass-box" : ""}</h2>
@@ -320,13 +270,4 @@ function outcome(f: SquadFrame): string {
   const dead = f.teams.filter((t) => t.alive === 0);
   if (dead.length) return `${teamName(dead[0].side)} eliminated`;
   return "engaging";
-}
-
-/** Map a raw wall action label to a human phase for the "now" readout. */
-function wallPhase(action: string, holding: boolean): { icon: string; text: string; color: string } {
-  if (action.startsWith("grab")) return { icon: "✋", text: "picking up a block from the pile", color: "#f59e0b" };
-  if (action.startsWith("place")) return { icon: "▮", text: "laying a block on the wall", color: "#34d399" };
-  if (action.startsWith("goto")) return holding ? { icon: "→", text: "carrying a block to the wall", color: "#38bdf8" } : { icon: "→", text: "walking to a block", color: "#38bdf8" };
-  if (action === "start") return { icon: "•", text: "planning the first placement", color: "var(--muted)" };
-  return { icon: "✓", text: "wall complete", color: "#34d399" };
 }

--- a/examples/web/components/WallPanel.tsx
+++ b/examples/web/components/WallPanel.tsx
@@ -1,0 +1,217 @@
+"use client";
+import { useEffect, useMemo, useRef } from "react";
+import type { WallRun, WallSubgoal } from "../lib/runWall";
+
+const VERB = {
+  goto: { color: "#38bdf8", icon: "→", label: "walk" },
+  grab: { color: "#f59e0b", icon: "✋", label: "pick up" },
+  place: { color: "#34d399", icon: "▮", label: "place" },
+  start: { color: "var(--muted)", icon: "•", label: "start" },
+} as const;
+
+function phaseText(verb: string, holding: boolean): string {
+  if (verb === "grab") return "picking up a block from the pile";
+  if (verb === "place") return "laying a block on the wall";
+  if (verb === "goto") return holding ? "carrying a block to the wall" : "walking to a block";
+  if (verb === "start") return "planning the first subgoal";
+  return "wall complete";
+}
+
+/** A small status dot for an agenda item. */
+function Dot({ state }: { state: "done" | "active" | "pending" }) {
+  const map = { done: "#34d399", active: "#38bdf8", pending: "#3a4763" } as const;
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: 12,
+        height: 12,
+        borderRadius: state === "active" ? 3 : 7,
+        background: map[state],
+        boxShadow: state === "active" ? "0 0 8px #38bdf8" : "none",
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+export default function WallPanel({ run, step }: { run: WallRun; step: number }) {
+  const last = run.frames.length - 1;
+  const f = run.frames[Math.min(step, last)];
+  const want = run.wantHeight;
+  const done = run.status === "succeeded" && step >= last;
+
+  // a subgoal is satisfied when the world (this frame) meets its threshold
+  const isDone = (s: WallSubgoal) => (s.cell ? (f.heights[s.cell] ?? 0) >= s.level : false);
+  const doneCount = run.subgoals.filter(isDone).length;
+  const activeIdx = f.goalIndex;
+  const activeCell = run.subgoals[activeIdx]?.cell ?? null;
+
+  // group agenda by level (base course / top course); levels appear in order
+  const groups = useMemo(() => {
+    const byLevel = new Map<number, { idx: number; s: WallSubgoal }[]>();
+    run.subgoals.forEach((s, idx) => {
+      const arr = byLevel.get(s.level) ?? [];
+      arr.push({ idx, s });
+      byLevel.set(s.level, arr);
+    });
+    return [...byLevel.entries()].sort((a, b) => a[0] - b[0]);
+  }, [run.subgoals]);
+
+  const blocksLaid = run.targets.reduce((n, c) => n + Math.min(f.heights[c] ?? 0, want), 0);
+  const totalBlocks = run.targets.length * want;
+
+  // auto-scroll the active agenda row + current plan row into view
+  const agendaActive = useRef<HTMLDivElement>(null);
+  const planActive = useRef<HTMLDivElement>(null);
+  useEffect(() => { agendaActive.current?.scrollIntoView({ block: "nearest" }); }, [activeIdx]);
+  useEffect(() => { planActive.current?.scrollIntoView({ block: "nearest" }); }, [step]);
+
+  const levelName = (level: number) =>
+    run.subgoals.some((s) => s.level !== level) ? (level === 1 ? "Base course" : level === 2 ? "Top course" : `Level ${level}`) : "Wall slots";
+
+  return (
+    <>
+      {/* ---- goal ---- */}
+      <div className="card">
+        <h2>Goal · a structure, not a position</h2>
+        <div className="mono">{run.goalText}</div>
+        <div className="row" style={{ marginTop: 8, gap: 8 }}>
+          <span className="mono" style={{ color: "var(--muted)", minWidth: 64 }}>blocks</span>
+          <div style={{ flex: 1, height: 8, borderRadius: 4, background: "#1a2233", overflow: "hidden" }}>
+            <div style={{ width: `${(blocksLaid / totalBlocks) * 100}%`, height: "100%", background: "#34d399", transition: "width .2s" }} />
+          </div>
+          <span className="mono" style={{ color: "#34d399" }}>{blocksLaid}/{totalBlocks}</span>
+        </div>
+      </div>
+
+      {/* ---- metrics ---- */}
+      <div className="card">
+        <h2>Planner · glass box</h2>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginBottom: 4 }}>
+          <Metric label="subgoals" value={`${doneCount}/${run.metrics.subgoals}`} accent="#34d399" />
+          <Metric label="actions" value={`${Math.max(step, 0)}/${run.metrics.actions}`} accent="#38bdf8" />
+          <Metric label="plans built" value={`${run.metrics.plansBuilt}`} accent="#a78bfa" />
+          <Metric label="goto·grab·place" value={`${run.metrics.verbs.goto}·${run.metrics.verbs.grab}·${run.metrics.verbs.place}`} accent="var(--muted)" />
+        </div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--muted)", marginTop: 6 }}>
+          one declarative goal → {run.metrics.subgoals} {run.hard ? "threshold landmarks" : "per-cell subgoals"}, each its own search ({run.metrics.plansBuilt} plans)
+        </div>
+      </div>
+
+      {/* ---- subgoal / landmark agenda ---- */}
+      <div className="card">
+        <h2>{run.hard ? "Landmark agenda" : "Subgoal agenda"}</h2>
+        <div style={{ maxHeight: 230, overflowY: "auto", margin: "0 -4px", padding: "0 4px" }}>
+          {groups.map(([level, items]) => (
+            <div key={level} style={{ marginBottom: 6 }}>
+              <div className="mono" style={{ fontSize: 10, letterSpacing: 0.5, textTransform: "uppercase", color: "var(--muted)", padding: "4px 2px 2px" }}>
+                {levelName(level)} <span style={{ color: "var(--accent-2)" }}>height ≥ {level}</span> · {items.filter((it) => isDone(it.s)).length}/{items.length}
+              </div>
+              {items.map(({ idx, s }) => {
+                const state = isDone(s) ? "done" : idx === activeIdx && !done ? "active" : "pending";
+                return (
+                  <div
+                    key={idx}
+                    ref={state === "active" ? agendaActive : undefined}
+                    className="mono"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "3px 6px",
+                      borderRadius: 5,
+                      fontSize: 11,
+                      background: state === "active" ? "rgba(56,189,248,0.12)" : "transparent",
+                      color: state === "pending" ? "var(--muted)" : "var(--text)",
+                    }}
+                  >
+                    <Dot state={state} />
+                    <span style={{ flex: 1 }}>{s.cell ?? s.text}</span>
+                    {state === "done" && s.steps > 0 && <span style={{ color: "var(--muted)" }}>{s.steps} ops</span>}
+                    {state === "active" && <span style={{ color: "#38bdf8" }}>building…</span>}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ---- now ---- */}
+      <div className="card">
+        <h2>Current step</h2>
+        <div style={{ padding: "8px 10px", borderRadius: 8, background: "rgba(56,189,248,0.08)", border: "1px solid rgba(56,189,248,0.18)" }}>
+          <div className="mono" style={{ fontSize: 11, color: "var(--muted)" }}>
+            subgoal {Math.min(activeIdx + 1, run.metrics.subgoals)}/{run.metrics.subgoals}
+            {activeCell && <> · {activeCell} → height ≥ {run.subgoals[activeIdx]?.level}</>}
+          </div>
+          <div className="mono" style={{ marginTop: 3, color: (VERB[f.verb as keyof typeof VERB] ?? VERB.start).color }}>
+            {(VERB[f.verb as keyof typeof VERB] ?? VERB.start).icon} {done ? "wall complete" : phaseText(f.verb, f.holding)}
+          </div>
+          <div className="mono" style={{ fontSize: 11, color: "var(--muted)", marginTop: 3 }}>{f.action}</div>
+        </div>
+      </div>
+
+      {/* ---- realized plan ---- */}
+      <div className="card">
+        <h2>Realized plan · {run.metrics.actions} actions <span className="mono" style={{ color: "var(--muted)", fontWeight: 400 }}>(discovered by search)</span></h2>
+        <div style={{ maxHeight: 220, overflowY: "auto", margin: "0 -4px", padding: "0 4px" }}>
+          {run.frames.slice(1).map((fr, i) => {
+            const n = i + 1; // action index (1-based)
+            const cur = n === step;
+            const v = VERB[fr.verb as keyof typeof VERB] ?? VERB.start;
+            return (
+              <div
+                key={n}
+                ref={cur ? planActive : undefined}
+                className="mono"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "2px 6px",
+                  borderRadius: 5,
+                  fontSize: 11,
+                  background: cur ? "rgba(56,189,248,0.14)" : "transparent",
+                  opacity: n > step ? 0.4 : 1,
+                }}
+              >
+                <span style={{ color: "var(--muted)", minWidth: 22, textAlign: "right" }}>{n}</span>
+                <span style={{ color: v.color, minWidth: 16 }}>{v.icon}</span>
+                <span style={{ flex: 1, color: cur ? "var(--text)" : "var(--muted)" }}>{fr.action}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ---- how it's solved ---- */}
+      <div className="card">
+        <h2>How the planner solves it</h2>
+        <div className="mono" style={{ fontSize: 11, lineHeight: 1.7 }}>
+          <div><span style={{ color: "var(--muted)" }}>goal (declarative):</span> <span style={{ color: "var(--accent-2)" }}>∧ height(cell) ≥ {want}</span></div>
+          <div><span style={{ color: "var(--muted)" }}>domain ops:</span> <span style={{ color: "var(--accent)" }}>goto · grab · place</span> <span style={{ color: "var(--muted)" }}>// no &quot;build&quot; task</span></div>
+          <div style={{ marginTop: 2 }}>planner <b style={{ color: "var(--accent-2)" }}>discovers</b> grab→carry→place per cell</div>
+        </div>
+        <div className="mono" style={{ color: "var(--muted)", marginTop: 8, fontSize: 11 }}>
+          <b style={{ color: "var(--accent-2)" }}>goalAgenda</b>: splits the conjunction into {run.targets.length} subgoals, committed one at a time — a flat search blows up; this stays linear.
+        </div>
+        {run.hard && (
+          <div className="mono" style={{ color: "#fbbf24", marginTop: 8, fontSize: 11 }}>
+            <b>landmarks</b>: realistic physics makes cells interfere — a cell can only be topped from a raised neighbour. The planner derives <span style={{ color: "var(--accent-2)" }}>height ≥ 2</span> passes through <span style={{ color: "var(--accent-2)" }}>height ≥ 1</span> (a threshold landmark) and lays the whole <b>base course before any top course</b>.
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function Metric({ label, value, accent }: { label: string; value: string; accent: string }) {
+  return (
+    <div style={{ padding: "6px 8px", borderRadius: 6, background: "#11192a", border: "1px solid #1c2740" }}>
+      <div className="mono" style={{ fontSize: 16, color: accent, lineHeight: 1.1 }}>{value}</div>
+      <div className="mono" style={{ fontSize: 10, color: "var(--muted)", textTransform: "uppercase", letterSpacing: 0.4 }}>{label}</div>
+    </div>
+  );
+}

--- a/examples/web/components/WallScene.tsx
+++ b/examples/web/components/WallScene.tsx
@@ -15,6 +15,29 @@ interface SceneProps {
   core: string;
   wantHeight: number;
   reached: boolean;
+  /** the cell whose subgoal is being worked right now — pulsed in the scene */
+  activeCell?: string | null;
+}
+
+/** A pulsing column of light over the cell the planner is currently working on. */
+function ActiveMarker({ pos }: { pos: THREE.Vector3 }) {
+  const ref = useRef<THREE.Mesh>(null);
+  useFrame((state) => {
+    const m = ref.current;
+    if (!m) return;
+    const s = 1 + Math.sin(state.clock.elapsedTime * 4) * 0.12;
+    m.scale.set(s, 1, s);
+    (m.material as THREE.MeshBasicMaterial).opacity = 0.35 + Math.sin(state.clock.elapsedTime * 4) * 0.15;
+  });
+  return (
+    <group position={pos}>
+      <mesh ref={ref} position={[0, 1.6, 0]}>
+        <cylinderGeometry args={[0.62, 0.62, 3.2, 20, 1, true]} />
+        <meshBasicMaterial color="#38bdf8" transparent opacity={0.4} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+      <pointLight color="#38bdf8" intensity={1.4} distance={3} position={[0, 1.2, 0]} />
+    </group>
+  );
 }
 
 function Agent({ target, holding }: { target: THREE.Vector3; holding: boolean }) {
@@ -122,7 +145,7 @@ function FloorCell({ x, z, isCore }: { x: number; z: number; isCore: boolean }) 
   );
 }
 
-function Scene({ frame, cells, targets, sources, core, wantHeight, reached }: SceneProps) {
+function Scene({ frame, cells, targets, sources, core, wantHeight, reached, activeCell }: SceneProps) {
   const targetSet = useMemo(() => new Set(targets), [targets]);
   const sourceSet = useMemo(() => new Set(sources), [sources]);
 
@@ -167,6 +190,11 @@ function Scene({ frame, cells, targets, sources, core, wantHeight, reached }: Sc
 
       <Agent target={agentTarget} holding={frame.holding} />
 
+      {activeCell && !reached && (() => {
+        const p = cellPos.get(activeCell);
+        return p ? <ActiveMarker pos={new THREE.Vector3(p[0], 0, p[1])} /> : null;
+      })()}
+
       {reached && (
         <mesh position={[center[0], 0.02, center[2]]} rotation={[-Math.PI / 2, 0, 0]}>
           <ringGeometry args={[span * 0.32, span * 0.34, 64]} />
@@ -181,7 +209,7 @@ function Scene({ frame, cells, targets, sources, core, wantHeight, reached }: Sc
   );
 }
 
-export default function WallScene(props: SceneProps) {
+export default function WallScene(props: SceneProps & { activeCell?: string | null }) {
   return (
     <Canvas shadows dpr={[1, 2]} gl={{ antialias: true }} style={{ background: "linear-gradient(180deg,#0d1320,#0b0e14)" }}>
       <Scene {...props} />

--- a/examples/web/lib/runWall.ts
+++ b/examples/web/lib/runWall.ts
@@ -8,10 +8,13 @@
  * The wall is handed over as ONE declarative goal (`∧ height(cell) ≥ 2`); the
  * domain has only goto/grab/place, so the planner DISCOVERS pickup-and-place by
  * search. The Planner runs in `goalAgenda` mode, which splits the conjunction into
- * per-cell subgoals and commits to them one at a time — the standard fix for a
- * conjunction of independent sub-goals that would otherwise blow up one-shot.
+ * per-cell subgoals (and, in hard mode, threshold landmarks) and commits to them
+ * one at a time.
+ *
+ * For the glass-box UI we also capture: the derived subgoal/landmark AGENDA, which
+ * subgoal each executed step served, and per-subgoal/plan metrics.
  */
-import { Planner, goal, type TraceEvent } from "htn-ai";
+import { Planner, goal, printFormula, type GoalSpec, type TraceEvent } from "htn-ai";
 import { wallGoal, wallInstance, wallInstanceHard, wallModel, type WallInstance } from "@scenarios/wall";
 
 export interface WallCell {
@@ -28,8 +31,35 @@ export interface WallFrame {
   holding: boolean;
   /** label of the action that produced this frame ("start" for the initial one) */
   action: string;
+  /** the action's verb: goto | grab | place | start */
+  verb: string;
   /** how many wall slots are fully laid (at wantHeight) in this frame */
   placed: number;
+  /** index into `subgoals` of the agenda item this step served */
+  goalIndex: number;
+}
+
+/** One item of the derived agenda — a per-cell subgoal or a threshold landmark. */
+export interface WallSubgoal {
+  /** human text, e.g. "height(c2_3) ≥ 1" */
+  text: string;
+  /** the cell it constrains, if any */
+  cell: string | null;
+  /** the target height (1 = base course, 2 = top course); 0 if not a threshold */
+  level: number;
+  /** number of executed steps that served this subgoal */
+  steps: number;
+}
+
+export interface WallMetrics {
+  /** agenda items (subgoals / landmarks) */
+  subgoals: number;
+  /** total executed actions in the realized plan */
+  actions: number;
+  /** how many distinct plans the planner built (one per subgoal + any repair) */
+  plansBuilt: number;
+  /** breakdown of executed actions by verb */
+  verbs: { goto: number; grab: number; place: number };
 }
 
 export interface WallRun {
@@ -43,11 +73,30 @@ export interface WallRun {
   /** how many blocks tall each wall slot must become */
   wantHeight: number;
   frames: WallFrame[];
+  /** the derived subgoal / landmark agenda, in serialization order */
+  subgoals: WallSubgoal[];
+  metrics: WallMetrics;
   status: string;
   trace: TraceEvent[];
   goalText: string;
   /** realistic-physics mode: cells interfere, solved by landmark layering */
   hard: boolean;
+}
+
+const verbOf = (label: string): string => label.split("(")[0] || "start";
+
+/** Parse a threshold-goal spec into {cell, level} for the agenda display. */
+function describeGoal(g: GoalSpec): { text: string; cell: string | null; level: number } {
+  if (g.kind !== "goal") return { text: g.name, cell: null, level: 0 };
+  const cond = g.condition;
+  let cell: string | null = null;
+  let level = 0;
+  if (cond.f === "cmp" && cond.a.n === "fluent" && cond.b.n === "const") {
+    const arg = cond.a.args[0];
+    if (arg && arg.t === "sym") cell = arg.name;
+    level = cond.b.value;
+  }
+  return { text: printFormula(cond).replace(/>=/g, "≥"), cell, level };
 }
 
 /**
@@ -79,7 +128,9 @@ export function runWall(hard = false): WallRun {
     trace: (e) => trace.push(e),
   });
 
-  const snap = (action: string): WallFrame => {
+  const subgoals: WallSubgoal[] = planner.agenda().map((g) => ({ ...describeGoal(g), steps: 0 }));
+
+  const snap = (action: string, goalIndex: number): WallFrame => {
     const heights = Object.fromEntries(cellNames.map((c) => [c, model.read(planner.state, "height", c) as number]));
     const placed = inst.targets.reduce((n, c) => n + (heights[c] >= want ? 1 : 0), 0);
     return {
@@ -88,20 +139,29 @@ export function runWall(hard = false): WallRun {
       agentY: model.read(planner.state, "agentY") as number,
       holding: model.read(planner.state, "holding") as boolean,
       action,
+      verb: verbOf(action),
       placed,
+      goalIndex,
     };
   };
 
-  const frames: WallFrame[] = [snap("start")];
+  const frames: WallFrame[] = [snap("start", 0)];
   for (let i = 0; i < 20000; i++) {
     const status = planner.getStatus();
     if (status === "succeeded" || status === "failed") break;
+    const gi = planner.activeGoalIndex(); // the subgoal being worked this tick
     t += 1;
     const before = trace.length;
     planner.tick({ ms: 30 }); // generous budget; runs offline, not per animation frame
     const done = trace.slice(before).find((e) => e.t === "step.done");
-    if (done && done.t === "step.done") frames.push(snap(done.label));
+    if (done && done.t === "step.done") {
+      if (subgoals[gi]) subgoals[gi].steps += 1;
+      frames.push(snap(done.label, gi));
+    }
   }
+
+  const verbs = { goto: 0, grab: 0, place: 0 };
+  for (const f of frames) if (f.verb in verbs) verbs[f.verb as keyof typeof verbs] += 1;
 
   return {
     cells: inst.cells.map((c) => ({ name: c.name, x: c.x, z: c.z })),
@@ -110,6 +170,13 @@ export function runWall(hard = false): WallRun {
     core: inst.core,
     wantHeight: want,
     frames,
+    subgoals,
+    metrics: {
+      subgoals: subgoals.length,
+      actions: frames.length - 1,
+      plansBuilt: trace.filter((e) => e.t === "plan.new").length,
+      verbs,
+    },
     status: planner.getStatus(),
     trace,
     goalText: `enclose the courtyard — a ${inst.targets.length}-slot wall, ${want} blocks tall`,

--- a/examples/web/lib/runWall.ts
+++ b/examples/web/lib/runWall.ts
@@ -12,7 +12,7 @@
  * conjunction of independent sub-goals that would otherwise blow up one-shot.
  */
 import { Planner, goal, type TraceEvent } from "htn-ai";
-import { wallGoal, wallInstance, wallModel, type WallInstance } from "@scenarios/wall";
+import { wallGoal, wallInstance, wallInstanceHard, wallModel, type WallInstance } from "@scenarios/wall";
 
 export interface WallCell {
   name: string;
@@ -46,10 +46,17 @@ export interface WallRun {
   status: string;
   trace: TraceEvent[];
   goalText: string;
+  /** realistic-physics mode: cells interfere, solved by landmark layering */
+  hard: boolean;
 }
 
-export function runWall(): WallRun {
-  const inst: WallInstance = wallInstance();
+/**
+ * @param hard when true, use realistic physics (no reach-up) so the wall cells
+ *   interfere — and switch the planner to `landmarks: true` so it lays the whole
+ *   base course before any top course (per-cell serialization alone can't finish).
+ */
+export function runWall(hard = false): WallRun {
+  const inst: WallInstance = hard ? wallInstanceHard() : wallInstance();
   const model = wallModel(inst);
   const cellNames = inst.cells.map((c) => c.name);
   const want = inst.wantHeight;
@@ -59,9 +66,12 @@ export function runWall(): WallRun {
   const planner = new Planner(model, {
     // ONE declarative goal: "every wall cell ends up wantHeight tall". goalAgenda
     // splits that conjunction into per-cell subgoals and serialises them; the
-    // planner discovers the goto/grab/place actions for each by search.
+    // planner discovers the goto/grab/place actions for each by search. In hard
+    // mode the cells interfere, so `landmarks` decomposes each cell's height goal
+    // into ordered threshold landmarks (base course before top course).
     goals: [goal(wallGoal(inst))],
     goalAgenda: true,
+    landmarks: hard,
     weight: 3,
     maxNodes: 200_000,
     now: () => t,
@@ -103,5 +113,6 @@ export function runWall(): WallRun {
     status: planner.getStatus(),
     trace,
     goalText: `enclose the courtyard — a ${inst.targets.length}-slot wall, ${want} blocks tall`,
+    hard,
   };
 }

--- a/scenarios/wall.ts
+++ b/scenarios/wall.ts
@@ -44,9 +44,19 @@ import type { CellSpec } from "./staircase";
  * The generic construction domain: just the primitive spatial actions. Nothing
  * here mentions a wall, a ring, or how to build anything — the desired shape lives
  * entirely in the declarative goal and in each cell's static `wantHeight`.
+ *
+ * `reachUp` controls the only physics knob that matters for the demo:
+ *   • true  — the agent may place a block ONE level above where it stands. A wall
+ *             cell can then be built to full height from the ground, so the cells
+ *             are INDEPENDENT (the easy wall; plain goal-agenda suffices).
+ *   • false — realistic: the agent must stand at ≥ the target column's height to
+ *             place. Topping a cell needs an adjacent cell already built up, so the
+ *             cells INTERFERE (the hard wall; needs landmark layering — base course
+ *             before top course).
  */
-export const constructionDomain: DomainDoc = {
-  name: "construction-world",
+function makeConstructionDomain(reachUp: boolean): DomainDoc {
+  return {
+  name: reachUp ? "construction-world" : "construction-world-strict",
   types: [{ name: "cell" }],
   fluents: [
     { name: "height", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 },
@@ -90,20 +100,28 @@ export const constructionDomain: DomainDoc = {
       cost: 1,
     },
     {
-      // drop the carried block on an adjacent cell, reaching up at most one level
+      // drop the carried block on an adjacent cell. With reachUp you may build one
+      // level above where you stand; without it you must stand at ≥ the target's
+      // height (so a cell can only be topped from an already-raised neighbour).
       name: "place",
       params: [{ name: "stand", type: "cell" }, { name: "at", type: "cell" }],
       pre: F.and(
         F.lit("holding"),
         F.lit("agentAt", [], "?stand"),
         F.lit("adj", ["?stand", "?at"]),
-        F.gte(N.fl("height", "?stand"), N.sub(N.fl("height", "?at"), N.c(1))),
+        F.gte(N.fl("height", "?stand"), reachUp ? N.sub(N.fl("height", "?at"), N.c(1)) : N.fl("height", "?at")),
       ),
       eff: [E.set("holding", [], false), E.inc("height", ["?at"], N.c(1))],
       cost: 1,
     },
   ],
-};
+  };
+}
+
+/** Easy physics: place reaches one level up, so wall cells are independent. */
+export const constructionDomain: DomainDoc = makeConstructionDomain(true);
+/** Realistic physics: no reach-up, so wall cells interfere (base before top). */
+export const strictConstructionDomain: DomainDoc = makeConstructionDomain(false);
 
 export interface WallInstance {
   /** the grid (floor tiles); a starting block is encoded as a cell `height` */
@@ -118,15 +136,19 @@ export interface WallInstance {
   sources: string[];
   /** the cell at the heart of the ring (the protected courtyard) — visual only */
   core: string;
+  /** realistic physics: no reach-up, so cells interfere and landmark layering is
+   *  needed (default false = the easy, independent wall) */
+  strictReach?: boolean;
 }
 
 /** Build a model for a construction instance over the generic domain. */
 export function wallModel(inst: WallInstance): Model {
   const entities: Record<string, string> = {};
   for (const c of inst.cells) entities[c.name] = "cell";
+  const domain = inst.strictReach ? strictConstructionDomain : constructionDomain;
   const sourceSet = new Set(inst.sources);
   const targetSet = new Set(inst.targets);
-  return createModel(constructionDomain, {
+  return createModel(domain, {
     entities,
     init: (w) => {
       for (const c of inst.cells) {
@@ -224,4 +246,16 @@ export function wallInstance(): WallInstance {
     sources: scattered.map(([x, z]) => nm(x, z)),
     core: nm(cx, cz),
   };
+}
+
+/**
+ * The HARD wall: the exact same courtyard fort, but under realistic physics
+ * (`strictReach`) — the agent can't place a block above its own reach. Now a ring
+ * cell can only be topped from an adjacent cell that's already been raised, so the
+ * 24 sub-goals INTERFERE: a lone 2-tall pillar is unbuildable, and per-cell
+ * serialization strands cells it can't reach. Solving it needs the base course
+ * laid before any top course — i.e. threshold-landmark layering (`landmarks: true`).
+ */
+export function wallInstanceHard(): WallInstance {
+  return { ...wallInstance(), strictReach: true };
 }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -93,6 +93,22 @@ export interface PlannerOptions {
    * demands. Defaults on whenever `goalAgenda` is set.
    */
   protectAchieved?: boolean;
+  /**
+   * Landmark decomposition of numeric build-up goals (goal-agenda only). A goal
+   * `f ≥ k` over a unit-step integer fluent (changed only by ±1) can only be
+   * reached by passing through `f ≥ 1, f ≥ 2, …` — each lower threshold is a
+   * sound *landmark* (a fact every solution must establish first). When set, the
+   * agenda is expanded into these threshold landmarks and **ordered by level**:
+   * every cell's `≥ 1` landmark before any cell's `≥ 2`, and so on.
+   *
+   * This matters when the build-up steps INTERFERE — e.g. a wall where placing a
+   * block's upper course requires standing on a neighbour's lower course. There,
+   * per-cell serialization fails (a lone 2-tall pillar is unbuildable in
+   * isolation), but laying the whole base course first (the level-ordered
+   * landmarks) makes every upper course reachable. It's the agenda analogue of
+   * ordered landmarks in classical planning (Hoffmann/Porteous/Sebastia 2004).
+   */
+  landmarks?: boolean;
 }
 
 export type PlannerStatus = "idle" | "planning" | "running" | "succeeded" | "failed";
@@ -114,6 +130,7 @@ export class Planner {
   private goalCursor = 0;
   private readonly goalAgenda: boolean;
   private readonly protectAchieved: boolean;
+  private readonly landmarks: boolean;
   private goals: GoalSpec[];
   private readonly nowFn: () => number;
   private readonly epoch: number;
@@ -140,6 +157,7 @@ export class Planner {
     this.goalAgenda = opts.goalAgenda ?? false;
     // protection defaults ON with goal-agenda so serialization is sound by default
     this.protectAchieved = opts.protectAchieved ?? this.goalAgenda;
+    this.landmarks = opts.landmarks ?? false;
     this.allGoals = this.buildAgenda(opts.goals ?? []);
     this.goalCursor = 0;
     this.goals = this.activeGoals();
@@ -164,15 +182,52 @@ export class Planner {
    *  whole (solved as one joint plan). */
   private buildAgenda(goals: GoalSpec[]): GoalSpec[] {
     if (!this.goalAgenda) return goals;
-    const out: GoalSpec[] = [];
+    // 1. split conjunctions into per-conjunct subgoals (tasks pass through)
+    const flat: GoalSpec[] = [];
     const pushGoal = (cond: Formula): void => {
       if (cond.f === "and") cond.parts.forEach(pushGoal);
-      else out.push({ kind: "goal", condition: cond });
+      else flat.push({ kind: "goal", condition: cond });
     };
     for (const g of goals) {
       if (g.kind === "goal") pushGoal(g.condition);
-      else out.push(g);
+      else flat.push(g);
     }
+    if (!this.landmarks) return flat;
+    return this.expandLandmarks(flat);
+  }
+
+  /** Expand unit-step numeric build-up goals (`f ≥ k`) into threshold landmarks
+   *  `f ≥ 1, …, f ≥ k` and order the agenda by level (every `≥ ℓ` before any
+   *  `≥ ℓ+1`). Non-numeric or single-level subgoals are appended unchanged. */
+  private expandLandmarks(flat: GoalSpec[]): GoalSpec[] {
+    /** if `cond` is `fluentExpr ≥/＞ const`, the integer height it must reach */
+    const targetOf = (cond: Formula): number | null => {
+      if (cond.f !== "cmp" || (cond.op !== ">=" && cond.op !== ">")) return null;
+      if (cond.b.n !== "const") return null;
+      const v = cond.b.value;
+      if (!Number.isFinite(v)) return null;
+      return cond.op === ">" ? Math.floor(v) + 1 : Math.ceil(v);
+    };
+    const levelGoal = (cond: Extract<Formula, { f: "cmp" }>, level: number): GoalSpec => ({
+      kind: "goal",
+      condition: { f: "cmp", op: ">=", a: cond.a, b: { n: "const", value: level } },
+    });
+
+    const thresholds: { cond: Extract<Formula, { f: "cmp" }>; target: number }[] = [];
+    const others: GoalSpec[] = [];
+    for (const g of flat) {
+      const t = g.kind === "goal" ? targetOf(g.condition) : null;
+      if (g.kind === "goal" && t !== null && t >= 2 && g.condition.f === "cmp") thresholds.push({ cond: g.condition, target: t });
+      else others.push(g);
+    }
+    if (thresholds.length === 0) return flat;
+
+    const maxLevel = thresholds.reduce((m, t) => Math.max(m, t.target), 0);
+    const out: GoalSpec[] = [];
+    for (let level = 1; level <= maxLevel; level++) {
+      for (const { cond, target } of thresholds) if (target >= level) out.push(levelGoal(cond, level));
+    }
+    out.push(...others); // booleans / single-level goals after the layered build-up
     return out;
   }
 

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -260,6 +260,13 @@ export class Planner {
     return this.allGoals.length;
   }
 
+  /** The derived subgoal agenda (read-only) — the conjuncts/landmarks the planner
+   *  serializes through, in order. Useful for glass-box UIs that visualize the
+   *  decomposition and progress. */
+  agenda(): readonly GoalSpec[] {
+    return this.allGoals;
+  }
+
   setTrace(fn: TraceFn): void {
     this.trace = fn;
   }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -76,6 +76,23 @@ export interface PlannerOptions {
    * state the planner reports `failed`; it never silently returns a wrong result.
    */
   goalAgenda?: boolean;
+  /**
+   * Protect already-achieved subgoals while serializing (goal-agenda only). When a
+   * subgoal is committed, every *later* subgoal's search must keep it true — its
+   * goal becomes the cumulative conjunction of all subgoals achieved so far plus
+   * the current one. This is the difference between *blind* serialization (which is
+   * unsound on non-serializable goals — it can report success while an earlier
+   * subgoal has been clobbered, e.g. the Sussman anomaly) and *protected*
+   * serialization, which stays sound: a later subgoal may pass *through* states
+   * that break an earlier one, but the committed result never violates it (the
+   * planner temporarily undoes and restores as needed).
+   *
+   * Each step still starts from a state where the protected prefix already holds,
+   * so when subgoals are independent the protection is nearly free (it isn't
+   * disturbed); when they interact it pays for the local re-work that correctness
+   * demands. Defaults on whenever `goalAgenda` is set.
+   */
+  protectAchieved?: boolean;
 }
 
 export type PlannerStatus = "idle" | "planning" | "running" | "succeeded" | "failed";
@@ -96,6 +113,7 @@ export class Planner {
   /** index of the subgoal currently being pursued in goal-agenda mode */
   private goalCursor = 0;
   private readonly goalAgenda: boolean;
+  private readonly protectAchieved: boolean;
   private goals: GoalSpec[];
   private readonly nowFn: () => number;
   private readonly epoch: number;
@@ -120,6 +138,8 @@ export class Planner {
     this.state = model.createExecState();
     this.rng = createRng(opts.seed ?? 0x12345678);
     this.goalAgenda = opts.goalAgenda ?? false;
+    // protection defaults ON with goal-agenda so serialization is sound by default
+    this.protectAchieved = opts.protectAchieved ?? this.goalAgenda;
     this.allGoals = this.buildAgenda(opts.goals ?? []);
     this.goalCursor = 0;
     this.goals = this.activeGoals();
@@ -156,12 +176,23 @@ export class Planner {
     return out;
   }
 
-  /** the subgoal actively being planned: a single agenda item in goal-agenda
-   *  mode, or the whole goal set otherwise. */
+  /** the subgoal actively being planned: in goal-agenda mode, the current agenda
+   *  item — conjoined with every already-achieved goal-subgoal when protection is
+   *  on, so committing the current one cannot clobber an earlier one. Outside
+   *  goal-agenda mode, the whole goal set (one joint plan). */
   private activeGoals(): GoalSpec[] {
     if (!this.goalAgenda) return this.allGoals;
     const g = this.allGoals[this.goalCursor];
-    return g ? [g] : [];
+    if (!g) return [];
+    if (this.protectAchieved && g.kind === "goal") {
+      const parts: Formula[] = [];
+      for (let i = 0; i <= this.goalCursor; i++) {
+        const gi = this.allGoals[i];
+        if (gi.kind === "goal") parts.push(gi.condition);
+      }
+      if (parts.length > 1) return [{ kind: "goal", condition: { f: "and", parts } }];
+    }
+    return [g];
   }
 
   /** In goal-agenda mode, the index of the subgoal currently being pursued, and

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export {
   PlanningSession,
   planOnce,
   hAdd,
+  lmcut,
   type Plan,
   type PlanStep,
   type PlanRequest,

--- a/src/search.ts
+++ b/src/search.ts
@@ -122,8 +122,11 @@ export interface PlanRequest {
   collectRejections?: boolean;
   /** novelty tie-breaking on goal-search open lists */
   novelty?: boolean;
-  /** goal-search heuristic: h_add (fast, may overestimate — default), h_max (admissible: use with weight 1 for guaranteed-optimal plans), or none (Dijkstra) */
-  heuristic?: "hadd" | "hmax" | "none";
+  /** goal-search heuristic: h_add (fast, may overestimate — default), h_max
+   *  (admissible, weak), lmcut (admissible, stronger — fewest expansions for
+   *  optimal/weight-1 search), or none (Dijkstra). Pair an admissible heuristic
+   *  with weight 1 for guaranteed-optimal plans. */
+  heuristic?: "hadd" | "hmax" | "lmcut" | "none";
   /** internal: plan a pre-built agenda instead of `goals` (used by plan repair) */
   agendaOverride?: Agenda;
 }
@@ -337,6 +340,166 @@ export function hAdd(model: Model, s: Snap, goalAtoms: Atom[], mode: "add" | "ma
   return relaxCore(model, snapToFlat(model, s), new Float64Array(model.relaxAtomCount), goalDescs(model, goalAtoms), mode === "add");
 }
 
+// ------------------------------------------------------- LM-cut landmark heuristic
+
+/**
+ * The model's delete-relaxation in the propositional form LM-cut needs, built once
+ * per model and reused: every ground operator (with an add effect) becomes an
+ * action with precondition/add atom-id lists over the interned relaxation atoms,
+ * plus two artificial atoms — a unique source `INIT` (precondition of any action
+ * that has no real preconditions) and a sink `GOAL`. Fuzzy (numeric/external)
+ * atoms are dropped from preconditions and treated as free, exactly as the h_max
+ * core treats them optimistically; this keeps LM-cut an admissible lower bound.
+ */
+interface LmcutStatic {
+  pre: Int32Array[]; // per action: precondition atom ids (≥1, INIT if otherwise empty)
+  add: Int32Array[]; // per action: add atom ids
+  nReal: number; // count of real relaxation atoms; GOAL = nReal, INIT = nReal+1
+}
+const lmcutStaticCache = new WeakMap<Model, LmcutStatic>();
+function lmcutStatic(model: Model): LmcutStatic {
+  const cached = lmcutStaticCache.get(model);
+  if (cached) return cached;
+  const nReal = model.relaxAtomCount;
+  const INIT = nReal + 1;
+  const fuzzy = model.relaxAtomFuzzy;
+  const pre: Int32Array[] = [];
+  const add: Int32Array[] = [];
+  for (const g of model.groundOps) {
+    const addIds = g.addIds as Int32Array;
+    if (addIds.length === 0) continue;
+    const preIds = g.preIds as Int32Array;
+    const fp: number[] = [];
+    for (let i = 0; i < preIds.length; i++) if (!fuzzy[preIds[i]]) fp.push(preIds[i]);
+    if (fp.length === 0) fp.push(INIT);
+    pre.push(Int32Array.from(fp));
+    add.push(addIds);
+  }
+  const st: LmcutStatic = { pre, add, nReal };
+  lmcutStaticCache.set(model, st);
+  return st;
+}
+
+/**
+ * LM-cut (Helmert & Domshlak 2009): an admissible landmark heuristic over the
+ * delete relaxation. Repeatedly computes h_max (with a precondition-choice
+ * function), extracts the cut between the goal zone and the rest, charges the
+ * cheapest action in that cut (a disjunctive action landmark), and subtracts it —
+ * until h_max reaches 0. The summed cut costs are an admissible estimate that
+ * dominates h_max, so weighted-A* with weight 1 stays optimal while expanding far
+ * fewer nodes on goals h_max under-informs (interacting subgoals, deep rework).
+ */
+function lmcutCore(model: Model, flat: Float64Array, goals: GoalAtomDesc[], st: LmcutStatic): number {
+  const nReal = st.nReal;
+  const GOAL = nReal;
+  const INIT = nReal + 1;
+  const nAtoms = nReal + 2;
+  const aSlot = model.relaxAtomSlot;
+  const aVal = model.relaxAtomValue;
+
+  // The artificial goal action's preconditions = the real goal atoms. Mirror the
+  // h_max core's optimism for atoms no operator can produce: a satisfied or fuzzy
+  // one is free; a non-fuzzy unreachable one makes the goal unreachable.
+  const goalPre: number[] = [];
+  for (const g of goals) {
+    if (g.id >= 0) goalPre.push(g.id);
+    else if (flat[g.slot] === g.value || g.fuzzy) continue;
+    else return Infinity;
+  }
+  const M = st.pre.length; // real actions; the goal action is index M
+  const nActions = M + 1;
+  const goalPreArr = Int32Array.from(goalPre);
+  const goalAddArr = Int32Array.from([GOAL]);
+  const preOf = (a: number): Int32Array => (a < M ? st.pre[a] : goalPreArr);
+  const addOf = (a: number): Int32Array => (a < M ? st.add[a] : goalAddArr);
+
+  const cost = new Float64Array(nActions).fill(1);
+  cost[M] = 0; // the goal action is free
+
+  const hmax = new Float64Array(nAtoms);
+  const supporter = new Int32Array(nActions); // precondition-choice function (per action)
+  const inZone = new Uint8Array(nAtoms);
+  let h = 0;
+
+  for (let iter = 0; iter < 100000; iter++) {
+    // --- h_max with precondition choice (supporter = costliest precondition) ---
+    hmax.fill(Infinity);
+    hmax[INIT] = 0;
+    for (let id = 0; id < nReal; id++) if (flat[aSlot[id]] === aVal[id]) hmax[id] = 0;
+    supporter.fill(-1);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (let a = 0; a < nActions; a++) {
+        const pr = preOf(a);
+        let mx = 0;
+        let sup = -1;
+        let ok = true;
+        for (let i = 0; i < pr.length; i++) {
+          const hv = hmax[pr[i]];
+          if (hv === Infinity) { ok = false; break; }
+          if (hv >= mx) { mx = hv; sup = pr[i]; }
+        }
+        if (!ok) continue;
+        if (sup === -1) sup = INIT; // empty precondition ⇒ supported by the source
+        supporter[a] = sup;
+        const through = cost[a] + mx;
+        const ad = addOf(a);
+        for (let i = 0; i < ad.length; i++) {
+          if (through < hmax[ad[i]]) { hmax[ad[i]] = through; changed = true; }
+        }
+      }
+    }
+    const hg = hmax[GOAL];
+    if (hg === Infinity) return Infinity;
+    if (hg === 0) break;
+
+    // --- goal zone: atoms reaching GOAL through zero-cost supporter edges ---
+    inZone.fill(0);
+    inZone[GOAL] = 1;
+    changed = true;
+    while (changed) {
+      changed = false;
+      for (let a = 0; a < nActions; a++) {
+        const sup = supporter[a];
+        if (sup < 0 || cost[a] !== 0 || inZone[sup]) continue;
+        const ad = addOf(a);
+        for (let i = 0; i < ad.length; i++) {
+          if (inZone[ad[i]]) { inZone[sup] = 1; changed = true; break; }
+        }
+      }
+    }
+
+    // --- cut: reachable actions whose supporter is outside the zone but that add
+    //     into it; charge the cheapest and subtract it from each (a landmark) ---
+    let m = Infinity;
+    const cut: number[] = [];
+    for (let a = 0; a < nActions; a++) {
+      const sup = supporter[a];
+      if (sup < 0 || inZone[sup]) continue;
+      const ad = addOf(a);
+      let crosses = false;
+      for (let i = 0; i < ad.length; i++) if (inZone[ad[i]]) { crosses = true; break; }
+      if (!crosses) continue;
+      cut.push(a);
+      if (cost[a] < m) m = cost[a];
+    }
+    if (cut.length === 0 || !(m > 0) || m === Infinity) break; // safety; shouldn't happen
+    h += m;
+    for (const a of cut) cost[a] -= m;
+  }
+  return h;
+}
+
+/**
+ * Public LM-cut heuristic (admissible; dominates {@link hAdd} in `max` mode).
+ * Allocates scratch per call; the Engine reuses a faster cached path.
+ */
+export function lmcut(model: Model, s: Snap, goalAtoms: Atom[]): number {
+  if (goalAtoms.length === 0) return 0;
+  return lmcutCore(model, snapToFlat(model, s), goalDescs(model, goalAtoms), lmcutStatic(model));
+}
+
 // ---------------------------------------------------------------- engine
 
 interface MtrCursor {
@@ -367,6 +530,8 @@ export class Engine {
   private costBuf: Float64Array | null = null;
   /** reusable flat state buffer for O(1) reads during heuristic evaluation */
   private flatBuf: Float64Array | null = null;
+  /** memoized LM-cut relaxation (built once per model) */
+  private lmStatic: LmcutStatic | null = null;
   /** reusable candidate-op scratch for the indexed successor generator */
   private readonly succScratch: GroundOp[] = [];
 
@@ -785,7 +950,10 @@ export class Engine {
       this.flatBuf = new Float64Array(this.model.slotCount);
     }
     state.materializeInto(this.flatBuf);
-    const h = relaxCore(this.model, this.flatBuf, this.costBuf, descs, this.req.heuristic !== "hmax");
+    const h =
+      this.req.heuristic === "lmcut"
+        ? lmcutCore(this.model, this.flatBuf, descs, (this.lmStatic ??= lmcutStatic(this.model)))
+        : relaxCore(this.model, this.flatBuf, this.costBuf, descs, this.req.heuristic !== "hmax");
     this.hCache.set(key, h);
     return h;
   }

--- a/tests/exec.ts
+++ b/tests/exec.ts
@@ -325,4 +325,33 @@ test("goalAgenda: protection is enabled by default whenever goalAgenda is set", 
   assert.ok(bothOn(model, planner));
 });
 
+// ---------------------------------------------------------------- landmark decomposition
+
+test("landmarks: a numeric build-up goal expands into level-ordered threshold landmarks", () => {
+  // two cells, each needing height ≥ 2. With landmarks, the goal h(a)≥2 ∧ h(b)≥2
+  // becomes the level-ordered agenda [a≥1, b≥1, a≥2, b≥2] — base course before top.
+  const doc: DomainDoc = {
+    name: "stack",
+    types: [{ name: "cell" }],
+    fluents: [{ name: "h", params: [{ name: "c", type: "cell" }], kind: "int", initial: 0 }],
+    operators: [{ name: "raise", params: [{ name: "c", type: "cell" }], eff: [E.inc("h", ["?c"], N.c(1))] }],
+  };
+  const model = createModel(doc, { entities: { a: "cell", b: "cell" } });
+  const buildUp = goal(F.and(F.gte(N.fl("h", "a"), N.c(2)), F.gte(N.fl("h", "b"), N.c(2))));
+
+  // without landmarks: 2 conjuncts (one per cell)
+  const plain = new Planner(model, { goals: [buildUp], goalAgenda: true, now: () => 0, seed: 1 });
+  assert.equal(plain.goalCount(), 2);
+
+  // with landmarks: 4 threshold landmarks, ordered by level
+  const lm = new Planner(model, { goals: [buildUp], goalAgenda: true, landmarks: true, now: () => 0, seed: 1 });
+  assert.equal(lm.goalCount(), 4, "h(a)≥2 ∧ h(b)≥2 → [a≥1, b≥1, a≥2, b≥2]");
+
+  // and it still solves (each raise op bumps height by one)
+  for (let i = 0; i < 200 && lm.getStatus() !== "succeeded" && lm.getStatus() !== "failed"; i++) lm.tick({ ms: 5 });
+  assert.equal(lm.getStatus(), "succeeded");
+  assert.equal(model.read(lm.state, "h", "a"), 2);
+  assert.equal(model.read(lm.state, "h", "b"), 2);
+});
+
 test.run();

--- a/tests/exec.ts
+++ b/tests/exec.ts
@@ -14,6 +14,7 @@ import {
   planOnce,
   task,
 } from "../src/index";
+import { blocksModel, sussmanSetup } from "../scenarios/blocks";
 
 // ---------------------------------------------------------------- suffix repair from the failure point
 
@@ -286,6 +287,42 @@ test("goalAgenda off (default): the same goals are pursued as one joint plan", (
   // without goal-agenda the cursor never advances (it's not in serialization mode)
   assert.equal(planner.activeGoalIndex(), 0);
   for (const i of ids) assert.equal(model.read(planner.state, `on${i}`), true);
+});
+
+// ---------------------------------------------------------------- protected serialization (non-serializable goals)
+
+const sussmanGoal = goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")));
+const bothOn = (model: ReturnType<typeof blocksModel>, p: Planner): boolean =>
+  model.read(p.state, "on", "a") === "b" && model.read(p.state, "on", "b") === "c";
+const drive = (p: Planner): void => {
+  for (let i = 0; i < 5000 && p.getStatus() !== "succeeded" && p.getStatus() !== "failed"; i++) p.tick({ ms: 20 });
+};
+
+test("goalAgenda: BLIND serialization (protectAchieved:false) is UNSOUND on the Sussman anomaly", () => {
+  // C-on-A, A,B on table; goal on(a,b) ∧ on(b,c). The conjuncts are non-serializable:
+  // achieving on(b,c) after on(a,b) clobbers on(a,b). Without protection the planner
+  // reports success after the LAST subgoal while the first has been undone.
+  const model = blocksModel(sussmanSetup());
+  const planner = new Planner(model, { goals: [sussmanGoal], goalAgenda: true, protectAchieved: false, now: () => 0, seed: 1 });
+  drive(planner);
+  assert.equal(planner.getStatus(), "succeeded", "blind serialization thinks it's done…");
+  assert.not.ok(bothOn(model, planner), "…but the conjunction is violated — that's why protection is the default");
+});
+
+test("goalAgenda: PROTECTED serialization (default) stays sound on the Sussman anomaly", () => {
+  const model = blocksModel(sussmanSetup());
+  const planner = new Planner(model, { goals: [sussmanGoal], goalAgenda: true, now: () => 0, seed: 1 });
+  drive(planner);
+  assert.equal(planner.getStatus(), "succeeded");
+  assert.ok(bothOn(model, planner), "both on(a,b) and on(b,c) must hold — protection re-works the clobber");
+});
+
+test("goalAgenda: protection is enabled by default whenever goalAgenda is set", () => {
+  const model = blocksModel(sussmanSetup());
+  // same as the protected case but without naming protectAchieved — must still be sound
+  const planner = new Planner(model, { goals: [sussmanGoal], goalAgenda: true, now: () => 0, seed: 1 });
+  drive(planner);
+  assert.ok(bothOn(model, planner));
 });
 
 test.run();

--- a/tests/lmcut.ts
+++ b/tests/lmcut.ts
@@ -1,0 +1,96 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { F, Formula, goal, planOnce } from "../src/index";
+import type { Model } from "../src/index";
+import { blocksModel, sussmanSetup, towerSetup } from "../scenarios/blocks";
+
+/**
+ * LM-cut (Helmert & Domshlak 2009) — an admissible landmark heuristic that
+ * dominates h_max. These tests pin the two properties that matter for the goal
+ * we set out to reach: it stays OPTIMAL (weight-1 A* returns the same cost as the
+ * admissible h_max), and it is far more INFORMATIVE (it expands a fraction of the
+ * nodes), which is what makes joint optimal planning tractable on the interacting
+ * subgoals where serialization is forced to choose suboptimality (cf. Sussman:
+ * serialized 10 vs optimal 6 — see docs/goal-serialization.md).
+ */
+
+interface Solved {
+  status: "success" | "failure";
+  cost: number;
+  expansions: number;
+}
+function solve(model: Model, g: Formula, heuristic: "hmax" | "lmcut" | "hadd", maxNodes = 2_000_000): Solved {
+  const r = planOnce(model, model.createExecState(), { goals: [goal(g)], weight: 1, heuristic, maxNodes });
+  return {
+    status: r.status,
+    cost: r.plan ? r.plan.steps.filter((s) => s.k === "op").length : -1,
+    expansions: r.stats.expansions,
+  };
+}
+
+/** reverse a tower b0-on-b1-…-on-table into b(N-1)-on-…-on-b0 */
+function reverseTower(n: number): { model: () => Model; g: Formula } {
+  const ns = Array.from({ length: n }, (_, i) => `b${i}`);
+  const conj: Formula[] = [];
+  for (let i = 1; i < n; i++) conj.push(F.lit("on", [ns[i]], ns[i - 1]));
+  return { model: () => blocksModel(towerSetup(ns)), g: F.and(...conj) };
+}
+
+const sussmanGoal = F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c"));
+
+// ---------------------------------------------------------------- optimality
+
+test("lmcut with weight 1 returns the optimal cost (matches admissible h_max)", () => {
+  const cases: { name: string; model: () => Model; g: Formula }[] = [
+    { name: "sussman", model: () => blocksModel(sussmanSetup()), g: sussmanGoal },
+    { name: "reverse6", ...reverseTower(6) },
+    { name: "reverse8", ...reverseTower(8) },
+  ];
+  for (const c of cases) {
+    const ref = solve(c.model(), c.g, "hmax");
+    const lm = solve(c.model(), c.g, "lmcut");
+    assert.is(lm.status, "success", `${c.name}: lmcut should solve`);
+    // Both heuristics are admissible at weight 1 ⇒ both return the optimal cost.
+    assert.is(lm.cost, ref.cost, `${c.name}: lmcut cost ${lm.cost} must equal optimal ${ref.cost}`);
+  }
+});
+
+// ---------------------------------------------------------------- informativeness
+
+test("lmcut expands far fewer nodes than h_max on interacting goals", () => {
+  for (const n of [8, 9]) {
+    const { model, g } = reverseTower(n);
+    const hmax = solve(model(), g, "hmax");
+    const lm = solve(model(), g, "lmcut");
+    assert.is(lm.cost, hmax.cost, `reverse${n}: same optimal cost`);
+    // LM-cut's landmark bound is much tighter here — demand at least a 2× cut.
+    assert.ok(
+      lm.expansions * 2 <= hmax.expansions,
+      `reverse${n}: lmcut expansions ${lm.expansions} should be ≤ half of h_max ${hmax.expansions}`,
+    );
+  }
+});
+
+test("lmcut solves an optimal goal within a node budget that h_max cannot", () => {
+  // reverse9 needs ~1.2k expansions under h_max; LM-cut needs a small fraction.
+  const { model, g } = reverseTower(9);
+  const budget = 300;
+  const hmax = solve(model(), g, "hmax", budget);
+  const lm = solve(model(), g, "lmcut", budget);
+  assert.is(hmax.status, "failure", `h_max should exhaust the ${budget}-node budget`);
+  assert.is(lm.status, "success", `lmcut should solve within the ${budget}-node budget`);
+  assert.is(lm.cost, 18, "and still optimally (18 actions)");
+});
+
+// ---------------------------------------------------------------- soundness edges
+
+test("lmcut handles an already-satisfied goal (h = 0) and stays admissible", () => {
+  // Goal already true in the initial tower ⇒ zero-cost, instantly solved.
+  const ns = ["b0", "b1", "b2"];
+  const model = blocksModel(towerSetup(ns)); // b0-on-b1-on-b2-on-table
+  const already = solve(model, F.lit("on", ["b0"], "b1"), "lmcut");
+  assert.is(already.status, "success");
+  assert.is(already.cost, 0);
+});
+
+test.run();

--- a/tests/wall.ts
+++ b/tests/wall.ts
@@ -1,7 +1,7 @@
 import { test } from "uvu";
 import * as assert from "uvu/assert";
 import { Planner, goal, planOnce, type Model, type Snap } from "../src/index";
-import { wallGoal, wallInstance, wallModel, type WallInstance } from "../scenarios/wall";
+import { wallGoal, wallInstance, wallInstanceHard, wallModel, type WallInstance } from "../scenarios/wall";
 
 /**
  * Construction World — a *structure-building* scenario whose goal is purely
@@ -115,6 +115,28 @@ test("construction: the SAME declarative domain builds a different structure (a 
   runToEnd(planner);
   assert.equal(planner.getStatus(), "succeeded", "the same operators + declarative goal build any structure");
   assert.equal(model.read(planner.state, "height", nm(2)), 2, "the tower must be two blocks tall");
+});
+
+test("construction (HARD): interdependent wall needs landmark layering, not plain serialization", () => {
+  // realistic physics (strictReach): a ring cell can only be topped from a neighbour
+  // that's already been raised, so the per-cell subgoals INTERFERE.
+  const inst = wallInstanceHard();
+
+  // plain goal-agenda (split per cell, protected) cannot finish it — a lone cell
+  // can't be built to full height before its neighbours, and it strands cells.
+  const plain = new Planner(wallModel(inst), { goals: [goal(wallGoal(inst))], goalAgenda: true, weight: 3, maxNodes: 200_000, now: () => 0, seed: 1 });
+  runToEnd(plain);
+  const plainBuilt = inst.targets.filter((c) => (plain.model.read(plain.state, "height", c) as number) >= inst.wantHeight).length;
+  assert.ok(plainBuilt < inst.targets.length, "without landmarks the interdependent wall can't be completed");
+
+  // landmarks: derive the threshold landmarks and lay the whole base course before
+  // any top course — every upper course then has a neighbour to stand on.
+  const withLM = new Planner(wallModel(inst), { goals: [goal(wallGoal(inst))], goalAgenda: true, landmarks: true, weight: 3, maxNodes: 200_000, now: () => 0, seed: 1 });
+  runToEnd(withLM);
+  assert.equal(withLM.getStatus(), "succeeded");
+  for (const c of inst.targets) {
+    assert.equal(withLM.model.read(withLM.state, "height", c), inst.wantHeight, `slot ${c} must reach full height with landmark layering`);
+  }
 });
 
 test.run();


### PR DESCRIPTION
Builds on #21 (branched off `claude/fervent-bell-bkcncb`). This is the principled "landmarks / factored planning" follow-up to the wall demo's `goalAgenda` serialization.

## The problem it fixes

`goalAgenda` serializes a conjunctive goal by committing to one subgoal at a time. That's the right move for **independent** subgoals (the wall), but it is **unsound** on **non-serializable** ones: it reports success after the *last* subgoal while an *earlier* one has been clobbered.

The canonical case — the **Sussman anomaly**, `on(a,b) ∧ on(b,c)` — demonstrates it concretely. Blind serialization:

```
blind (protect OFF) : status=succeeded  on(a,b)=false  on(b,c)=true   ← WRONG
```

It says "succeeded" but the conjunction is violated.

## The fix: goal protection (default on)

When a subgoal is committed, every *later* subgoal's search goal becomes the **cumulative conjunction** of all subgoals achieved so far plus the current one. A later subgoal may pass *through* states that break an earlier one, but the committed result never violates it — the planner temporarily undoes and restores as correctness demands (for Sussman: unstack `a`, stack `b` on `c`, re-stack `a` on `b`).

```
protected (default) : status=succeeded  on(a,b)=true   on(b,c)=true   ← correct
```

Because each step starts from a state where the protected prefix already holds, protection is **nearly free when subgoals are independent** (the wall: 168ms vs 155ms) and pays only for local re-work when they interact. This is the soundness core of agenda-driven / ordered-landmark planning (cf. Koehler & Hoffmann, *On Reasonable and Forced Goal Orderings*, JAIR 2000).

## What's in it

- **Planner** — new `protectAchieved` option, **default ON whenever `goalAgenda` is set**, so serialization is sound by default. `activeGoals()` conjoins the achieved goal-subgoals with the current one.
- **Tests** (`tests/exec.ts`) — blind serialization is unsound on Sussman; protected is sound; protection is on by default; the wall (independent subgoals) is unaffected.
- **`docs/goal-serialization.md`** — the problem (depth + symmetry), serialization, protection, and an honest soundness-vs-completeness story.

## Guarantees (honest scope)

- **Sound** by default — never reports success with the conjunction violated; reports `failed` (not a wrong result) if a subgoal genuinely can't be added.
- Solves **serializable-under-protection** goals, including classic non-serializable puzzles (Sussman).
- **Not** a general completeness guarantee in a reactive executor (committed = executed, can't un-execute). The documented next steps — **reasonable goal orderings** and **landmark heuristics (LM-count/LM-cut)** — close that gap and are called out as future work in the docs note.

107/107 tests pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNvYCvYdn4fb7LvLkkVsKK)_