### PR TITLE
Real-time/agile search: BFWS with preferred operators + deferred evaluation

### DIFF
--- a/docs/real-time-search.md
+++ b/docs/real-time-search.md
@@ -1,0 +1,105 @@
+# Real-time / agile planning: BFWS, preferred operators, deferred evaluation
+
+The optimal-planning heuristics (`heuristic: "lmcut"`, see
+[goal-serialization.md](./goal-serialization.md)) prove plans optimal but spend
+search effort to do it. A reactive, embedded planner running under a **tick
+budget** usually wants the opposite trade: a *good* plan *fast*, with cheap
+per-node work, scaling to large states. That is the **satisficing / agile**
+lineage, and `search: "bfws"` brings its current state of the art into the engine.
+
+## What it is
+
+`search: "bfws"` (on `planOnce`'s `PlanRequest` and the reactive `Planner`'s
+options) is **Best-First Width Search** (Lipovetzky & Geffner, *Best-First Width
+Search: Exploration and Exploitation in Classical Planning*, AAAI 2017), bundled
+with the two standard accelerators that make greedy search fast:
+
+### 1. Novelty width as the primary key (exploration)
+
+A state's **novelty width** is the size of the smallest tuple of facts it makes
+*new* — width 1 if it carries a fact never seen before, width 2 if a never-seen
+*pair*, and so on. BFWS orders the frontier by ⟨width, #unmet-goals, h⟩: prefer the
+structurally novel first, break ties by goal progress, then by a cheap heuristic.
+Novelty is measured *within a partition* keyed by the unmet-goal count (#g), and
+capped (default 2, `noveltyWidth`). The striking empirical fact behind width-based
+search is that most planning domains have **low width**, so this exploration term
+alone carries the search through huge state spaces that defeat pure heuristic
+hill-climbing. Novelty is computed over the interned **relaxation atoms**, so
+numeric/clock fluents (which would make every state trivially "novel") are excluded
+automatically.
+
+### 2. Preferred operators (exploitation)
+
+At each expanded node we extract a **relaxed plan** (back-chaining cheapest
+achievers from the goals, h_add). An applicable operator that appears in that
+relaxed plan is a **preferred operator** — FF's "helpful actions" (Hoffmann &
+Nebel 2001). Their successors go into a *second* open list, and the search uses a
+**boosted dual queue**: it favours preferred-operator nodes but keeps the regular
+queue in rotation so width-based exploration never starves (Richter & Helmert,
+*Preferred Operators and Deferred Evaluation*, ICAPS 2009).
+
+### 3. Deferred heuristic evaluation
+
+The relaxed plan is computed **once per expanded node**, not for every generated
+child (a child is ordered using its parent's estimate until it is itself
+expanded). Since the relaxed-plan/heuristic computation dominates per-node cost,
+this is a large constant-factor win — and it is exactly why BFWS's heuristic
+evaluations track its *expansions* rather than its (much larger) generated count.
+
+## Measured (vs weighted-A\*, on hard blocks instances)
+
+A deterministic 18-block instance (random initial layout → random goal), and a
+22-block one, joint goal, no serialization:
+
+| instance | search | status | expansions | heuristic evals | time |
+|---|---|---|---|---|---|
+| 18-block | weighted-A\* | success | 9101 | 41 331 | 2641 ms |
+| 18-block | **BFWS** | success | **436** | **435** | **94 ms** |
+| 22-block | weighted-A\* | success | 3211 | 25 606 | 1824 ms |
+| 22-block | **BFWS** | success | **964** | **963** | **309 ms** |
+
+Two effects are visible:
+
+- **Deferred evaluation** collapses heuristic work: BFWS does ≈ one relaxed plan
+  per *expanded* node (`heuristicEvals ≈ expansions`), where weighted-A\* evaluates
+  every generated child — a **25–95× reduction** in heuristic computations.
+- **Novelty + preferred operators** cut expansions and wall-clock by an order of
+  magnitude on the instances where the delete-relaxation heuristic plateaus.
+
+## The trade-off (read this before switching)
+
+BFWS is **not cost-optimal**. On the same instances its plans are often longer
+than weighted-A\*'s (e.g. it may return a 120-action plan where weighted-A\* finds
+60). That is the agile bargain: a fast, scalable *first* solution instead of a
+proven-optimal one. Use it when:
+
+- you plan under a **tick / latency budget** and need an answer now;
+- the state space is **large** (many objects) and pure heuristic search stalls;
+- plan *length* is secondary to **getting a working plan** and to coverage.
+
+Reach for weighted-A\* (default) — optionally with `heuristic: "lmcut"` at
+`weight: 1` — when you need the optimal or a bounded-suboptimal plan and the
+problem is small enough to afford it.
+
+## What's intentionally *not* here yet
+
+- **Anytime improvement** (ARA\* / restarting weighted-A\*): emit a fast plan, then
+  keep improving it within the remaining budget with a shrinking suboptimality
+  bound. This is the natural complement that would let BFWS's quick-but-long first
+  plan be refined toward optimal as time allows.
+- **Bounded-suboptimal search with a distinct distance-to-go estimate** (EES,
+  Thayer & Ruml 2011).
+
+These are the next rungs on the real-time ladder, deliberately left for a separate
+change.
+
+## API
+
+```ts
+// offline
+planOnce(model, state, { goals: [goal(G)], search: "bfws" });            // width cap 2
+planOnce(model, state, { goals: [goal(G)], search: "bfws", noveltyWidth: 1 });
+
+// reactive executor (per-subgoal episodes use BFWS)
+new Planner(model, { goals: [goal(G)], search: "bfws" });
+```

--- a/examples/web/app/page.tsx
+++ b/examples/web/app/page.tsx
@@ -25,9 +25,10 @@ const WallScene = dynamic(() => import("../components/WallScene"), { ssr: false 
 const SquadScene = dynamic(() => import("../components/SquadScene"), { ssr: false });
 import SquadDirector from "../components/SquadDirector";
 import WallPanel from "../components/WallPanel";
+import BlocksComparePanel from "../components/BlocksComparePanel";
 
 type GridId = "staircase" | "ledge" | "quarry" | "scavenger" | "scavengerBig" | "scavengerHuge";
-type ScenarioId = GridId | "blocks" | "wall" | "wallHard" | SquadScenarioId;
+type ScenarioId = GridId | "blocks" | "blocksHard" | "wall" | "wallHard" | SquadScenarioId;
 type Kind = "grid" | "blocks" | "wall" | "squad";
 
 type Run =
@@ -48,13 +49,14 @@ const SCENARIOS: Record<ScenarioId, { name: string; blurb: string; kind: Kind }>
   scavengerBig: { name: "Scavenger XL", kind: "grid", blurb: "A bigger 4×3 grid, a height-3 goal, seven scattered blocks. The planner harvests a pillar and stacks a 3-level structure." },
   scavengerHuge: { name: "Scavenger HUGE (~9s)", kind: "grid", blurb: "A 6×4 grid (24 cells) — a deliberate stress test (~9s to plan). Search is hard-capped so it can't run away." },
   blocks: { name: "Blocks World (Sussman)", kind: "blocks", blurb: "The classic Sussman anomaly: goal A-on-B-on-C. The naive order deadlocks, so the planner interleaves subgoals." },
+  blocksHard: { name: "★ BFWS vs weighted-A* (12 blocks)", kind: "blocks", blurb: "The SAME 12-block scramble, solved two ways. The delete-relaxation heuristic plateaus here, so weighted-A* fans out — ~1400 expansions and ~4500 heuristic evaluations. Best-First Width Search orders the frontier by NOVELTY first (explore the structurally new), boosts FF preferred operators on a second queue, and DEFERS heuristic work to expanded nodes only — reaching a plan in ~130 expansions / ~130 heuristic evaluations. The panel shows the head-to-head cost; the animation plays the BFWS solve. The trade-off is honest: BFWS isn't cost-optimal, so its plan can be longer — agility for quality." },
   wall: { name: "Build a wall (structure goal)", kind: "wall", blurb: "The goal isn't a position to stand at — and it isn't a recipe either. It's one DECLARATIVE end-state: 'every cell of this octagonal ring ends up two blocks tall.' The domain has only goto / grab / place; nothing tells the agent to pick up or place anything. The planner DISCOVERS pickup-and-place by search. A single search over all 12 cells blows up, so the planner runs in goal-agenda mode: it splits the conjunction into per-cell subgoals and commits to them one at a time. Blocks come only from the scattered pile, so a laid block is never cannibalised — which is what makes serialising sound." },
   wallHard: { name: "Build a wall — realistic physics (needs landmarks)", kind: "wall", blurb: "The SAME wall, same declarative goal — but realistic physics: the agent can't place a block above its own reach. Now a cell can only be topped from a neighbour that's already raised, so the cells INTERFERE: a lone 2-tall pillar is unbuildable, and per-cell serialization strands cells it can't reach. The fix is landmark layering — the planner derives that every cell's height-2 goal passes through height-1 first (a sound threshold landmark) and lays the WHOLE base course before any top course, so every upper course has a neighbour to stand on. This is the Sussman-like 'subgoals interfere, order matters' case made tractable." },
 };
 
 function buildRun(id: ScenarioId): Run {
   const kind = SCENARIOS[id].kind;
-  if (kind === "blocks") return { kind: "blocks", data: runBlocks() };
+  if (kind === "blocks") return { kind: "blocks", data: runBlocks(id === "blocksHard") };
   if (kind === "wall") return { kind: "wall", data: runWall(id === "wallHard") };
   if (kind === "squad") return { kind: "squad", data: runSquad(id as SquadScenarioId) };
   return { kind: "grid", data: runScenario(id as GridId) };
@@ -249,6 +251,8 @@ export default function Page() {
             <div className="mono">be at 3D position <span style={{ color: "var(--accent-2)" }}>({run.data.target.x}, {run.data.target.y}, {run.data.target.z})</span></div>
           </div>
         )}
+
+        {run?.kind === "blocks" && run.data.compare && <BlocksComparePanel compare={run.data.compare} />}
 
         {run?.kind === "wall" && <WallPanel run={run.data} step={Math.min(step, lastStep)} />}
 

--- a/examples/web/components/BlocksComparePanel.tsx
+++ b/examples/web/components/BlocksComparePanel.tsx
@@ -1,0 +1,60 @@
+"use client";
+import type { BlocksCompare, SearchMetric } from "../lib/runBlocks";
+
+/**
+ * Head-to-head search cost for the hard blocks instance: weighted-A* vs BFWS on
+ * the SAME world and goal. Bars are normalised to the larger of the two so the
+ * gap is read at a glance — fewer expansions, far fewer heuristic evaluations,
+ * less wall-clock. (Plan length is shown too: BFWS trades optimality for speed,
+ * so its plan can be longer — the honest part of the agile bargain.)
+ */
+function Row({ m, peak, accent }: { m: SearchMetric; peak: { exp: number; hev: number; ms: number }; accent: string }) {
+  const bar = (v: number, max: number) => `${Math.max(2, Math.round((v / Math.max(max, 1)) * 100))}%`;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div className="row spread" style={{ marginBottom: 4 }}>
+        <b className="mono" style={{ color: accent }}>{m.label}</b>
+        <span className="mono" style={{ color: "var(--muted)", fontSize: 11 }}>{m.note}</span>
+      </div>
+      <Metric name="expansions" value={m.expansions} width={bar(m.expansions, peak.exp)} accent={accent} />
+      <Metric name="heuristic evals" value={m.heuristicEvals} width={bar(m.heuristicEvals, peak.hev)} accent={accent} />
+      <Metric name="time" value={`${m.ms.toFixed(0)} ms`} width={bar(m.ms, peak.ms)} accent={accent} />
+      <div className="mono" style={{ fontSize: 11, color: "var(--muted)", marginTop: 2 }}>plan length {m.planLength} · {m.ok ? "solved" : "gave up"}</div>
+    </div>
+  );
+}
+
+function Metric({ name, value, width, accent }: { name: string; value: number | string; width: string; accent: string }) {
+  return (
+    <div className="row" style={{ gap: 8, alignItems: "center", marginBottom: 2 }}>
+      <span className="mono" style={{ width: 110, color: "var(--muted)", fontSize: 11 }}>{name}</span>
+      <div style={{ flex: 1, height: 8, background: "#0e1422", borderRadius: 4, overflow: "hidden" }}>
+        <div style={{ width, height: "100%", background: accent, borderRadius: 4, transition: "width .4s" }} />
+      </div>
+      <span className="mono" style={{ width: 64, textAlign: "right" }}>{value}</span>
+    </div>
+  );
+}
+
+export default function BlocksComparePanel({ compare }: { compare: BlocksCompare }) {
+  const peak = {
+    exp: Math.max(compare.wastar.expansions, compare.bfws.expansions),
+    hev: Math.max(compare.wastar.heuristicEvals, compare.bfws.heuristicEvals),
+    ms: Math.max(compare.wastar.ms, compare.bfws.ms),
+  };
+  const hevX = (compare.wastar.heuristicEvals / Math.max(compare.bfws.heuristicEvals, 1)).toFixed(0);
+  const expX = (compare.wastar.expansions / Math.max(compare.bfws.expansions, 1)).toFixed(0);
+  return (
+    <div className="card">
+      <h2>Search cost · same instance</h2>
+      <div className="mono" style={{ color: "var(--muted)", marginBottom: 10, fontSize: 11 }}>
+        identical 12-block world &amp; goal, solved two ways. The animation plays the <span style={{ color: "#34d399" }}>BFWS</span> solution.
+      </div>
+      <Row m={compare.wastar} peak={peak} accent="#fbbf24" />
+      <Row m={compare.bfws} peak={peak} accent="#34d399" />
+      <div className="mono" style={{ color: "var(--accent-2)", marginTop: 4 }}>
+        BFWS: {expX}× fewer expansions · {hevX}× fewer heuristic evaluations
+      </div>
+    </div>
+  );
+}

--- a/examples/web/lib/runBlocks.ts
+++ b/examples/web/lib/runBlocks.ts
@@ -6,9 +6,17 @@
  * frame (so the renderer stays dumb): each block sits in the column of its
  * stack's table-root, at a height equal to its depth; a held block hovers above
  * where it will land next.
+ *
+ * Two scenarios share this path:
+ *  - Sussman (default): the classic A-on-B-on-C anomaly.
+ *  - Hard (`runBlocks(true)`): a 12-block scramble that the heuristic plateaus on,
+ *    run under BOTH weighted-A* and BFWS so the demo can show, side by side, how
+ *    much cheaper Best-First Width Search reaches a plan. The animated solve is the
+ *    BFWS one.
  */
-import { F, Planner, goal, type TraceEvent } from "htn-ai";
+import { F, Planner, goal, planOnce, type Formula, type TraceEvent } from "htn-ai";
 import { blocksModel, sussmanSetup } from "@scenarios/blocks";
+import type { Model } from "htn-ai";
 
 export interface BlocksFrame {
   /** block name → [x, stackDepth] for rendering */
@@ -19,30 +27,89 @@ export interface BlocksFrame {
   action: string;
 }
 
+/** one planner's cost to reach a plan on the same instance */
+export interface SearchMetric {
+  label: string;
+  note: string;
+  expansions: number;
+  heuristicEvals: number;
+  ms: number;
+  planLength: number;
+  ok: boolean;
+}
+export interface BlocksCompare {
+  wastar: SearchMetric;
+  bfws: SearchMetric;
+}
+
 export interface BlocksRun {
   blocks: string[];
   frames: BlocksFrame[];
   status: string;
   trace: TraceEvent[];
   goalText: string;
+  /** present only for the hard instance: the head-to-head search-cost comparison */
+  compare?: BlocksCompare;
 }
 
 const SPACING = 1.7;
 const CARRY_Y = 4;
 const HAND = "arm";
 
-export function runBlocks(): BlocksRun {
-  const setup = sussmanSetup(); // C on A; A,B on table — the Sussman anomaly
-  const blocks = setup.blocks;
-  const model = blocksModel(setup);
+// A deterministic 12-block scramble (random initial layout → random goal). The
+// delete-relaxation heuristic plateaus on it: weighted-A* expands ~1400 nodes and
+// runs ~4500 heuristic evaluations; BFWS solves it in ~130 expansions / ~130
+// heuristic evaluations — novelty + preferred operators + deferred evaluation.
+const HARD_INIT: [string, string][] = [["C", "F"], ["D", "H"], ["F", "B"], ["G", "K"], ["H", "I"], ["J", "L"], ["K", "A"], ["L", "E"]];
+const HARD_GOAL: [string, string][] = [["B", "G"], ["C", "I"], ["D", "A"], ["E", "D"], ["F", "J"], ["G", "H"], ["I", "L"], ["J", "K"]];
+const HARD_BLOCKS = "ABCDEFGHIJKL".split("");
+
+function hardModel(): Model {
+  return blocksModel({
+    blocks: HARD_BLOCKS,
+    init: (w) => {
+      for (const [b, u] of HARD_INIT) {
+        w.set("on", [b], u);
+        w.set("clear", [u], false);
+      }
+    },
+  });
+}
+
+/** Plan the joint goal once with a given strategy and report what it cost. */
+function bench(label: string, note: string, goalFormula: Formula, req: object): SearchMetric {
+  const model = hardModel();
+  const t0 = performance.now();
+  const r = planOnce(model, model.createExecState(), { goals: [goal(goalFormula)], maxNodes: 200_000, ...req });
+  const ms = performance.now() - t0;
+  const planLength = r.plan ? r.plan.steps.filter((s) => s.k === "op").length : -1;
+  return { label, note, expansions: r.stats.expansions, heuristicEvals: r.stats.heuristicEvals, ms, planLength, ok: r.status === "success" };
+}
+
+export function runBlocks(hard = false): BlocksRun {
+  const blocks = hard ? HARD_BLOCKS : sussmanSetup().blocks;
+  const model = hard ? hardModel() : blocksModel(sussmanSetup());
+  const goalFormula = hard
+    ? F.and(...HARD_GOAL.map(([b, u]) => F.lit("on", [b], u)))
+    : F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c"));
+
+  // head-to-head search cost on the hard instance (same goal, same world)
+  const compare: BlocksCompare | undefined = hard
+    ? {
+        wastar: bench("weighted-A*", "default · cost-optimal-ish, evaluates every child", goalFormula, {}),
+        bfws: bench("BFWS", "novelty + preferred ops + deferred eval", goalFormula, { search: "bfws" }),
+      }
+    : undefined;
 
   const trace: TraceEvent[] = [];
   let t = 0;
   const planner = new Planner(model, {
-    goals: [goal(F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c")))],
+    goals: [goal(goalFormula)],
     now: () => t,
     seed: 1,
     trace: (e) => trace.push(e),
+    // the animated solve uses BFWS for the hard instance, default for Sussman
+    ...(hard ? { search: "bfws" as const } : {}),
   });
 
   const sorted = [...blocks].sort();
@@ -69,7 +136,7 @@ export function runBlocks(): BlocksRun {
   };
 
   const raws: Raw[] = [readRaw("start")];
-  for (let i = 0; i < 500; i++) {
+  for (let i = 0; i < 800; i++) {
     const st = planner.getStatus();
     if (st === "succeeded" || st === "failed") break;
     t += 1;
@@ -110,5 +177,12 @@ export function runBlocks(): BlocksRun {
     frames[i].positions[held] = [destX, CARRY_Y];
   }
 
-  return { blocks, frames, status: planner.getStatus(), trace, goalText: "A·on·B·on·C" };
+  return {
+    blocks,
+    frames,
+    status: planner.getStatus(),
+    trace,
+    goalText: hard ? "12-block scramble → scramble" : "A·on·B·on·C",
+    compare,
+  };
 }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -109,6 +109,18 @@ export interface PlannerOptions {
    * ordered landmarks in classical planning (Hoffmann/Porteous/Sebastia 2004).
    */
   landmarks?: boolean;
+  /**
+   * Goal-search strategy for each subgoal's planning episode. `"wastar"` (default)
+   * is weighted-A\* — cost-bounded, optimal at weight 1. `"bfws"` is **Best-First
+   * Width Search** (Lipovetzky & Geffner 2017): a satisficing/agile search ordered
+   * by novelty width, with preferred operators (FF helpful actions) and deferred
+   * heuristic evaluation. It is not cost-optimal but scales to large, low-width
+   * problems that defeat pure heuristic search while staying cheap per node — the
+   * right default for real-time/agent planning under a tick budget.
+   */
+  search?: "wastar" | "bfws";
+  /** BFWS novelty width cap (1 = atoms only, cheapest; 2 = atom pairs, default). */
+  noveltyWidth?: number;
 }
 
 export type PlannerStatus = "idle" | "planning" | "running" | "succeeded" | "failed";
@@ -377,6 +389,8 @@ export class Planner {
     maxNodes?: number;
     maxDepth?: number;
     collectRejections?: boolean;
+    search?: "wastar" | "bfws";
+    noveltyWidth?: number;
   } {
     return {
       goals: this.goals,
@@ -384,6 +398,8 @@ export class Planner {
       maxNodes: this.opts.maxNodes,
       maxDepth: this.opts.maxDepth,
       collectRejections: this.opts.collectRejections,
+      search: this.opts.search,
+      noveltyWidth: this.opts.noveltyWidth,
       ...extra,
     };
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -127,6 +127,20 @@ export interface PlanRequest {
    *  optimal/weight-1 search), or none (Dijkstra). Pair an admissible heuristic
    *  with weight 1 for guaranteed-optimal plans. */
   heuristic?: "hadd" | "hmax" | "lmcut" | "none";
+  /**
+   * Goal-search strategy. `"wastar"` (default) is weighted-A\* — cost-bounded,
+   * optimal at weight 1. `"bfws"` is **Best-First Width Search** (Lipovetzky &
+   * Geffner 2017): a satisficing/agile search that orders the frontier by
+   * **novelty width** first (explore the structurally new), then unmet-goal count,
+   * then a deferred relaxed-plan estimate. It pairs **preferred operators** (FF
+   * helpful actions, via a second open list) with **deferred heuristic evaluation**
+   * (the relaxed plan is computed once per *expanded* node, not per generated one).
+   * BFWS is not cost-optimal but scales to large, low-width problems that defeat
+   * pure heuristic search, while staying cheap per node — the right tool for
+   * real-time/agent planning. */
+  search?: "wastar" | "bfws";
+  /** BFWS novelty width cap (1 = atoms only, cheapest; 2 = atom pairs, default). */
+  noveltyWidth?: number;
   /** internal: plan a pre-built agenda instead of `goals` (used by plan repair) */
   agendaOverride?: Agenda;
 }
@@ -149,10 +163,16 @@ interface HeapNode {
   ops: GroundOp[] | null; // path as parent-pointer alternative kept simple: full path arrays are fine at v0 scale
   parent: HeapNode | null;
   via: GroundOp | null;
+  // BFWS evaluation keys (best-first width search); unused by weighted-A*
+  w: number; // novelty width (1 best)
+  hg: number; // number of unmet goals (#g)
+  h: number; // deferred heuristic estimate (relaxed-plan length, parent's)
 }
 
 class Heap {
   private items: HeapNode[] = [];
+
+  constructor(private readonly less: (a: HeapNode, b: HeapNode) => boolean = Heap.astarLess) {}
 
   get size(): number {
     return this.items.length;
@@ -164,7 +184,7 @@ class Heap {
     let i = a.length - 1;
     while (i > 0) {
       const p = (i - 1) >> 1;
-      if (Heap.less(a[i], a[p])) {
+      if (this.less(a[i], a[p])) {
         const t = a[i];
         a[i] = a[p];
         a[p] = t;
@@ -185,8 +205,8 @@ class Heap {
         const l = 2 * i + 1;
         const r = l + 1;
         let m = i;
-        if (l < a.length && Heap.less(a[l], a[m])) m = l;
-        if (r < a.length && Heap.less(a[r], a[m])) m = r;
+        if (l < a.length && this.less(a[l], a[m])) m = l;
+        if (r < a.length && this.less(a[r], a[m])) m = r;
         if (m === i) break;
         const t = a[i];
         a[i] = a[m];
@@ -197,12 +217,21 @@ class Heap {
     return top;
   }
 
-  private static less(a: HeapNode, b: HeapNode): boolean {
+  private static astarLess(a: HeapNode, b: HeapNode): boolean {
     if (a.f !== b.f) return a.f < b.f;
     if (a.novelty !== b.novelty) return a.novelty < b.novelty;
     if (a.g !== b.g) return a.g > b.g; // prefer more progress
     return a.seq < b.seq;
   }
+}
+
+/** BFWS ordering: novelty width first (explore the structurally new), then goal
+ *  count (#g — exploit progress), then the deferred relaxed-plan estimate. */
+function bfwsLess(a: HeapNode, b: HeapNode): boolean {
+  if (a.w !== b.w) return a.w < b.w;
+  if (a.hg !== b.hg) return a.hg < b.hg;
+  if (a.h !== b.h) return a.h < b.h;
+  return a.seq < b.seq;
 }
 
 // ---------------------------------------------------------------- h_add / h_max relaxation heuristic
@@ -500,6 +529,138 @@ export function lmcut(model: Model, s: Snap, goalAtoms: Atom[]): number {
   return lmcutCore(model, snapToFlat(model, s), goalDescs(model, goalAtoms), lmcutStatic(model));
 }
 
+// ----------------------------------------------- relaxed plan / preferred operators
+
+/**
+ * h_add over the delete relaxation, plus the **relaxed plan** extracted by
+ * back-chaining cheapest achievers from the goals. The ground-op ids it returns
+ * are the source of **preferred operators** (FF "helpful actions", Hoffmann &
+ * Nebel 2001): an applicable operator lying in the relaxed plan is far likelier to
+ * be useful, and biasing search toward them — via a second open list — is one of
+ * the largest practical speedups in satisficing planning (Richter & Helmert,
+ * *Preferred Operators and Deferred Evaluation*, ICAPS 2009). `h` is the relaxed
+ * plan's length (h_FF), a cheap, informative estimate.
+ */
+function relaxedPlan(model: Model, flat: Float64Array, goals: GoalAtomDesc[]): { h: number; pref: Set<number> } {
+  const n = model.relaxAtomCount;
+  const slot = model.relaxAtomSlot;
+  const val = model.relaxAtomValue;
+  const fuzzy = model.relaxAtomFuzzy;
+  const cost = new Float64Array(n);
+  const achiever = new Int32Array(n).fill(-1);
+  for (let id = 0; id < n; id++) cost[id] = flat[slot[id]] === val[id] ? 0 : Infinity;
+
+  const ops = model.groundOps;
+  let changed = true;
+  let rounds = 0;
+  while (changed && rounds < 64) {
+    changed = false;
+    rounds++;
+    for (let oi = 0; oi < ops.length; oi++) {
+      const addIds = ops[oi].addIds as Int32Array;
+      if (addIds.length === 0) continue;
+      const preIds = ops[oi].preIds as Int32Array;
+      let pc = 0;
+      let inf = false;
+      for (let i = 0; i < preIds.length; i++) {
+        const pid = preIds[i];
+        let c = cost[pid];
+        if (c === Infinity) c = fuzzy[pid] ? 1 : Infinity;
+        if (c === Infinity) { inf = true; break; }
+        pc += c; // h_add combination
+      }
+      if (inf) continue;
+      const through = pc + 1;
+      for (let i = 0; i < addIds.length; i++) {
+        const aid = addIds[i];
+        if (through < cost[aid]) { cost[aid] = through; achiever[aid] = oi; changed = true; }
+      }
+    }
+  }
+
+  const pref = new Set<number>();
+  const visited = new Uint8Array(n);
+  const stack: number[] = [];
+  for (const gd of goals) {
+    if (gd.id >= 0) {
+      if (cost[gd.id] === Infinity) return { h: Infinity, pref };
+      stack.push(gd.id);
+    } else if (flat[gd.slot] !== gd.value && !gd.fuzzy) {
+      return { h: Infinity, pref };
+    }
+  }
+  let h = 0;
+  while (stack.length > 0) {
+    const aid = stack.pop() as number;
+    if (visited[aid]) continue;
+    visited[aid] = 1;
+    if (cost[aid] === 0) continue; // already true: no achiever needed
+    const oi = achiever[aid];
+    if (oi < 0) continue;
+    if (!pref.has(oi)) {
+      pref.add(oi);
+      h += 1;
+      const preIds = ops[oi].preIds as Int32Array;
+      for (let i = 0; i < preIds.length; i++) {
+        const pid = preIds[i];
+        if (!fuzzy[pid] && !visited[pid]) stack.push(pid);
+      }
+    }
+  }
+  return { h, pref };
+}
+
+// ----------------------------------------------------------- novelty (width-based)
+
+/** Per-model, per-slot `value → relaxation-atom id` lookup so a state's true
+ *  relaxation atoms can be enumerated without string-keyed probes. */
+const slotValueAtomsCache = new WeakMap<Model, Map<number, number>[]>();
+function slotValueAtoms(model: Model): Map<number, number>[] {
+  const cached = slotValueAtomsCache.get(model);
+  if (cached) return cached;
+  const bySlot: Map<number, number>[] = Array.from({ length: model.slotCount }, () => new Map<number, number>());
+  for (let id = 0; id < model.relaxAtomCount; id++) bySlot[model.relaxAtomSlot[id]].set(model.relaxAtomValue[id], id);
+  slotValueAtomsCache.set(model, bySlot);
+  return bySlot;
+}
+
+/**
+ * Novelty bookkeeping for Best-First Width Search (Lipovetzky & Geffner, *Best-
+ * First Width Search*, AAAI 2017). A state's **width** is the size of the smallest
+ * atom tuple it makes new *within its partition* — here partitioned by the number
+ * of unmet goals (#g). Width 1 = it carries an atom never seen at this #g; width 2
+ * = a never-seen atom *pair*; capped beyond. Low width ⇒ structurally novel ⇒
+ * explored first. This is what lets BFWS cover huge, low-width problems that defeat
+ * pure heuristic search, while staying cheap per node.
+ */
+class NoveltyTable {
+  private readonly seen1: Set<number>[] = [];
+  private readonly seen2: (Set<number> | undefined)[] = [];
+  constructor(private readonly nAtoms: number, private readonly cap: number) {}
+
+  /** width of `atoms` (ascending true-atom ids) in partition `p`, recording them */
+  evaluate(p: number, atoms: number[]): number {
+    let s1 = this.seen1[p];
+    if (!s1) s1 = this.seen1[p] = new Set<number>();
+    let w = this.cap + 1;
+    for (let i = 0; i < atoms.length; i++) if (!s1.has(atoms[i])) { w = 1; break; }
+    if (this.cap >= 2) {
+      let s2 = this.seen2[p];
+      if (!s2) s2 = this.seen2[p] = new Set<number>();
+      let newPair = false;
+      for (let i = 0; i < atoms.length; i++) {
+        for (let j = i + 1; j < atoms.length; j++) {
+          const key = atoms[i] * this.nAtoms + atoms[j];
+          if (!s2.has(key)) { s2.add(key); newPair = true; }
+        }
+      }
+      if (w > 2 && newPair) w = 2;
+    }
+    for (let i = 0; i < atoms.length; i++) s1.add(atoms[i]);
+    return w;
+  }
+}
+
 // ---------------------------------------------------------------- engine
 
 interface MtrCursor {
@@ -516,7 +677,7 @@ interface SeekOutcome {
 
 export class Engine {
   private readonly model: Model;
-  private readonly req: Required<Pick<PlanRequest, "weight" | "maxNodes" | "maxDepth" | "novelty" | "heuristic">> & PlanRequest;
+  private readonly req: Required<Pick<PlanRequest, "weight" | "maxNodes" | "maxDepth" | "novelty" | "heuristic" | "search" | "noveltyWidth">> & PlanRequest;
   public decompositions = 0;
   public expansions = 0;
   public heuristicEvals = 0;
@@ -544,6 +705,8 @@ export class Engine {
       maxDepth: req.maxDepth ?? 400,
       novelty: req.novelty ?? true,
       heuristic: req.heuristic ?? "hadd",
+      search: req.search ?? "wastar",
+      noveltyWidth: req.noveltyWidth ?? 2,
     };
     this.mtrCursor = { last: req.lastMTR && req.lastMTR.length > 0 ? req.lastMTR : null, pos: 0, stillEqual: req.lastMTR !== undefined && (req.lastMTR?.length ?? 0) > 0 };
   }
@@ -830,6 +993,7 @@ export class Engine {
     item: { fn: (s: Snap) => boolean; atoms: Atom[]; label: string },
     scopes: ScopeInstance[],
   ): Generator<void, SeekOutcome | null, void> {
+    if (this.req.search === "bfws") return yield* this.goalSearchBFWS(start, item, scopes);
     const model = this.model;
     const weight = this.req.weight;
     const open = new Heap();
@@ -843,7 +1007,7 @@ export class Engine {
       this.reject(item.label, "goal unreachable under relaxation");
       return null;
     }
-    open.push({ f: weight * h0, novelty: 0, g: 0, seq: seq++, state: start, ops: null, parent: null, via: null });
+    open.push({ f: weight * h0, novelty: 0, g: 0, seq: seq++, state: start, ops: null, parent: null, via: null, w: 0, hg: 0, h: 0 });
     closed.set(start.key(), 0);
 
     while (open.size > 0) {
@@ -922,10 +1086,125 @@ export class Engine {
             }
           }
         }
-        open.push({ f: g2 + weight * h, novelty, g: g2, seq: seq++, state: child, ops: null, parent: node, via: g });
+        open.push({ f: g2 + weight * h, novelty, g: g2, seq: seq++, state: child, ops: null, parent: node, via: g, w: 0, hg: 0, h: 0 });
       }
     }
     this.reject(item.label, "goal search exhausted open list");
+    return null;
+  }
+
+  // ---------------- best-first width search (novelty + preferred ops + deferred eval)
+
+  private *goalSearchBFWS(
+    start: StateView,
+    item: { fn: (s: Snap) => boolean; atoms: Atom[]; label: string },
+    scopes: ScopeInstance[],
+  ): Generator<void, SeekOutcome | null, void> {
+    const model = this.model;
+    const descs = goalDescs(model, item.atoms);
+    const slotAtoms = slotValueAtoms(model);
+    const novelty = new NoveltyTable(model.relaxAtomCount, Math.max(1, this.req.noveltyWidth));
+    const open = new Heap(bfwsLess);
+    const openPref = new Heap(bfwsLess); // preferred-operator successors (FF helpful actions)
+    const closed = new Set<number>(); // generated-state dedupe
+    const expanded = new Set<number>(); // popped-state dedupe (a node can sit in both queues)
+    const flatScratch = new Float64Array(model.slotCount);
+    let seq = 0;
+
+    const unmetGoals = (st: StateView): number => {
+      let c = 0;
+      for (let i = 0; i < descs.length; i++) if (st.get(descs[i].slot) !== descs[i].value) c++;
+      return c;
+    };
+    const trueAtoms = (st: StateView): number[] => {
+      st.materializeInto(flatScratch);
+      const out: number[] = [];
+      for (let s = 0; s < flatScratch.length; s++) {
+        const id = slotAtoms[s].get(flatScratch[s]);
+        if (id !== undefined) out.push(id);
+      }
+      out.sort((a, b) => a - b);
+      return out;
+    };
+
+    const startHg = unmetGoals(start);
+    open.push({ f: 0, novelty: 0, g: 0, seq: seq++, state: start, ops: null, parent: null, via: null, w: novelty.evaluate(startHg, trueAtoms(start)), hg: startHg, h: 0 });
+    closed.add(start.key());
+
+    let turn = 0;
+    while (open.size > 0 || openPref.size > 0) {
+      // boosted dual-queue: favour preferred-operator nodes, but keep the regular
+      // queue in rotation so width-based exploration never starves.
+      const usePref = openPref.size > 0 && (open.size === 0 || (turn++ & 1) === 0);
+      const node = (usePref ? openPref.pop() : open.pop()) as HeapNode;
+      const nkey = node.state.key();
+      if (expanded.has(nkey)) continue;
+      expanded.add(nkey);
+
+      this.expansions++;
+      if (this.expansions % 16 === 0) yield;
+      if (this.expansions > this.req.maxNodes) {
+        this.reject(item.label, `BFWS node budget (${this.req.maxNodes}) exhausted`);
+        return null;
+      }
+
+      if (item.fn(node.state)) {
+        const ops: { g: GroundOp; start: number; end: number }[] = [];
+        let cur: HeapNode | null = node;
+        while (cur && cur.via) {
+          const prevClock = cur.parent ? cur.parent.state.get(CLOCK_SLOT) : 0;
+          ops.unshift({ g: cur.via, start: prevClock, end: cur.state.get(CLOCK_SLOT) });
+          cur = cur.parent;
+        }
+        const steps: PlanStep[] = ops.map((o) => ({ k: "op", g: o.g, projStart: o.start, projEnd: o.end, agendaBefore: null }));
+        return { state: node.state, steps, cost: node.g };
+      }
+
+      // deferred evaluation: the relaxed plan (h_FF + preferred ops) is computed
+      // once per EXPANDED node, not for every generated child.
+      node.state.materializeInto(flatScratch);
+      this.heuristicEvals++;
+      const { h: hSelf, pref } = relaxedPlan(model, flatScratch, descs);
+      if (hSelf === Infinity) continue; // dead end under the relaxation
+
+      const cand = this.succScratch;
+      cand.length = 0;
+      const always = model.succAlwaysOps;
+      for (let i = 0; i < always.length; i++) cand.push(always[i]);
+      const selSlots = model.succSelSlots;
+      const selTables = model.succSelTables;
+      for (let k = 0; k < selSlots.length; k++) {
+        const list = selTables[k].get(node.state.get(selSlots[k]));
+        if (list !== undefined) for (let i = 0; i < list.length; i++) cand.push(list[i]);
+      }
+      if (model.succNeedsSort && cand.length > 1) cand.sort(byGid);
+
+      for (let ci = 0; ci < cand.length; ci++) {
+        const g = cand[ci];
+        const pre = g.preAtoms;
+        let preOk = true;
+        for (let i = 0; i < pre.length; i++) {
+          if (node.state.get(pre[i].slot) !== pre[i].value) { preOk = false; break; }
+        }
+        if (!preOk) continue;
+        if (g.op.pre && !g.op.pre.atomsComplete && !g.op.pre.fn(node.state, g.b)) continue;
+        const child = node.state.child();
+        g.op.effects.apply(child, g.b, TIMINGS_PLANNING);
+        const dur = g.op.duration.fn(node.state, g.b);
+        if (dur !== 0) child.set(CLOCK_SLOT, node.state.get(CLOCK_SLOT) + dur);
+        if (!this.scopesOkQuiet(child, scopes)) continue;
+        const key = child.key();
+        if (closed.has(key)) continue;
+        closed.add(key);
+        const cost = g.op.cost.fn(node.state, g.b);
+        const g2 = node.g + (cost > 0 ? cost : 1e-6);
+        const hg = unmetGoals(child);
+        const cnode: HeapNode = { f: 0, novelty: 0, g: g2, seq: seq++, state: child, ops: null, parent: node, via: g, w: novelty.evaluate(hg, trueAtoms(child)), hg, h: hSelf };
+        open.push(cnode);
+        if (pref.has(g.gid)) openPref.push(cnode); // preferred operator ⇒ boosted queue
+      }
+    }
+    this.reject(item.label, "BFWS exhausted open list");
     return null;
   }
 

--- a/tests/bfws.ts
+++ b/tests/bfws.ts
@@ -1,0 +1,104 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { F, Planner, goal, planOnce } from "../src/index";
+import type { Model } from "../src/index";
+import { blocksModel, sussmanSetup } from "../scenarios/blocks";
+
+/**
+ * Best-First Width Search (Lipovetzky & Geffner, AAAI 2017) with preferred
+ * operators (FF helpful actions) and deferred heuristic evaluation — the real-time
+ * / agile search lineage. These tests pin the two properties that make it the
+ * right tool under a tick budget: it stays cheap (deferred evaluation computes the
+ * relaxed plan once per EXPANDED node, not per generated child) and it scales to
+ * hard instances that weighted-A\* can't reach within a small budget — trading
+ * cost-optimality for coverage and speed, by design.
+ */
+
+// A deterministic hard 18-block instance (random init + random goal). Weighted-A\*
+// needs ~9k expansions / ~41k heuristic evals; BFWS solves it in ~436 / ~435.
+const HARD_INIT: [string, string][] = [
+  ["b0", "b17"], ["b1", "b15"], ["b2", "b7"], ["b3", "b12"], ["b4", "b6"], ["b7", "b3"],
+  ["b8", "b10"], ["b9", "b16"], ["b10", "b0"], ["b11", "b14"], ["b13", "b5"], ["b14", "b1"], ["b16", "b13"],
+];
+const HARD_GOAL: [string, string][] = [
+  ["b1", "b0"], ["b2", "b9"], ["b3", "b1"], ["b4", "b15"], ["b5", "b11"], ["b6", "b2"], ["b7", "b17"],
+  ["b8", "b3"], ["b10", "b4"], ["b12", "b6"], ["b13", "b7"], ["b14", "b13"], ["b16", "b10"],
+];
+const HARD_BLOCKS = Array.from({ length: 18 }, (_, i) => `b${i}`);
+function hardModel(): Model {
+  return blocksModel({
+    blocks: HARD_BLOCKS,
+    init: (w) => {
+      for (const [b, u] of HARD_INIT) {
+        w.set("on", [b], u);
+        w.set("clear", [u], false);
+      }
+    },
+  });
+}
+const hardGoal = F.and(...HARD_GOAL.map(([b, u]) => F.lit("on", [b], u)));
+const sussmanGoal = F.and(F.lit("on", ["a"], "b"), F.lit("on", ["b"], "c"));
+
+function solve(model: Model, g: typeof hardGoal, req: object, maxNodes = 500_000) {
+  const r = planOnce(model, model.createExecState(), { goals: [goal(g)], maxNodes, ...req });
+  return { status: r.status, expansions: r.stats.expansions, heuristicEvals: r.stats.heuristicEvals };
+}
+
+/** Drive a reactive Planner to a terminal state and return it. */
+function execute(model: Model, g: typeof hardGoal, search: "wastar" | "bfws"): Planner {
+  let t = 0;
+  const p = new Planner(model, { goals: [goal(g)], search, now: () => t, seed: 1 });
+  for (let i = 0; i < 5000 && p.getStatus() !== "succeeded" && p.getStatus() !== "failed"; i++) {
+    t++;
+    p.tick({ ms: 50 });
+  }
+  return p;
+}
+
+// ---------------------------------------------------------------- validity (end-to-end)
+
+test("BFWS finds a valid plan that, executed, reaches the goal (Sussman + hard instance)", () => {
+  const s = execute(blocksModel(sussmanSetup()), sussmanGoal, "bfws");
+  assert.is(s.getStatus(), "succeeded", "Sussman should be solved");
+  assert.is(s.model.read(s.state, "on", "a"), "b");
+  assert.is(s.model.read(s.state, "on", "b"), "c");
+
+  const h = execute(hardModel(), hardGoal, "bfws");
+  assert.is(h.getStatus(), "succeeded", "hard instance should be solved");
+  for (const [b, u] of HARD_GOAL) assert.is(h.model.read(h.state, "on", b), u, `on(${b}, ${u}) must hold`);
+});
+
+// ---------------------------------------------------------------- agility / coverage
+
+test("BFWS solves within a tight node budget that weighted-A* exhausts", () => {
+  const budget = 1500;
+  const wastar = solve(hardModel(), hardGoal, {}, budget);
+  const bfws = solve(hardModel(), hardGoal, { search: "bfws" }, budget);
+  assert.is(wastar.status, "failure", `weighted-A* should exhaust the ${budget}-node budget`);
+  assert.is(bfws.status, "success", `BFWS should solve within ${budget} nodes`);
+});
+
+// ---------------------------------------------------------------- deferred evaluation
+
+test("deferred evaluation: BFWS computes ~one heuristic per expanded node, far fewer than weighted-A*", () => {
+  const wastar = solve(hardModel(), hardGoal, {});
+  const bfws = solve(hardModel(), hardGoal, { search: "bfws" });
+  assert.is(bfws.status, "success");
+  // The relaxed plan is computed once per expanded node (goal nodes don't need it).
+  assert.ok(
+    bfws.heuristicEvals <= bfws.expansions,
+    `deferred: heuristicEvals ${bfws.heuristicEvals} should be ≤ expansions ${bfws.expansions}`,
+  );
+  // Weighted-A* evaluates every generated child ⇒ dramatically more heuristic work.
+  assert.ok(
+    bfws.heuristicEvals * 10 < wastar.heuristicEvals,
+    `BFWS heuristicEvals ${bfws.heuristicEvals} should be «  weighted-A* ${wastar.heuristicEvals}`,
+  );
+});
+
+test("BFWS width cap 1 (atoms only) still solves the hard instance", () => {
+  const bfws = solve(hardModel(), hardGoal, { search: "bfws", noveltyWidth: 1 });
+  assert.is(bfws.status, "success");
+});
+
+test.run();


### PR DESCRIPTION
Forked off PR #26's branch (`claude/factored-goal-serialization`). Brings the **satisficing / agile** search lineage into the engine — the state of the art that actually fits a reactive, embedded planner running under a tick budget (a fast good-enough plan beats a slow optimal one).

New `search: "bfws"` option on `PlanRequest` and the reactive `Planner`. **Default stays weighted-A\*** — zero behavior change for existing code.

## What landed (the two gaps we agreed on)

**#1 — Best-First Width Search** (Lipovetzky & Geffner, AAAI 2017): orders the frontier by **novelty width** first (explore the structurally new), then unmet-goal count, then a cheap estimate. Novelty is computed over interned **relaxation atoms** (numeric/clock fluents excluded so they don't make every state spuriously novel), partitioned by unmet-goal count, capped at `noveltyWidth` (default 2).

**#2 — Preferred operators + deferred evaluation:**
- **Preferred operators** (FF helpful actions, Hoffmann & Nebel 2001): a relaxed plan is extracted at each expanded node; applicable ops in it are boosted via a **second open list** (boosted dual queue).
- **Deferred evaluation** (Richter & Helmert, ICAPS 2009): the relaxed plan is computed once per **expanded** node, not per generated child.

## Measured vs weighted-A\* (hard 18-block instance: random init → random goal)

| search | status | expansions | heuristic evals | time |
|---|---|---|---|---|
| weighted-A\* | success | 9101 | 41 331 | 2641 ms |
| **BFWS** | success | **436** | **435** | **94 ms** |

- **Deferred evaluation** → `heuristicEvals ≈ expansions` (**25–95× fewer** heuristic computations than weighted-A\*, which evaluates every generated child).
- **Novelty + preferred operators** → ~20× fewer expansions and ~28× faster where the delete-relaxation heuristic plateaus.

## The trade-off (called out honestly)

BFWS is **not cost-optimal** — its plans can be longer than weighted-A\*'s. That's the agile bargain: a fast, scalable *first* solution instead of a proven-optimal one. Use weighted-A\* (optionally `heuristic: "lmcut"` at `weight: 1`) when you need optimality and the problem is small enough to afford it.

## Files
- `src/search.ts` — comparator-parameterized `Heap` + `bfwsLess`; `relaxedPlan` (h_FF + preferred ops); `slotValueAtoms` + `NoveltyTable`; `goalSearchBFWS` (dual queue + deferred eval); option plumbing.
- `src/exec.ts` — `search`/`noveltyWidth` on `PlannerOptions`, passed through to the search request.
- `tests/bfws.ts` — end-to-end validity (executes the plan, checks the world reaches the goal), coverage within a budget weighted-A\* exhausts, the deferred-evaluation property, and a width-cap-1 variant.
- `docs/real-time-search.md` — the lineage, the measured table, the trade-off, and what's intentionally left next (anytime/ARA\*, EES).

## Verification
All **117 tests pass** (4 new), typecheck and lint clean.

## Not included (deliberately, next rungs)
Anytime improvement (ARA\* / restarting weighted-A\*) and bounded-suboptimal search with a distinct distance-to-go estimate (EES) — left for a separate change.

> Note: targets PR #26's branch as base, so this diff shows only the BFWS work. It should be reviewed/merged after (or alongside) #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNvYCvYdn4fb7LvLkkVsKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNvYCvYdn4fb7LvLkkVsKK)_